### PR TITLE
Cli

### DIFF
--- a/PoshMcp.Server/Program.cs
+++ b/PoshMcp.Server/Program.cs
@@ -40,11 +40,19 @@ public class Program
             aliases: new[] { "--trace", "-t" },
             description: "Enable trace logging");
 
+        // Add subcommands
+        var psModulePathCommand = new Command("psmodulepath", "Start a PowerShell runspace and report the value of $env:PSModulePath");
+        psModulePathCommand.AddOption(verboseOption);
+        psModulePathCommand.AddOption(debugOption);
+        psModulePathCommand.AddOption(traceOption);
+
         rootCommand.AddOption(evaluateToolsOption);
         rootCommand.AddOption(verboseOption);
         rootCommand.AddOption(debugOption);
         rootCommand.AddOption(traceOption);
+        rootCommand.AddCommand(psModulePathCommand);
 
+        // Handler for the main command (default MCP server behavior)
         rootCommand.SetHandler(async (evaluateTools, verbose, debug, trace) =>
         {
             // Determine log level based on options
@@ -63,7 +71,79 @@ public class Program
             }
         }, evaluateToolsOption, verboseOption, debugOption, traceOption);
 
+        // Handler for the psmodulepath command
+        psModulePathCommand.SetHandler((verbose, debug, trace) =>
+        {
+            // Determine log level based on options
+            LogLevel logLevel = LogLevel.Information;
+            if (trace) logLevel = LogLevel.Trace;
+            else if (debug) logLevel = LogLevel.Debug;
+            else if (verbose) logLevel = LogLevel.Debug; // Verbose maps to Debug level
+
+            RunPSModulePathCommand(logLevel);
+        }, verboseOption, debugOption, traceOption);
+
         return await rootCommand.InvokeAsync(args);
+    }
+
+    private static void RunPSModulePathCommand(LogLevel logLevel)
+    {
+        Console.Error.WriteLine("=== PowerShell MCP Server - PSModulePath Report ===");
+        Console.Error.WriteLine();
+
+        using var loggerFactory = CreateLoggerFactory(logLevel);
+        var logger = loggerFactory.CreateLogger("PSModulePath");
+
+        try
+        {
+            logger.LogInformation("Starting PowerShell runspace to check PSModulePath");
+
+            using var runspace = new IsolatedPowerShellRunspace();
+
+            var psModulePath = runspace.ExecuteThreadSafe(ps =>
+            {
+                ps.Commands.Clear();
+                ps.AddScript("$env:PSModulePath");
+
+                var results = ps.Invoke();
+
+                if (ps.HadErrors)
+                {
+                    var errors = string.Join(Environment.NewLine, ps.Streams.Error);
+                    throw new InvalidOperationException($"PowerShell execution failed: {errors}");
+                }
+
+                return results.Count > 0 ? results[0]?.ToString() ?? string.Empty : string.Empty;
+            });
+
+            Console.WriteLine("PSModulePath:");
+            Console.WriteLine(new string('=', 50));
+
+            if (!string.IsNullOrEmpty(psModulePath))
+            {
+                // Split the path and display each entry on a separate line for better readability
+                var paths = psModulePath.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+                for (int i = 0; i < paths.Length; i++)
+                {
+                    Console.WriteLine($"{i + 1:D2}. {paths[i]}");
+                }
+
+                Console.WriteLine();
+                Console.WriteLine($"Total module paths: {paths.Length}");
+            }
+            else
+            {
+                Console.WriteLine("(empty or undefined)");
+            }
+
+            Console.WriteLine(new string('=', 50));
+            logger.LogInformation("PSModulePath report completed successfully");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error while checking PSModulePath: {ErrorMessage}", ex.Message);
+            Console.Error.WriteLine($"Error: {ex.Message}");
+        }
     }
 
     private static async Task RunToolEvaluationAsync(LogLevel logLevel)

--- a/PoshMcp.Tests/Integration/CommandLineTests.cs
+++ b/PoshMcp.Tests/Integration/CommandLineTests.cs
@@ -136,5 +136,48 @@ namespace PoshMcp.Tests.Integration
             Assert.True(parseResult.GetValueForOption(evaluateToolsOption));
             Assert.True(parseResult.GetValueForOption(verboseOption));
         }
+
+        [Fact]
+        public void CommandLine_PSModulePathCommand_ShouldBeRecognized()
+        {
+            // Test that the psmodulepath command is properly set up
+            var rootCommand = new RootCommand("PowerShell MCP Server - Provides access to PowerShell commands via Model Context Protocol");
+
+            var verboseOption = new Option<bool>(
+                aliases: new[] { "--verbose", "-v" },
+                description: "Enable verbose logging");
+
+            var debugOption = new Option<bool>(
+                aliases: new[] { "--debug", "-d" },
+                description: "Enable debug logging");
+
+            var traceOption = new Option<bool>(
+                aliases: new[] { "--trace", "-t" },
+                description: "Enable trace logging");
+
+            // Create the psmodulepath subcommand
+            var psModulePathCommand = new Command("psmodulepath", "Start a PowerShell runspace and report the value of $env:PSModulePath");
+            psModulePathCommand.AddOption(verboseOption);
+            psModulePathCommand.AddOption(debugOption);
+            psModulePathCommand.AddOption(traceOption);
+
+            rootCommand.AddCommand(psModulePathCommand);
+
+            // Verify the command structure
+            Assert.NotNull(rootCommand);
+            Assert.Single(rootCommand.Subcommands);
+            Assert.Equal("psmodulepath", rootCommand.Subcommands[0].Name);
+            Assert.Equal("Start a PowerShell runspace and report the value of $env:PSModulePath", rootCommand.Subcommands[0].Description);
+
+            // Test parsing the psmodulepath command
+            var parseResult = rootCommand.Parse(new[] { "psmodulepath" });
+            Assert.NotNull(parseResult);
+            Assert.Empty(parseResult.Errors);
+
+            // Test parsing psmodulepath command with options
+            var parseResultWithVerbose = rootCommand.Parse(new[] { "psmodulepath", "--verbose" });
+            Assert.NotNull(parseResultWithVerbose);
+            Assert.Empty(parseResultWithVerbose.Errors);
+        }
     }
 }

--- a/launcher.sh
+++ b/launcher.sh
@@ -11,12 +11,14 @@ echo "2. Run Interactive Test Client (for testing/debugging)"
 echo "3. Build both projects"
 echo "4. Run tests"
 echo "5. Launch MCP Inspector"
-echo "6. Exit"
+echo "6. Evaluate PowerShell Tools (--evaluate-tools)"
+echo "7. Check PowerShell Module Path (psmodulepath)"
+echo "8. Exit"
 echo ""
 
 export Logging__LogLevel__Microsoft="Debug"
 
-read -p "Enter your choice (1-6): " choice
+read -p "Enter your choice (1-8): " choice
 
 case $choice in
     1)
@@ -43,11 +45,23 @@ case $choice in
         npx @modelcontextprotocol/inspector dotnet run --project PoshMcp.Server/PoshMcp.csproj
         ;;
     6)
+        echo "Evaluating PowerShell Tools..."
+        echo "This will analyze your PowerShell configuration and list discovered tools."
+        echo ""
+        dotnet run --project PoshMcp.Server/PoshMcp.csproj -- --evaluate-tools
+        ;;
+    7)
+        echo "Checking PowerShell Module Path..."
+        echo "This will show the PSModulePath environment variable values."
+        echo ""
+        dotnet run --project PoshMcp.Server/PoshMcp.csproj -- psmodulepath
+        ;;
+    8)
         echo "Goodbye!"
         exit 0
         ;;
     *)
-        echo "Invalid choice. Please run the script again and choose 1-5."
+        echo "Invalid choice. Please run the script again and choose 1-8."
         exit 1
         ;;
 esac


### PR DESCRIPTION
This pull request adds a new `psmodulepath` subcommand to the MCP server, allowing users to report the value of the PowerShell `$env:PSModulePath` environment variable via the CLI. It also improves the launcher script to expose this new functionality and updates the integration tests to ensure the command is recognized and parsed correctly.

### New CLI Feature: PSModulePath Reporting

* Added a new `psmodulepath` subcommand to the MCP server CLI (`Program.cs`) that starts a PowerShell runspace and reports the value of `$env:PSModulePath`, including formatted output and error handling. [[1]](diffhunk://#diff-13d7ec05d8a013d1c946a51a5a25462d2e9edd7e4070ff9963d7737156057fd9R43-R55) [[2]](diffhunk://#diff-13d7ec05d8a013d1c946a51a5a25462d2e9edd7e4070ff9963d7737156057fd9R74-R148)
* Implemented the handler logic for `psmodulepath`, including logging and splitting the module path for readability.

### Integration and Testing

* Added an integration test to verify that the `psmodulepath` command is properly recognized and parsed, including option handling. (`CommandLineTests.cs`)

### Launcher Script Improvements

* Updated the `launcher.sh` script to include menu options for evaluating PowerShell tools and checking the PowerShell module path, reflecting the new CLI features.
* Added corresponding case logic to the launcher script to run the new commands, with user instructions and improved error messages.