### PR TITLE
Refactor test classes and methods for clarity and consistency

### DIFF
--- a/PoshMcp.Tests/Functional/FilterLastCommandOutput/ShouldReturnNullWhenInvalidScriptTest.cs
+++ b/PoshMcp.Tests/Functional/FilterLastCommandOutput/ShouldReturnNullWhenInvalidScriptTest.cs
@@ -21,7 +21,7 @@ public partial class FilterCachedResults : PowerShellTestBase
 {
 
     [Fact]
-    public async Task FilterLastCommandOutput_ShouldReturnNull_WhenInvalidScript()
+    public async Task ShouldReturnNull_WhenInvalidScript()
     {
         // Arrange - Execute a command first to have cached data
         var parameterInfos = Array.Empty<PowerShellParameterInfo>();

--- a/PoshMcp.Tests/Functional/GeneratedAssembly/ShouldCreateParameterSetSpecificMethodsTest.cs
+++ b/PoshMcp.Tests/Functional/GeneratedAssembly/ShouldCreateParameterSetSpecificMethodsTest.cs
@@ -12,7 +12,7 @@ namespace PoshMcp.Tests.Functional.GeneratedAssembly;
 /// <summary>
 /// Test for parameter set specific method generation
 /// </summary>
-public partial class UtilityMethods : PowerShellTestBase
+public partial class GeneratedInstance : PowerShellTestBase
 {
     [Fact]
     public async Task GenerateAssembly_ShouldCreateParameterSetSpecificMethods()
@@ -73,7 +73,7 @@ public partial class UtilityMethods : PowerShellTestBase
 
         foreach (var paramSetName in parameterSetNames)
         {
-            var expectedMethodPattern = PowerShellDynamicAssemblyGenerator.SanitizeMethodName("Get-ChildItem", paramSetName);
+            var expectedMethodPattern = PowerShellAssemblyGenerator.SanitizeMethodName("Get-ChildItem", paramSetName);
             var hasExpectedMethod = methodNames.Any(name =>
                 name.Equals(expectedMethodPattern, System.StringComparison.OrdinalIgnoreCase));
 

--- a/PoshMcp.Tests/Functional/GeneratedAssembly/ShouldCreateValidAssemblyTest.cs
+++ b/PoshMcp.Tests/Functional/GeneratedAssembly/ShouldCreateValidAssemblyTest.cs
@@ -12,10 +12,10 @@ namespace PoshMcp.Tests.Functional.GeneratedAssembly;
 /// <summary>
 /// Test for assembly generation validation
 /// </summary>
-public partial class UtilityMethods : PowerShellTestBase
+public partial class GeneratedInstance : PowerShellTestBase
 {
     [Fact]
-    public void GenerateAssembly_ShouldCreateValidAssembly()
+    public void ShouldCreateValidAssembly()
     {
         // Arrange - Setup test PowerShell function
         SetupTestPowerShellFunction();

--- a/PoshMcp.Tests/Functional/GeneratedAssembly/ShouldIncludeAllUtilityMethodsTest.cs
+++ b/PoshMcp.Tests/Functional/GeneratedAssembly/ShouldIncludeAllUtilityMethodsTest.cs
@@ -17,9 +17,9 @@ namespace PoshMcp.Tests.Functional.GeneratedAssembly;
 /// <summary>
 /// Test for generated assembly including all utility methods
 /// </summary>
-public partial class UtilityMethods : PowerShellTestBase
+public partial class GeneratedInstance : PowerShellTestBase
 {
-    public UtilityMethods(ITestOutputHelper output) : base(output) { }
+    public GeneratedInstance(ITestOutputHelper output) : base(output) { }
 
     [Fact]
     public void ShouldIncludeAllUtilityMethods()

--- a/PoshMcp.Tests/Functional/GeneratedAssembly/ShouldIncludeFilterUtilityMethodTest.cs
+++ b/PoshMcp.Tests/Functional/GeneratedAssembly/ShouldIncludeFilterUtilityMethodTest.cs
@@ -17,7 +17,7 @@ namespace PoshMcp.Tests.Functional.GeneratedAssembly;
 /// <summary>
 /// Test for generated assembly filter utility method
 /// </summary>
-public partial class UtilityMethods : PowerShellTestBase
+public partial class GeneratedInstance : PowerShellTestBase
 {
 
     [Fact]

--- a/PoshMcp.Tests/Functional/GeneratedAssembly/ShouldIncludeSortUtilityMethodsTest.cs
+++ b/PoshMcp.Tests/Functional/GeneratedAssembly/ShouldIncludeSortUtilityMethodsTest.cs
@@ -16,7 +16,7 @@ namespace PoshMcp.Tests.Functional.GeneratedAssembly;
 /// <summary>
 /// Test for generated assembly sort utility method
 /// </summary>
-public partial class UtilityMethods : PowerShellTestBase
+public partial class GeneratedInstance : PowerShellTestBase
 {
     [Fact]
     public void ShouldIncludeSortUtilityMethods()

--- a/PoshMcp.Tests/Functional/GeneratedAssembly/ShouldReturnMethodsForCommandsTest.cs
+++ b/PoshMcp.Tests/Functional/GeneratedAssembly/ShouldReturnMethodsForCommandsTest.cs
@@ -12,7 +12,7 @@ namespace PoshMcp.Tests.Functional.GeneratedAssembly;
 /// <summary>
 /// Test for generated methods validation
 /// </summary>
-public partial class UtilityMethods : PowerShellTestBase
+public partial class GeneratedInstance : PowerShellTestBase
 {
     [Fact]
     public void GetGeneratedMethods_ShouldReturnMethodsForCommands()

--- a/PoshMcp.Tests/Functional/GeneratedAssembly/ShouldReturnValidInstanceTest.cs
+++ b/PoshMcp.Tests/Functional/GeneratedAssembly/ShouldReturnValidInstanceTest.cs
@@ -12,10 +12,10 @@ namespace PoshMcp.Tests.Functional.GeneratedAssembly;
 /// <summary>
 /// Test for generated instance validation
 /// </summary>
-public partial class UtilityMethods : PowerShellTestBase
+public partial class GeneratedInstance : PowerShellTestBase
 {
-    [Fact]
-    public void GetGeneratedInstance_ShouldReturnValidInstance()
+    [Fact()]
+    public void ShouldReturnValidInstance()
     {
         // Arrange - Setup test PowerShell function
         SetupTestPowerShellFunction();

--- a/PoshMcp.Tests/Functional/GeneratedAssembly/UtilityMethodsShared.cs
+++ b/PoshMcp.Tests/Functional/GeneratedAssembly/UtilityMethodsShared.cs
@@ -12,7 +12,7 @@ namespace PoshMcp.Tests.Functional.GeneratedAssembly;
 /// <summary>
 /// Shared utilities for assembly generation tests
 /// </summary>
-public partial class UtilityMethods : PowerShellTestBase
+public partial class GeneratedInstance : PowerShellTestBase
 {
     private void SetupTestPowerShellFunction()
     {

--- a/PoshMcp.Tests/Functional/McpServerSetup/ShouldFilterCorrectlyWithExcludePatternsTest.cs
+++ b/PoshMcp.Tests/Functional/McpServerSetup/ShouldFilterCorrectlyWithExcludePatternsTest.cs
@@ -31,7 +31,7 @@ public partial class SetupTests : PowerShellTestBase
         };
 
         // Act
-        var tools = McpToolFactoryV2.GetToolsList(config, Logger);
+        var tools = ToolFactory.GetToolsList(config, Logger);
 
         // Assert
         Assert.NotNull(tools);

--- a/PoshMcp.Tests/Functional/McpServerSetup/ShouldHandleNonExistentFunctionGracefullyTest.cs
+++ b/PoshMcp.Tests/Functional/McpServerSetup/ShouldHandleNonExistentFunctionGracefullyTest.cs
@@ -31,7 +31,7 @@ public partial class SetupTests : PowerShellTestBase
         };
 
         // Act
-        var tools = McpToolFactoryV2.GetToolsList(config, Logger);
+        var tools = ToolFactory.GetToolsList(config, Logger);
 
         // Assert
         Assert.NotNull(tools);

--- a/PoshMcp.Tests/Functional/McpServerSetup/ShouldReturnEmptyListWithEmptyConfigurationTest.cs
+++ b/PoshMcp.Tests/Functional/McpServerSetup/ShouldReturnEmptyListWithEmptyConfigurationTest.cs
@@ -31,7 +31,7 @@ public partial class SetupTests : PowerShellTestBase
         };
 
         // Act
-        var tools = McpToolFactoryV2.GetToolsList(config, Logger);
+        var tools = ToolFactory.GetToolsList(config, Logger);
 
         // Assert
         Assert.NotNull(tools);

--- a/PoshMcp.Tests/Functional/McpServerSetup/ShouldReturnToolsWithValidConfigurationTest.cs
+++ b/PoshMcp.Tests/Functional/McpServerSetup/ShouldReturnToolsWithValidConfigurationTest.cs
@@ -34,7 +34,7 @@ public partial class SetupTests : PowerShellTestBase
         List<McpServerTool> tools;
         try
         {
-            tools = McpToolFactoryV2.GetToolsList(config, Logger);
+            tools = ToolFactory.GetToolsList(config, Logger);
         }
         catch (System.Management.Automation.InvalidPowerShellStateException)
         {

--- a/PoshMcp.Tests/Functional/McpServerSetup/ShouldWorkWithConfigurationToToolsListIntegrationTest.cs
+++ b/PoshMcp.Tests/Functional/McpServerSetup/ShouldWorkWithConfigurationToToolsListIntegrationTest.cs
@@ -49,7 +49,7 @@ public partial class SetupTests : PowerShellTestBase
 
             try
             {
-                var tools = McpToolFactoryV2.GetToolsList(powerShellConfig, Logger);
+                var tools = ToolFactory.GetToolsList(powerShellConfig, Logger);
 
                 // Assert
                 Assert.NotNull(tools);

--- a/PoshMcp.Tests/Functional/McpServerSetup/ShouldWorkWithDefaultParameterlessOverloadTest.cs
+++ b/PoshMcp.Tests/Functional/McpServerSetup/ShouldWorkWithDefaultParameterlessOverloadTest.cs
@@ -22,7 +22,7 @@ public partial class SetupTests : PowerShellTestBase
     public void GetToolsList_WithDefaultParameterlessOverload_ShouldWork()
     {
         // Act
-        var tools = McpToolFactoryV2.GetToolsList(Logger);
+        var tools = ToolFactory.GetToolsList(Logger);
 
         // Assert
         Assert.NotNull(tools);

--- a/PoshMcp.Tests/Functional/PowerShellCommandExecution/ShouldCacheResultsTest.cs
+++ b/PoshMcp.Tests/Functional/PowerShellCommandExecution/ShouldCacheResultsTest.cs
@@ -17,9 +17,9 @@ namespace PoshMcp.Tests.Functional.PowerShellCommandExecution;
 /// <summary>
 /// Test for caching PowerShell command results and retrieval
 /// </summary>
-public partial class ExecutePowerShellCommand : PowerShellTestBase
+public class CacheResults : PowerShellTestBase
 {
-    public ExecutePowerShellCommand(ITestOutputHelper output) : base(output) { }
+    public CacheResults(ITestOutputHelper output) : base(output) { }
 
     [Fact]
     public async Task ShouldCacheResults_AndAllowRetrieval()

--- a/PoshMcp.Tests/Functional/PowerShellCommandExecution/ShouldHandleInvalidCommandTest.cs
+++ b/PoshMcp.Tests/Functional/PowerShellCommandExecution/ShouldHandleInvalidCommandTest.cs
@@ -17,8 +17,12 @@ namespace PoshMcp.Tests.Functional.PowerShellCommandExecution;
 /// <summary>
 /// Test for handling invalid PowerShell commands
 /// </summary>
-public partial class ExecutePowerShellCommand : PowerShellTestBase
+public class InvalidCommand : PowerShellTestBase
 {
+    public InvalidCommand(ITestOutputHelper output) : base(output)
+    {
+    }
+
     [Fact]
     public async Task ShouldHandleInvalidCommand()
     {

--- a/PoshMcp.Tests/Functional/PowerShellCommandExecution/ShouldHandleValidCommandTest.cs
+++ b/PoshMcp.Tests/Functional/PowerShellCommandExecution/ShouldHandleValidCommandTest.cs
@@ -17,8 +17,12 @@ namespace PoshMcp.Tests.Functional.PowerShellCommandExecution;
 /// <summary>
 /// Test for handling valid PowerShell commands
 /// </summary>
-public partial class ExecutePowerShellCommand : PowerShellTestBase
+public class ValidCommand : PowerShellTestBase
 {
+    public ValidCommand(ITestOutputHelper output) : base(output)
+    {
+    }
+
     [Fact]
     public async Task ShouldHandleValidCommand()
     {

--- a/PoshMcp.Tests/Functional/PowerShellCommandExecution/ShouldOverwritePreviousCacheTest.cs
+++ b/PoshMcp.Tests/Functional/PowerShellCommandExecution/ShouldOverwritePreviousCacheTest.cs
@@ -17,8 +17,12 @@ namespace PoshMcp.Tests.Functional.PowerShellCommandExecution;
 /// <summary>
 /// Test for cache overwriting behavior
 /// </summary>
-public partial class ExecutePowerShellCommand : PowerShellTestBase
+public class OverwriteCache : PowerShellTestBase
 {
+
+    public OverwriteCache(ITestOutputHelper output) : base(output)
+    {
+    }
 
     [Fact]
     public async Task ShouldOverwritePreviousCache()

--- a/PoshMcp.Tests/Functional/PowerShellCommandExecution/WithParametersTest.cs
+++ b/PoshMcp.Tests/Functional/PowerShellCommandExecution/WithParametersTest.cs
@@ -17,10 +17,14 @@ namespace PoshMcp.Tests.Functional.PowerShellCommandExecution;
 /// <summary>
 /// Test for parameterized command caching
 /// </summary>
-public partial class ExecutePowerShellCommand : PowerShellTestBase
+public class ExecutePowerShellCommandWithParameters : PowerShellTestBase
 {
+    public ExecutePowerShellCommandWithParameters(ITestOutputHelper output) : base(output)
+    {
+    }
+
     [Fact]
-    public async Task _WithParameters_ShouldCacheParameterizedResults()
+    public async Task ShouldCacheParameterizedResults()
     {
         // Arrange - Test with Get-ChildItem command that takes parameters
         var parameterInfos = new[]

--- a/PoshMcp.Tests/Functional/SortLastCommandOutput/ShouldReturnNullTest.cs
+++ b/PoshMcp.Tests/Functional/SortLastCommandOutput/ShouldReturnNullTest.cs
@@ -4,17 +4,17 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Xunit.Abstractions;
 
-namespace PoshMcp.Tests.Functional.PowerShellCommandExecution;
+namespace PoshMcp.Tests.Functional.SortLastCommandOutput;
 
 /// <summary>
 /// Test for sort behavior when no cache exists
 /// </summary>
-public class SortLastCommandOutput_ShouldReturnNullTest : PowerShellTestBase
+public class ShouldReturnNullTest : PowerShellTestBase
 {
-    public SortLastCommandOutput_ShouldReturnNullTest(ITestOutputHelper output) : base(output) { }
+    public ShouldReturnNullTest(ITestOutputHelper output) : base(output) { }
 
     [Fact]
-    public async Task SortLastCommandOutput_ShouldReturnNull_WhenNoCacheExists()
+    public async Task WhenNoCacheExists()
     {
         // Arrange - Clear any existing cache
         await PowerShellRunspace.ExecuteThreadSafeAsync<object?>(ps =>

--- a/PoshMcp.Tests/Functional/SortLastCommandOutput/ShouldSortCachedResultsTest.cs
+++ b/PoshMcp.Tests/Functional/SortLastCommandOutput/ShouldSortCachedResultsTest.cs
@@ -12,17 +12,17 @@ using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace PoshMcp.Tests.Functional.PowerShellCommandExecution;
+namespace PoshMcp.Tests.Functional.SortLastCommand;
 
 /// <summary>
 /// Test for sorting cached results
 /// </summary>
-public class SortLastCommandOutput_ShouldSortCachedResultsTest : PowerShellTestBase
+public class Output_Test : PowerShellTestBase
 {
-    public SortLastCommandOutput_ShouldSortCachedResultsTest(ITestOutputHelper output) : base(output) { }
+    public Output_Test(ITestOutputHelper output) : base(output) { }
 
     [Fact]
-    public async Task SortLastCommandOutput_ShouldSortCachedResults()
+    public async Task ShouldSortCachedResults()
     {
         // Arrange - Execute a simpler command that produces known sortable output
         var parameterInfos = new PowerShellParameterInfo[0];

--- a/PoshMcp.Tests/Integration/McpServerIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/McpServerIntegrationTests.cs
@@ -20,16 +20,16 @@ namespace PoshMcp.Tests.Integration;
 /// <summary>
 /// Integration tests that run the MCP server in-process and communicate with external clients
 /// </summary>
-public class McpServerIntegrationTests : PowerShellTestBase
+public class ServerWithExternalClient : PowerShellTestBase
 {
-    public McpServerIntegrationTests(ITestOutputHelper output) : base(output)
+    public ServerWithExternalClient(ITestOutputHelper output) : base(output)
     {
     }
 
     [Fact]
-    public async Task ServerWithExternalClient_ShouldInitializeAndListTools()
+    public async Task ShouldInitializeAndListTools()
     {
-        Logger.LogInformation("=== Starting ServerWithExternalClient_ShouldInitializeAndListTools Test ===");
+        Logger.LogInformation("=== Starting ShouldInitializeAndListTools Test ===");
 
         // Start the MCP server in-process
         using var server = await StartInProcessMcpServerAsync();
@@ -64,9 +64,9 @@ public class McpServerIntegrationTests : PowerShellTestBase
     }
 
     [Fact]
-    public async Task ServerWithExternalClient_ShouldExecutePowerShellCommand()
+    public async Task ShouldExecutePowerShellCommand()
     {
-        Logger.LogInformation("=== Starting ServerWithExternalClient_ShouldExecutePowerShellCommand Test ===");
+        Logger.LogInformation("=== Starting ShouldExecutePowerShellCommand Test ===");
 
         // Start the MCP server in-process  
         using var server = await StartInProcessMcpServerAsync();
@@ -83,9 +83,9 @@ public class McpServerIntegrationTests : PowerShellTestBase
         Assert.True(toolsResponse["result"]?["tools"] != null);
 
         // Call the PowerShell function through MCP
-        var callResponse = await client.SendToolCallAsync("get_some_data", new
+        var callResponse = await client.SendToolCallAsync("get_process_name", new
         {
-            test = "ExternalClientTest"
+            name = "dotnet"
         });
 
         // Assert: Verify the response
@@ -106,15 +106,15 @@ public class McpServerIntegrationTests : PowerShellTestBase
         Logger.LogInformation($"Tool call result from external client: {textContent}");
 
         // Verify the output contains expected data
-        Assert.Contains("ExternalClientTest", textContent);
+        Assert.Contains("dotnet", textContent);
 
         Logger.LogInformation("PowerShell command executed successfully via external client");
     }
 
     [Fact]
-    public async Task ServerWithExternalClient_ShouldHandleErrors()
+    public async Task ShouldHandleErrors()
     {
-        Logger.LogInformation("=== Starting ServerWithExternalClient_ShouldHandleErrors Test ===");
+        Logger.LogInformation("=== Starting ShouldHandleErrors Test ===");
 
         // Start the MCP server in-process
         using var server = await StartInProcessMcpServerAsync();

--- a/PoshMcp.Tests/Shared/PowerShellTestBase.cs
+++ b/PoshMcp.Tests/Shared/PowerShellTestBase.cs
@@ -17,6 +17,7 @@ public abstract class PowerShellTestBase : IDisposable
     protected readonly ITestOutputHelper Output;
     protected readonly IPowerShellRunspace PowerShellRunspace;
     protected readonly PowerShellAssemblyGenerator AssemblyGenerator;
+    protected readonly McpToolFactoryV2 ToolFactory;
 
     protected PowerShellTestBase(ITestOutputHelper output)
     {
@@ -36,6 +37,9 @@ public abstract class PowerShellTestBase : IDisposable
 
         // Create an instance-based assembly generator with the isolated runspace
         AssemblyGenerator = new PowerShellAssemblyGenerator(PowerShellRunspace);
+
+        // Create an instance of the tool factory for this test
+        ToolFactory = new McpToolFactoryV2();
     }    /// <summary>
          /// Helper method to convert JSON string results back to objects for testing.
          /// This allows tests to work with both the old PSObject[] format and new JSON string format.

--- a/PoshMcpServer/McpToolFactoryV2.cs
+++ b/PoshMcpServer/McpToolFactoryV2.cs
@@ -28,11 +28,26 @@ public class PowerShellCommandMetadata
 /// <summary>
 /// Factory class for creating MCP tools from PowerShell commands using dynamically generated assemblies
 /// </summary>
-public static class McpToolFactoryV2
+public class McpToolFactoryV2
 {
-    private static Assembly? _generatedAssembly;
-    private static object? _generatedInstance;
-    private static Dictionary<string, MethodInfo>? _generatedMethods;
+    private readonly PowerShellAssemblyGenerator _assemblyGenerator;
+
+    /// <summary>
+    /// Initializes a new instance of McpToolFactoryV2 with default runspace
+    /// </summary>
+    public McpToolFactoryV2()
+    {
+        _assemblyGenerator = new PowerShellAssemblyGenerator(new SingletonPowerShellRunspace());
+    }
+
+    /// <summary>
+    /// Initializes a new instance of McpToolFactoryV2 with specified runspace
+    /// </summary>
+    /// <param name="runspace">PowerShell runspace to use</param>
+    public McpToolFactoryV2(IPowerShellRunspace runspace)
+    {
+        _assemblyGenerator = new PowerShellAssemblyGenerator(runspace);
+    }
 
     /// <summary>
     /// Gets PowerShell command metadata including parameter-set-specific syntax and verb information
@@ -42,7 +57,7 @@ public static class McpToolFactoryV2
     /// <param name="powerShell">PowerShell instance for executing queries</param>
     /// <param name="logger">Logger instance</param>
     /// <returns>Command metadata with parameter-set-specific syntax, verb info, and safety characteristics</returns>
-    private static PowerShellCommandMetadata GetCommandMetadata(CommandInfo commandInfo, CommandParameterSetInfo parameterSet, PSPowerShell powerShell, ILogger logger)
+    private PowerShellCommandMetadata GetCommandMetadata(CommandInfo commandInfo, CommandParameterSetInfo parameterSet, PSPowerShell powerShell, ILogger logger)
     {
         var metadata = new PowerShellCommandMetadata
         {
@@ -200,7 +215,7 @@ public static class McpToolFactoryV2
         }
 
         logger.LogDebug($"Command metadata for {metadata.CommandName} ({parameterSet.Name}): Description='{metadata.Description}', IsDestructive={metadata.IsDestructive}, IsReadOnly={metadata.IsReadOnly}, IsIdempotent={metadata.IsIdempotent}");
-        
+
         return metadata;
     }
 
@@ -210,7 +225,7 @@ public static class McpToolFactoryV2
     /// <param name="config">PowerShell configuration</param>
     /// <param name="logger">Logger instance</param>
     /// <returns>List of MCP server tools</returns>
-    public static List<McpServerTool> GetToolsList(PowerShellConfiguration config, ILogger logger)
+    public List<McpServerTool> GetToolsList(PowerShellConfiguration config, ILogger logger)
     {
         try
         {
@@ -236,15 +251,15 @@ public static class McpToolFactoryV2
 
             // Generate the assembly with all command methods
             logger.LogDebug("Generating dynamic assembly for PowerShell commands...");
-            _generatedAssembly = PowerShellDynamicAssemblyGenerator.GenerateAssembly(commands, logger);
-            _generatedInstance = PowerShellDynamicAssemblyGenerator.GetGeneratedInstance(logger);
-            _generatedMethods = PowerShellDynamicAssemblyGenerator.GetGeneratedMethods();
+            var generatedAssembly = _assemblyGenerator.GenerateAssembly(commands, logger);
+            var generatedInstance = _assemblyGenerator.GetGeneratedInstance(logger);
+            var generatedMethods = _assemblyGenerator.GetGeneratedMethods();
 
-            logger.LogInformation($"Generated assembly with {_generatedMethods.Count} methods");
+            logger.LogInformation($"Generated assembly with {generatedMethods.Count} methods");
             if (logger.IsEnabled(LogLevel.Trace))
             {
                 logger.LogTrace("Generated methods:");
-                foreach (var method in _generatedMethods.OrderBy(m => m.Key))
+                foreach (var method in generatedMethods.OrderBy(m => m.Key))
                 {
                     logger.LogTrace($"  {method.Key} -> {method.Value.ReturnType.Name} with {method.Value.GetParameters().Length} parameters");
                 }
@@ -258,22 +273,22 @@ public static class McpToolFactoryV2
             // Create a mapping from method names to parameter-set-specific metadata
             var methodToCommandMap = new Dictionary<string, PowerShellCommandMetadata>();
             var powerShell = PowerShellRunspaceHolder.Instance;
-            
+
             foreach (var command in commands)
             {
                 // For each parameter set of this command, create parameter-set-specific metadata
                 foreach (var parameterSet in command.ParameterSets)
                 {
-                    var methodName = PowerShellDynamicAssemblyGenerator.SanitizeMethodName(command.Name, parameterSet.Name);
-                    
+                    var methodName = PowerShellAssemblyGenerator.SanitizeMethodName(command.Name, parameterSet.Name);
+
                     // Get parameter-set-specific metadata instead of general command metadata
                     var metadata = GetCommandMetadata(command, parameterSet, powerShell, logger);
                     methodToCommandMap[methodName] = metadata;
                     logger.LogDebug($"Created parameter-set-specific metadata for method '{methodName}' from command '{command.Name}' parameter set '{parameterSet.Name}'");
                 }
             }
-
-            foreach (var kvp in _generatedMethods)
+            // Use previously declared generatedMethods and generatedInstance
+            foreach (var kvp in generatedMethods)
             {
                 var methodName = kvp.Key;
                 var method = kvp.Value;
@@ -284,7 +299,7 @@ public static class McpToolFactoryV2
 
                     // Create a delegate from the method
                     var delegateType = GetDelegateTypeForMethod(method);
-                    var methodDelegate = Delegate.CreateDelegate(delegateType, _generatedInstance, method);
+                    var methodDelegate = Delegate.CreateDelegate(delegateType, generatedInstance, method);
 
                     // Get metadata for this method
                     var metadata = methodToCommandMap.GetValueOrDefault(methodName, new PowerShellCommandMetadata
@@ -351,7 +366,7 @@ public static class McpToolFactoryV2
     /// <summary>
     /// Gets available PowerShell commands to generate methods for based on configuration
     /// </summary>
-    private static (List<CommandInfo> commands, Dictionary<string, PowerShellCommandMetadata> metadata) GetAvailableCommandsWithMetadata(PowerShellConfiguration config, ILogger logger)
+    private (List<CommandInfo> commands, Dictionary<string, PowerShellCommandMetadata> metadata) GetAvailableCommandsWithMetadata(PowerShellConfiguration config, ILogger logger)
     {
         var powerShell = PowerShellRunspaceHolder.Instance;
         var commands = new List<CommandInfo>();
@@ -435,13 +450,13 @@ public static class McpToolFactoryV2
     /// <summary>
     /// Gets available PowerShell commands to generate methods for based on configuration (legacy method)
     /// </summary>
-    private static List<CommandInfo> GetAvailableCommands(PowerShellConfiguration config, ILogger logger)
+    private List<CommandInfo> GetAvailableCommands(PowerShellConfiguration config, ILogger logger)
     {
         var (commands, _) = GetAvailableCommandsWithMetadata(config, logger);
         return commands;
     }
 
-    private static List<CommandInfo> GetCommandsByName(List<string> functionNames, PSPowerShell powerShell, ILogger logger)
+    private List<CommandInfo> GetCommandsByName(List<string> functionNames, PSPowerShell powerShell, ILogger logger)
     {
         var commands = new List<CommandInfo>();
 
@@ -473,7 +488,7 @@ public static class McpToolFactoryV2
         return commands;
     }
 
-    private static List<CommandInfo> GetCommandsByModule(List<string> modules, PSPowerShell powerShell, ILogger logger)
+    private List<CommandInfo> GetCommandsByModule(List<string> modules, PSPowerShell powerShell, ILogger logger)
     {
         var commands = new List<CommandInfo>();
 
@@ -498,7 +513,7 @@ public static class McpToolFactoryV2
         return commands;
     }
 
-    private static List<CommandInfo> GetCommandsByPattern(List<string> includePatterns, List<string> excludePatterns, PSPowerShell powerShell, ILogger logger)
+    private List<CommandInfo> GetCommandsByPattern(List<string> includePatterns, List<string> excludePatterns, PSPowerShell powerShell, ILogger logger)
     {
         var commands = new List<CommandInfo>();
 
@@ -523,7 +538,7 @@ public static class McpToolFactoryV2
         return commands;
     }
 
-    private static List<CommandInfo> ApplyIncludePatterns(List<CommandInfo> commands, List<string> includePatterns, ILogger logger)
+    private List<CommandInfo> ApplyIncludePatterns(List<CommandInfo> commands, List<string> includePatterns, ILogger logger)
     {
         var filteredCommands = new List<CommandInfo>();
 
@@ -550,7 +565,7 @@ public static class McpToolFactoryV2
         return filteredCommands;
     }
 
-    private static List<CommandInfo> ApplyExcludePatterns(List<CommandInfo> commands, List<string> excludePatterns, ILogger logger)
+    private List<CommandInfo> ApplyExcludePatterns(List<CommandInfo> commands, List<string> excludePatterns, ILogger logger)
     {
         var filteredCommands = new List<CommandInfo>();
 
@@ -577,7 +592,7 @@ public static class McpToolFactoryV2
         return filteredCommands;
     }
 
-    private static bool IsWildcardMatch(string input, string pattern)
+    private bool IsWildcardMatch(string input, string pattern)
     {
         // Convert wildcard pattern to regex
         var regexPattern = "^" + Regex.Escape(pattern).Replace(@"\*", ".*").Replace(@"\?", ".") + "$";
@@ -587,7 +602,7 @@ public static class McpToolFactoryV2
     /// <summary>
     /// Gets available PowerShell commands to generate methods for (legacy method for backwards compatibility)
     /// </summary>
-    private static List<CommandInfo> GetAvailableCommands(ILogger logger)
+    private List<CommandInfo> GetAvailableCommands(ILogger logger)
     {
         // Create default configuration for backwards compatibility
         var defaultConfig = new PowerShellConfiguration
@@ -601,7 +616,7 @@ public static class McpToolFactoryV2
     /// <summary>
     /// Gets the appropriate delegate type for a generated method
     /// </summary>
-    private static Type GetDelegateTypeForMethod(MethodInfo method)
+    private Type GetDelegateTypeForMethod(MethodInfo method)
     {
         var parameters = method.GetParameters();
         var parameterTypes = parameters.Select(p => p.ParameterType).ToArray();
@@ -653,7 +668,7 @@ public static class McpToolFactoryV2
     /// <summary>
     /// Converts a normalized method name back to the original command name
     /// </summary>
-    private static string DeNormalizeMethodName(string methodName)
+    private string DeNormalizeMethodName(string methodName)
     {
         // This is a simple reverse of the normalization process
         // Replace underscores with hyphens for PowerShell command names
@@ -663,23 +678,25 @@ public static class McpToolFactoryV2
     /// <summary>
     /// Gets information about the generated assembly for debugging
     /// </summary>
-    public static string GetAssemblyInfo(ILogger logger)
+    public string GetAssemblyInfo(ILogger logger)
     {
         try
         {
-            if (_generatedAssembly == null)
+            var generatedAssembly = _assemblyGenerator.GeneratedAssembly;
+            if (generatedAssembly == null)
             {
                 return "No assembly has been generated yet";
             }
 
-            var info = $"Generated Assembly: {_generatedAssembly.FullName}\n";
-            info += $"Location: {_generatedAssembly.Location}\n";
-            info += $"Dynamic: {_generatedAssembly.IsDynamic}\n";
+            var info = $"Generated Assembly: {generatedAssembly.FullName}\n";
+            info += $"Location: {generatedAssembly.Location}\n";
+            info += $"Dynamic: {generatedAssembly.IsDynamic}\n";
 
-            if (_generatedMethods != null)
+            var generatedMethods = _assemblyGenerator.GetGeneratedMethods();
+            if (generatedMethods != null)
             {
-                info += $"Generated Methods ({_generatedMethods.Count}):\n";
-                foreach (var kvp in _generatedMethods)
+                info += $"Generated Methods ({generatedMethods.Count}):\n";
+                foreach (var kvp in generatedMethods)
                 {
                     var method = kvp.Value;
                     var parameters = method.GetParameters();
@@ -700,16 +717,19 @@ public static class McpToolFactoryV2
     /// <summary>
     /// Tests the generated assembly by invoking a specific method
     /// </summary>
-    public static async Task<string> TestGeneratedMethod(string methodName, object[] parameters, ILogger logger)
+    public async Task<string> TestGeneratedMethod(string methodName, object[] parameters, ILogger logger)
     {
         try
         {
-            if (_generatedMethods == null || _generatedInstance == null)
+
+            var generatedMethods = _assemblyGenerator.GetGeneratedMethods();
+            var generatedInstance = _assemblyGenerator.GetGeneratedInstance(logger);
+            if (generatedMethods == null || generatedInstance == null)
             {
                 return "Assembly has not been generated yet";
             }
 
-            if (!_generatedMethods.TryGetValue(methodName, out var method))
+            if (!generatedMethods.TryGetValue(methodName, out var method))
             {
                 return $"Method '{methodName}' not found in generated assembly";
             }
@@ -726,7 +746,7 @@ public static class McpToolFactoryV2
             }
 
             // Invoke the method
-            var result = method.Invoke(_generatedInstance, allParameters.ToArray());
+            var result = method.Invoke(generatedInstance, allParameters.ToArray());
 
             if (result is Task<string> taskResult)
             {
@@ -749,7 +769,7 @@ public static class McpToolFactoryV2
     /// </summary>
     /// <param name="logger">Logger instance</param>
     /// <returns>List of MCP server tools</returns>
-    public static List<McpServerTool> GetToolsList(ILogger logger)
+    public List<McpServerTool> GetToolsList(ILogger logger)
     {
         // Create default configuration for backwards compatibility
         var defaultConfig = new PowerShellConfiguration

--- a/PoshMcpServer/PowerShell/PowerShellAssemblyGenerator.cs
+++ b/PoshMcpServer/PowerShell/PowerShellAssemblyGenerator.cs
@@ -17,11 +17,64 @@ namespace PoshMcp.PowerShell;
 /// </summary>
 public class PowerShellAssemblyGenerator
 {
+    public Assembly? GeneratedAssembly => _generatedAssembly;
     private readonly IPowerShellRunspace _powerShellRunspace;
     private Assembly? _generatedAssembly;
     private Type? _generatedType;
     private object? _generatedInstance;
     private readonly object _lock = new object();
+
+    public static string SanitizeMethodName(string commandName, string? parameterSetName = null)
+    {
+        return SanitizeMethodName_Internal(commandName, parameterSetName);
+    }
+
+    private static string CamelCaseToSnakeCase(string input)
+    {
+        if (string.IsNullOrEmpty(input))
+            return input;
+
+        // Use a regex to insert underscores before uppercase letters
+        var result = System.Text.RegularExpressions.Regex.Replace(input, "([a-z0-9])([A-Z])", "$1_$2");
+        // replace - with _
+        result = result.Replace("-", "_");
+        // remove duplicate underscores
+        result = System.Text.RegularExpressions.Regex.Replace(result, "_+", "_");
+        return result.ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Sanitizes a command name to make it a valid C# method name
+    /// </summary>
+    private static string SanitizeMethodName_Internal(string commandName, string? parameterSetName = null)
+    {
+        if (string.IsNullOrWhiteSpace(commandName))
+        {
+            return "UnnamedCommand";
+        }
+
+        // Convert CamelCase to snake_case
+        var sanitized = CamelCaseToSnakeCase(commandName);
+
+        // Ensure it doesn't start with a digit
+        if (char.IsDigit(sanitized[0]))
+        {
+            sanitized = "_" + sanitized;
+        }
+
+        if (!(string.IsNullOrWhiteSpace(parameterSetName) || parameterSetName == "__AllParameterSets"))
+        {
+            sanitized += "_" + CamelCaseToSnakeCase(parameterSetName);
+        }
+
+        // Ensure it's not empty after sanitization
+        if (string.IsNullOrWhiteSpace(sanitized))
+        {
+            sanitized = "UnnamedCommand";
+        }
+
+        return sanitized;
+    }
 
     public PowerShellAssemblyGenerator(IPowerShellRunspace powerShellRunspace)
     {
@@ -239,7 +292,7 @@ public class PowerShellAssemblyGenerator
             .ToList();
 
         // Create method name (sanitized) - append parameter set name unless it's __AllParameterSets
-        var methodName = PowerShellDynamicAssemblyGenerator.SanitizeMethodName(commandInfo.Name, parameterSet.Name);
+        var methodName = PowerShellAssemblyGenerator.SanitizeMethodName(commandInfo.Name, parameterSet.Name);
 
         logger.LogDebug($"Generating method '{methodName}' for command '{commandInfo.Name}' parameter set '{parameterSet.Name}' with {parameters.Count} parameters");
 

--- a/PoshMcpServer/PowerShell/PowerShellDynamicAssemblyGenerator.cs
+++ b/PoshMcpServer/PowerShell/PowerShellDynamicAssemblyGenerator.cs
@@ -173,57 +173,6 @@ public static class PowerShellDynamicAssemblyGenerator
         return await PowerShellAssemblyGenerator.FilterLastCommandOutput(runspace, logger, filterScript, false, cancellationToken);
     }
 
-    public static string SanitizeMethodName(string commandName, string? parameterSetName = null)
-    {
-        return PowerShellDynamicAssemblyGenerator.SanitizeMethodName_Internal(commandName, parameterSetName);
-    }
-
-    private static string CamelCaseToSnakeCase(string input)
-    {
-        if (string.IsNullOrEmpty(input))
-            return input;
-
-        // Use a regex to insert underscores before uppercase letters
-        var result = System.Text.RegularExpressions.Regex.Replace(input, "([a-z0-9])([A-Z])", "$1_$2");
-        // replace - with _
-        result = result.Replace("-", "_");
-        // remove duplicate underscores
-        result = System.Text.RegularExpressions.Regex.Replace(result, "_+", "_");
-        return result.ToLowerInvariant();
-    }
-
-    /// <summary>
-    /// Sanitizes a command name to make it a valid C# method name
-    /// </summary>
-    private static string SanitizeMethodName_Internal(string commandName, string? parameterSetName = null)
-    {
-        if (string.IsNullOrWhiteSpace(commandName))
-        {
-            return "UnnamedCommand";
-        }
-
-        // Convert CamelCase to snake_case
-        var sanitized = CamelCaseToSnakeCase(commandName);
-
-        // Ensure it doesn't start with a digit
-        if (char.IsDigit(sanitized[0]))
-        {
-            sanitized = "_" + sanitized;
-        }
-
-        if (!(string.IsNullOrWhiteSpace(parameterSetName) || parameterSetName == "__AllParameterSets"))
-        {
-            sanitized += "_" + CamelCaseToSnakeCase(parameterSetName);
-        }
-
-        // Ensure it's not empty after sanitization
-        if (string.IsNullOrWhiteSpace(sanitized))
-        {
-            sanitized = "UnnamedCommand";
-        }
-
-        return sanitized;
-    }
 }
 
 /// <summary>

--- a/PoshMcpServer/Program.cs
+++ b/PoshMcpServer/Program.cs
@@ -21,19 +21,19 @@ public class Program
     {
         // Set up command line parsing
         var rootCommand = new RootCommand("PowerShell MCP Server - Provides access to PowerShell commands via Model Context Protocol");
-        
+
         var evaluateToolsOption = new Option<bool>(
             aliases: new[] { "--evaluate-tools", "-e" },
             description: "Evaluate and list discovered PowerShell tools without starting the MCP server");
-        
+
         var verboseOption = new Option<bool>(
             aliases: new[] { "--verbose", "-v" },
             description: "Enable verbose logging");
-            
+
         var debugOption = new Option<bool>(
             aliases: new[] { "--debug", "-d" },
             description: "Enable debug logging");
-            
+
         var traceOption = new Option<bool>(
             aliases: new[] { "--trace", "-t" },
             description: "Enable trace logging");
@@ -118,7 +118,8 @@ public class Program
 
             // Discover tools using the same logic as the main server
             logger.LogInformation("Discovering PowerShell tools...");
-            var tools = McpToolFactoryV2.GetToolsList(config, logger);
+            var toolFactory = new McpToolFactoryV2();
+            var tools = toolFactory.GetToolsList(config, logger);
 
             // Report results
             Console.Error.WriteLine();
@@ -201,7 +202,8 @@ public class Program
         logger.LogInformation($"Using configuration file: {finalConfigPath}");
 
         // Use the new dynamic assembly-based tool factory with configuration
-        var tools = McpToolFactoryV2.GetToolsList(config, logger);
+        var toolFactory = new McpToolFactoryV2();
+        var tools = toolFactory.GetToolsList(config, logger);
 
         // Configure JSON serializer options to handle cycles and deep object graphs
         builder.Services.Configure<JsonSerializerOptions>(options =>

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -5,29 +5,83 @@
 
 set -e
 
+## Check to see if TEST_VERBOSITY exists, if not default to normal
+if [ -z "${TEST_VERBOSITY}" ]; then
+    TEST_VERBOSITY="normal"
+fi
+
+## Check to see if TEST_VERBOSITY is a valid value
+## q, quiet, m, minimal, n, normal, d, detailed, diag, diagnostic
+case "${TEST_VERBOSITY}" in
+    "q"|"quiet"|"m"|"minimal"|"n"|"normal"|"d"|"detailed"|"diag"|"diagnostic")
+        # Valid verbosity level
+        ;;
+    *)
+        echo "❌ Invalid TEST_VERBOSITY value: '${TEST_VERBOSITY}'"
+        echo "Valid values are: q, quiet, m, minimal, n, normal, d, detailed, diag, diagnostic"
+        exit 1
+        ;;
+esac
+
+
+
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$PROJECT_ROOT"
 
 case "${1:-all}" in
     "unit")
         echo "🧪 Running Unit Tests..."
-        dotnet test PoshMcp.Tests/PoshMcp.Tests.csproj --filter "FullyQualifiedName~Unit" --logger "console;verbosity=normal"
+        filter="--filter FullyQualifiedName~Unit"
         ;;
     "functional")
+        ## Validate FUNCTIONAL_FILTER if provided
+        if [ -n "${FUNCTIONAL_FILTER}" ]; then
+            # Get all functional test directories
+            functional_dirs=""
+            if [ -d "PoshMcp.Tests/Functional" ]; then
+                functional_dirs=$(find PoshMcp.Tests/Functional -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort)
+            fi
+            
+            if [ -z "${functional_dirs}" ]; then
+                echo "❌ No functional test directories found in PoshMcp.Tests/Functional"
+                exit 1
+            fi
+            
+            # Check if FUNCTIONAL_FILTER matches any directory name (start or full match)
+            filter_valid=false
+            for dir in ${functional_dirs}; do
+                # Check for exact match or if the directory starts with the filter
+                if [ "${dir}" = "${FUNCTIONAL_FILTER}" ] || [[ "${dir}" == "${FUNCTIONAL_FILTER}"* ]]; then
+                    filter_valid=true
+                    break
+                fi
+            done
+            
+            if [ "${filter_valid}" = false ]; then
+                echo "❌ Invalid FUNCTIONAL_FILTER value: '${FUNCTIONAL_FILTER}'"
+                echo "Available functional test directories:"
+                for dir in ${functional_dirs}; do
+                    echo "  - ${dir}"
+                done
+                echo ""
+                echo "FUNCTIONAL_FILTER must match the start or full name of a directory"
+                exit 1
+            fi
+        fi
         echo "⚙️ Running Functional Tests..."
-        dotnet test PoshMcp.Tests/PoshMcp.Tests.csproj --filter "FullyQualifiedName~Functional" --logger "console;verbosity=normal"
+        filter="--filter FullyQualifiedName~Functional.${FUNCTIONAL_FILTER}"
         ;;
     "integration")
         echo "🔗 Running Integration Tests..."
-        dotnet test PoshMcp.Tests/PoshMcp.Tests.csproj --filter "FullyQualifiedName~Integration" --logger "console;verbosity=normal"
+        filter="--filter FullyQualifiedName~Integration"
         ;;
     "fast")
         echo "🚀 Running Fast Tests (Unit + Functional)..."
-        dotnet test PoshMcp.Tests/PoshMcp.Tests.csproj --filter "FullyQualifiedName~Unit|FullyQualifiedName~Functional" --logger "console;verbosity=normal"
+        filter="--filter FullyQualifiedName~Unit|FullyQualifiedName~Functional"
         ;;
     "all")
         echo "🎯 Running All Tests..."
-        dotnet test PoshMcp.Tests/PoshMcp.Tests.csproj --logger "console;verbosity=normal"
+        filter=""
         ;;
     "help"|"-h"|"--help")
         echo "PoshMcp Test Runner"
@@ -42,10 +96,21 @@ case "${1:-all}" in
         echo "  all          Run all tests (default)"
         echo "  help         Show this help message"
         echo ""
+        echo "Environment Variables:"
+        echo "  TEST_VERBOSITY     Set test output verbosity level (default: normal)"
+        echo "                     Valid values: q, quiet, m, minimal, n, normal, d, detailed, diag, diagnostic"
+        echo "  FUNCTIONAL_FILTER  Filter functional tests by directory name (optional)"
+        echo "                     Must match the start or full name of a directory in PoshMcp.Tests/Functional"
+        echo ""
         echo "Examples:"
-        echo "  $0 unit                # Run only unit tests"
-        echo "  $0 fast                # Run unit and functional tests"
-        echo "  $0                     # Run all tests"
+        echo "  $0 unit                                    # Run only unit tests"
+        echo "  $0 fast                                    # Run unit and functional tests"
+        echo "  $0                                         # Run all tests"
+        echo "  TEST_VERBOSITY=quiet $0 unit               # Run unit tests with minimal output"
+        echo "  TEST_VERBOSITY=detailed $0 all             # Run all tests with detailed output"
+        echo "  FUNCTIONAL_FILTER=Generated $0 functional  # Run only GeneratedAssembly functional tests"
+        echo "  FUNCTIONAL_FILTER=McpServer $0 functional  # Run only McpServerSetup functional tests"
+        exit 0
         ;;
     *)
         echo "❌ Unknown test category: $1"
@@ -53,3 +118,6 @@ case "${1:-all}" in
         exit 1
         ;;
 esac
+
+
+dotnet test PoshMcp.Tests/PoshMcp.Tests.csproj ${filter} --logger "console;verbosity=${TEST_VERBOSITY}"


### PR DESCRIPTION
- Renamed test classes from UtilityMethods to GeneratedInstance for better context.
- Updated method names in tests to follow a consistent naming convention.
- Refactored McpToolFactoryV2 to be an instance class instead of static, allowing for better encapsulation and flexibility.
- Enhanced PowerShellAssemblyGenerator with a public property for accessing the generated assembly.
- Removed redundant static methods from PowerShellDynamicAssemblyGenerator and moved sanitization logic to PowerShellAssemblyGenerator.
- Improved run-tests.sh script to include functionality for filtering functional tests by directory name.
- Updated various tests to utilize the new instance-based tool factory.