### PR TITLE
feat: MCP authentication configuration model (Phase 1)

### DIFF
--- a/.squad/agents/amy/history.md
+++ b/.squad/agents/amy/history.md
@@ -14,6 +14,15 @@
 
 ## Recent Learnings
 
+### 2026-04-12: v0.5.1 patch release
+
+- Bumped `PoshMcp.Server/PoshMcp.csproj` version from `0.5.0` → `0.5.1` (patch increment following "Bump version to 0.5.0" commit).
+- Pack command: `dotnet pack .\PoshMcp.Server\PoshMcp.csproj -c Release -o .\artifacts\nupkg` → produces `poshmcp.0.5.1.nupkg` (~25 MB).
+- Update command: `dotnet tool update -g poshmcp --version 0.5.1 --add-source .\artifacts\nupkg --ignore-failed-sources`
+- Verified: `poshmcp --version` → `0.5.1+fad23f66007916f0c2145e7c5e0eb8a20925c8dd`
+- `dotnet tool update` handles both first-time install and upgrades; no need to uninstall first.
+- No running poshmcp.exe processes were present; process-stop guard was a no-op but remains required as a pre-check.
+
 ### 2026-04-09 to 2026-04-10: Release and operational hygiene
 
 - `PoshMcp.Server/PoshMcp.csproj` is the source of truth for global tool versioning.

--- a/.squad/agents/bender/history.md
+++ b/.squad/agents/bender/history.md
@@ -1,3 +1,5 @@
+# Bender History
+
 # Bender Work History
 
 ## Project Context
@@ -331,3 +333,4 @@
 - `oop-host.ps1` is the subprocess host script — handles discover/invoke/ping/shutdown via ndjson
 - Crash recovery uses exponential backoff (3 retries in 5 min)
 - RuntimeMode is server-wide in v1 (InProcess or OutOfProcess), no per-function routing
+

--- a/.squad/agents/farnsworth/history.md
+++ b/.squad/agents/farnsworth/history.md
@@ -72,3 +72,26 @@ Current Priorities:
 **Key insight:** OOP isolation targets heavy module loading, not the SDK. The SDK can deserialize CLIXML, but doing so reconstructs full PSObject graphs that we immediately flatten — waste of CPU/memory for throwaway fidelity.
 **If types prove problematic:** Handle surgically in `oop-host.ps1` with per-type handlers rather than switching transport format. ConvertTo-Json -Depth 4 -Compress remains the correct approach.
 **Decision file:** `.squad/decisions/inbox/farnsworth-clixml-evaluation.md`
+
+### 2026-07-14: MCP authentication architecture design
+
+**Decision:** Implement two-layer authentication for HTTP transport:
+1. **ASP.NET Core middleware** validates identity (JWT Bearer tokens, API keys) → populates `HttpContext.User`
+2. **MCP SDK `CallToolFilters`** enforce per-tool authorization via `FunctionOverrides` config (scopes, roles, anonymous bypass)
+
+**Architecture rationale:**
+- Use `McpRequestFilters.CallToolFilters` (not `DelegatingMcpServerTool` wrappers) — cross-cutting, direct access to `User` and tool names, pairs with `ListToolsFilters` for consistent visibility
+- Standard ASP.NET Core auth stack (not custom MCP-layer parsing) — SDK's `MessageContext.User` proves this is the intended integration point
+- Multi-scheme support: JWT Bearer (spec compliance, enterprise) + API Key (simplicity)
+- Disabled by default (`Authentication.Enabled = false`) for backward compatibility
+- Stdio transport skips HTTP auth per MCP spec, but `CallToolFilters` still enforce tool-level policy
+
+**Implementation scope:**
+- New `Authentication` config section with `Enabled`, `Schemes`, `DefaultPolicy`
+- `FunctionOverride` extends existing pattern with `RequiredScopes`, `RequiredRoles`, `AllowAnonymous`
+- `Program.cs` gains conditional auth middleware in HTTP pipeline
+- RFC 9728 protected resource metadata endpoint: `/.well-known/oauth-protected-resource`
+- New dependency: `Microsoft.AspNetCore.Authentication.JwtBearer`
+
+**Full plan:** Session workspace `plan.md`
+**Decision file:** `.squad/decisions.md` entry 2026-07-14

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -683,3 +683,54 @@ If specific types prove problematic during implementation, the `oop-host.ps1` sc
 
 No changes to `specs/out-of-process-execution.md`. The existing ndjson protocol remains the correct approach.
 
+
+
+# Decision: MCP Authentication Architecture
+
+**Author:** Farnsworth (Lead/Architect)
+**Date:** 2026-07-14
+**Status:** Proposed
+
+## Context
+
+PoshMcp has no authentication or authorization. For HTTP deployments, any client can connect and invoke any tool — including destructive ones like `Stop-Process`. The MCP protocol spec (2025-06-18) defines an optional OAuth 2.1-based authorization model for HTTP transports.
+
+## Decision
+
+Implement a **two-layer authentication architecture** for PoshMcp's HTTP transport:
+
+1. **ASP.NET Core authentication middleware** validates caller identity (JWT Bearer tokens and API keys), populating `HttpContext.User` which the MCP SDK automatically propagates to `RequestContext.User`.
+
+2. **MCP SDK `CallToolFilters`** enforce per-tool authorization by matching tool names against configuration-driven scope and role requirements in `FunctionOverrides`.
+
+Authentication is **disabled by default** (`Authentication.Enabled = false`) to preserve backward compatibility.
+
+## Key Architectural Choices
+
+- **`McpRequestFilters.CallToolFilters`** for per-tool auth — not `DelegatingMcpServerTool` wrappers. Filters are cross-cutting, have direct access to `User` and tool name, and pair with `ListToolsFilters` for consistent tool visibility.
+- **Standard ASP.NET Core auth stack** for token validation — not custom MCP-layer parsing. The SDK's `MessageContext.User` (`ClaimsPrincipal`) proves this is the intended integration point.
+- **Per-tool overrides via `FunctionOverrides`** — extends the existing pattern (`RequiredScopes`, `RequiredRoles`, `AllowAnonymous`) rather than creating a parallel config section.
+- **Multi-scheme support** (JWT Bearer + API Key) — JWT for spec compliance and enterprise, API Key for simplicity.
+- **Stdio transport**: Skips HTTP auth per MCP spec, but `CallToolFilters` still run for tool-level policy enforcement.
+
+## Consequences
+
+- Existing deployments are unaffected (auth off by default)
+- New `Authentication` config section in `appsettings.json` with `Enabled`, `Schemes`, `DefaultPolicy`
+- `FunctionOverride` class gets three new properties
+- `Program.cs` HTTP pipeline gains auth middleware conditionally
+- RFC 9728 Protected Resource Metadata endpoint at `/.well-known/oauth-protected-resource`
+- New NuGet dependency: `Microsoft.AspNetCore.Authentication.JwtBearer`
+
+## Alternatives Considered
+
+1. **Auth at MCP filter layer only** (parse tokens in `CallToolFilters`): Rejected — reinvents ASP.NET Core's auth stack, misses session-init protection, fragile JWT handling.
+2. **`DelegatingMcpServerTool` per-tool wrappers**: Rejected — requires wrapping every tool individually, no cleaner than a single filter, and doesn't pair with tool-list filtering.
+3. **Auth enabled by default**: Rejected — would break all existing deployments immediately.
+
+## References
+
+- MCP Spec Authorization: https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization
+- C# MCP SDK v1.2.0 API: https://csharp.sdk.modelcontextprotocol.io/
+- Full implementation plan: Session workspace `plan.md`
+

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -1,4 +1,7 @@
 # Decisions Log
+Canonical record of decisions, actions, and outcomes.
+
+# Decisions Log
 
 Canonical record of decisions, actions, and outcomes.
 
@@ -563,4 +566,120 @@ Comprehensive plan for out-of-process PowerShell execution written to `specs/out
 **Impact:** Unblocks `dotnet build` (Phase 1 is immediate priority) and enables PoshMcp to serve modules from the `integration/Modules/` test corpus.
 
 **Full spec:** `specs/out-of-process-execution.md`
+
+
+
+
+# Decision: PoshMcp Release Packaging Workflow (v0.5.1)
+
+**Date:** 2026-04-12
+**Author:** Amy (DevOps / Platform Engineer)
+**Status:** Confirmed
+
+## Context
+
+Steven requested a new release of PoshMcp be packaged and installed globally. This is the first release from the `main` branch after the `0.5.0` bump commit.
+
+## Decision
+
+Use a **patch version increment** (`0.5.0` → `0.5.1`) for this release. The change set since `0.5.0` is purely operational (embedded oop-host.ps1 resource, CLI wiring) with no breaking changes or new features warranting a minor bump.
+
+## Established Workflow (canonical steps)
+
+1. **Stop any running poshmcp process** — prevents update lock failures on Windows.
+2. **Bump version** in `PoshMcp.Server/PoshMcp.csproj` (`<Version>` property).
+3. **Pack:** `dotnet pack .\PoshMcp.Server\PoshMcp.csproj -c Release -o .\artifacts\nupkg`
+4. **Install/Update:** `dotnet tool update -g poshmcp --version <newVersion> --add-source .\artifacts\nupkg --ignore-failed-sources`
+5. **Verify:** `poshmcp --version` should report `<newVersion>+<git-sha>`
+
+## Outcomes
+
+- Package: `artifacts/nupkg/poshmcp.0.5.1.nupkg` (~25 MB)
+- Global tool verified: `poshmcp --version` → `0.5.1+fad23f66007916f0c2145e7c5e0eb8a20925c8dd`
+- `dotnet tool update` works for both initial install and upgrade; no need to uninstall first.
+
+## Notes
+
+- `artifacts/nupkg/` is the local feed folder; not committed to source control.
+- Version bump commit should be made after packaging to keep git history clean.
+- NU1510 warnings (redundant explicit package refs) are pre-existing and non-blocking.
+
+
+
+### 2026-04-11: CLIXML vs ndjson for OOP subprocess communication
+
+**Author:** Farnsworth (Lead / Architect)
+**Date:** 2026-04-11
+**Status:** Proposed
+**Requested by:** Steven Murawski
+
+## Decision
+
+**Stick with ndjson (newline-delimited JSON) for OOP subprocess communication. Do not adopt CLIXML.**
+
+## Context
+
+Steven asked whether CLIXML (`Export-Clixml`/`Import-Clixml`, PowerShell's native serialization format used by PS Remoting) should replace or complement the ndjson protocol defined in `specs/out-of-process-execution.md`. The current spec has `oop-host.ps1` returning results via `ConvertTo-Json -Depth 4 -Compress` over stdin/stdout.
+
+## Analysis
+
+### The fundamental constraint: MCP output is JSON
+
+The entire pipeline terminates at a JSON string delivered to the MCP client. Any type fidelity gained from CLIXML is necessarily lost when the server converts results back to JSON for MCP transport. This makes CLIXML a detour, not a shortcut.
+
+### Can the server deserialize CLIXML?
+
+Yes — the server already loads `Microsoft.PowerShell.SDK`. The OOP architecture isolates **heavy module loading** (Az.\*, Microsoft.Graph.\*), not the SDK itself. `[System.Management.Automation.PSSerializer]::Deserialize()` would work fine on the server side. This is not a technical blocker — but it's also not a free benefit, because the resulting `PSObject` still needs to go through `PowerShellObjectSerializer.FlattenPSObject()` and then `System.Text.Json` serialization to reach MCP-compatible JSON.
+
+### CLIXML advantages (real but insufficient)
+
+| Advantage | Severity | Assessment |
+|-----------|----------|------------|
+| Round-trip type fidelity (DateTime Kind, TimeSpan, enums) | Medium | Lost at the JSON output boundary. MCP clients receive JSON strings regardless of internal transport format. |
+| ErrorRecord preservation (full exception chain, InvocationInfo) | Medium | Already solved differently: the spec uses a separate `error` response field for PowerShell errors, not serialized ErrorRecord objects in the result set. |
+| PSTypeName metadata | Low | The in-process path already strips this via `PowerShellObjectSerializer`. MCP tool schemas, not runtime type names, drive client behavior. |
+| SecureString/PSCredential handling | Low | These should never transit the subprocess boundary — security-sensitive types should be handled in-process or via environment variables. |
+| Battle-tested by PS Remoting | Neutral | PS Remoting sends CLIXML between two PowerShell endpoints. Our architecture is PowerShell→C#→JSON — different shape. |
+
+### CLIXML disadvantages (concrete)
+
+| Disadvantage | Impact |
+|-------------|--------|
+| **Triple conversion pipeline:** CLIXML serialize (pwsh) → CLIXML deserialize to PSObject (server) → FlattenPSObject → JSON serialize (server). Current path: JSON serialize (pwsh) → pass-through or parse (server). | Significant complexity and CPU overhead. |
+| **Wire size inflation:** CLIXML/XML is 5-10x larger than compressed JSON for equivalent data. The spec already flags large result serialization as Risk #4. CLIXML makes this worse. | Direct performance regression for large result sets. |
+| **Parsing cost:** XML parsing is heavier than JSON parsing. `PSSerializer.Deserialize()` reconstructs full PSObject graphs with type metadata — work we then discard. | Unnecessary CPU/memory for throwaway fidelity. |
+| **ConvertTo-Json is the simpler, tested path:** `ConvertTo-Json -Depth 4 -Compress` produces output close to what MCP needs. Minimal transformation required on the server side. | Current approach is already nearly optimal. |
+| **Subprocess simplicity:** `oop-host.ps1` stays lean with `ConvertTo-Json`. Adding `Export-Clixml` requires temp files or `[PSSerializer]::Serialize()` (string API) and careful stream handling. | Adding CLIXML complicates the host script for no user-visible benefit. |
+
+### Hybrid approach evaluation
+
+A hybrid (JSON for commands, CLIXML for results) was considered. The command direction (server→pwsh) is simple JSON — no type fidelity needed. The result direction (pwsh→server) is where CLIXML would theoretically help. But:
+
+- The server must still produce JSON for MCP clients, so CLIXML→PSObject→JSON adds steps
+- The existing `PowerShellObjectSerializer` normalizes PSObjects to JSON-safe shapes — this pipeline already exists and works
+- Net effect: CLIXML adds serialization + deserialization + normalization, replacing a direct JSON-to-JSON path
+
+### Where CLIXML genuinely helps (and what to do instead)
+
+The real types that `ConvertTo-Json` handles poorly: deeply nested objects, circular references, types without public properties. The spec already mitigates these:
+
+- **Depth:** `-Depth 4` matches the in-process `MaxDepth = 4` in `PowerShellObjectSerializer`
+- **Circular refs:** `ConvertTo-Json` handles this with depth limits; the host script can add `-WarningAction SilentlyContinue`
+- **Large result sets:** `_MaxResults` framework parameter and `Select-Object` injection (from the performance spec) cap output before serialization
+
+If specific types prove problematic during implementation, the `oop-host.ps1` script can add targeted handling (e.g., custom serialization for ErrorRecord) without switching the entire transport to CLIXML.
+
+## Recommendation
+
+1. **Keep ndjson/JSON as specified.** The current `ConvertTo-Json -Depth 4 -Compress` approach matches the MCP output format, minimizes conversion steps, and keeps the subprocess host script simple.
+
+2. **Do not add CLIXML support in OOP v1.** The complexity-to-benefit ratio is unfavorable when the pipeline ends at JSON regardless.
+
+3. **If type fidelity becomes a real problem during implementation** (not theoretical), address it surgically in `oop-host.ps1` with per-type handlers rather than switching transport format.
+
+4. **Document this decision** so the team doesn't revisit it without new evidence.
+
+## Impact
+
+No changes to `specs/out-of-process-execution.md`. The existing ndjson protocol remains the correct approach.
 

--- a/PoshMcp.Server/Authentication/AuthenticationConfiguration.cs
+++ b/PoshMcp.Server/Authentication/AuthenticationConfiguration.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+
+namespace PoshMcp.Server.Authentication;
+
+public class AuthenticationConfiguration
+{
+    public bool Enabled { get; set; } = false;
+    public string DefaultScheme { get; set; } = "Bearer";
+    public AuthorizationPolicyConfiguration DefaultPolicy { get; set; } = new();
+    public Dictionary<string, AuthSchemeConfiguration> Schemes { get; set; } = new();
+    public ProtectedResourceConfiguration? ProtectedResource { get; set; }
+    public CorsConfiguration? Cors { get; set; }
+}
+
+public class AuthorizationPolicyConfiguration
+{
+    public bool RequireAuthentication { get; set; } = true;
+    public List<string> RequiredScopes { get; set; } = new();
+    public List<string> RequiredRoles { get; set; } = new();
+}
+
+public class AuthSchemeConfiguration
+{
+    public string Type { get; set; } = "JwtBearer"; // "JwtBearer" | "ApiKey"
+    // JWT Bearer fields
+    public string? Authority { get; set; }
+    public string? Audience { get; set; }
+    public List<string> ValidIssuers { get; set; } = new();
+    public bool RequireHttpsMetadata { get; set; } = true;
+    public ClaimsMappingConfiguration ClaimsMapping { get; set; } = new();
+    // API Key fields
+    public string HeaderName { get; set; } = "X-API-Key";
+    public Dictionary<string, ApiKeyDefinition> Keys { get; set; } = new();
+}
+
+public class ClaimsMappingConfiguration
+{
+    public string ScopeClaim { get; set; } = "scp";
+    public string RoleClaim { get; set; } = "roles";
+}
+
+public class ApiKeyDefinition
+{
+    public List<string> Scopes { get; set; } = new();
+    public List<string> Roles { get; set; } = new();
+}
+
+public class ProtectedResourceConfiguration
+{
+    public string? Resource { get; set; }
+    public string? ResourceName { get; set; }
+    public List<string> AuthorizationServers { get; set; } = new();
+    public List<string> ScopesSupported { get; set; } = new();
+    public List<string> BearerMethodsSupported { get; set; } = new() { "header" };
+}
+
+public class CorsConfiguration
+{
+    public List<string> AllowedOrigins { get; set; } = new();
+    public bool AllowCredentials { get; set; } = false;
+}

--- a/PoshMcp.Server/Authentication/AuthenticationConfigurationValidator.cs
+++ b/PoshMcp.Server/Authentication/AuthenticationConfigurationValidator.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
+
+namespace PoshMcp.Server.Authentication;
+
+public class AuthenticationConfigurationValidator : IValidateOptions<AuthenticationConfiguration>
+{
+    public ValidateOptionsResult Validate(string? name, AuthenticationConfiguration options)
+    {
+        if (!options.Enabled) return ValidateOptionsResult.Success;
+
+        var errors = new List<string>();
+
+        if (options.Schemes.Count == 0)
+            errors.Add("Authentication.Enabled is true but no schemes are configured.");
+
+        foreach (var (schemeName, scheme) in options.Schemes)
+        {
+            if (scheme.Type == "JwtBearer" && string.IsNullOrEmpty(scheme.Authority))
+                errors.Add($"Authentication.Schemes[{schemeName}].Authority is required for JwtBearer.");
+
+            if (scheme.Type == "ApiKey" && scheme.Keys.Count == 0)
+                errors.Add($"Authentication.Schemes[{schemeName}].Keys must have at least one key.");
+        }
+
+        if (options.ProtectedResource?.Resource is not null)
+        {
+            if (!Uri.TryCreate(options.ProtectedResource.Resource, UriKind.Absolute, out _))
+                errors.Add("Authentication.ProtectedResource.Resource must be a valid absolute URI.");
+        }
+
+        return errors.Count > 0
+            ? ValidateOptionsResult.Fail(errors)
+            : ValidateOptionsResult.Success;
+    }
+}

--- a/PoshMcp.Server/PoshMcp.csproj
+++ b/PoshMcp.Server/PoshMcp.csproj
@@ -9,7 +9,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>poshmcp</ToolCommandName>
     <PackageId>poshmcp</PackageId>
-    <Version>0.5.0</Version>
+    <Version>0.5.1</Version>
     <Authors>Steven Murawski</Authors>
     <Description>A Model Context Protocol (MCP) server that exposes PowerShell commands and modules as AI-consumable tools.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/PoshMcp.Server/PowerShell/PerformanceConfiguration.cs
+++ b/PoshMcp.Server/PowerShell/PerformanceConfiguration.cs
@@ -46,4 +46,20 @@ public class FunctionOverride
     /// Null means fall through to the global setting.
     /// </summary>
     public bool? UseDefaultDisplayProperties { get; set; }
+
+    /// <summary>
+    /// Scopes required to invoke this function. Overrides the default policy when set.
+    /// </summary>
+    public List<string>? RequiredScopes { get; set; }
+
+    /// <summary>
+    /// Roles required to invoke this function. Overrides the default policy when set.
+    /// </summary>
+    public List<string>? RequiredRoles { get; set; }
+
+    /// <summary>
+    /// When true, this function can be invoked without authentication even if the global
+    /// policy requires it.
+    /// </summary>
+    public bool? AllowAnonymous { get; set; }
 }

--- a/PoshMcp.Server/Program.cs
+++ b/PoshMcp.Server/Program.cs
@@ -2086,6 +2086,14 @@ public class Program
         builder.Services.Configure<PowerShellConfiguration>(
             builder.Configuration.GetSection("PowerShellConfiguration"));
 
+        builder.Services
+            .AddOptions<PoshMcp.Server.Authentication.AuthenticationConfiguration>()
+            .BindConfiguration("Authentication")
+            .ValidateOnStart();
+
+        builder.Services.AddSingleton<Microsoft.Extensions.Options.IValidateOptions<PoshMcp.Server.Authentication.AuthenticationConfiguration>,
+            PoshMcp.Server.Authentication.AuthenticationConfigurationValidator>();
+
         ConfigureJsonSerializerOptions(builder);
         ConfigureCorsForMcp(builder);
         RegisterHealthChecks(builder);
@@ -2268,6 +2276,15 @@ public class Program
         builder.Configuration.AddJsonFile(finalConfigPath, optional: false, reloadOnChange: true);
         builder.Services.Configure<PowerShellConfiguration>(
             builder.Configuration.GetSection("PowerShellConfiguration"));
+
+        builder.Services
+            .AddOptions<PoshMcp.Server.Authentication.AuthenticationConfiguration>()
+            .BindConfiguration("Authentication")
+            .ValidateOnStart();
+
+        builder.Services.AddSingleton<Microsoft.Extensions.Options.IValidateOptions<PoshMcp.Server.Authentication.AuthenticationConfiguration>,
+            PoshMcp.Server.Authentication.AuthenticationConfigurationValidator>();
+
         return finalConfigPath;
     }
 

--- a/PoshMcp.Server/appsettings.json
+++ b/PoshMcp.Server/appsettings.json
@@ -19,5 +19,15 @@
       "EnableResultCaching": false,
       "UseDefaultDisplayProperties": true
     }
+  },
+  "Authentication": {
+    "Enabled": false,
+    "DefaultScheme": "Bearer",
+    "DefaultPolicy": {
+      "RequireAuthentication": true,
+      "RequiredScopes": [],
+      "RequiredRoles": []
+    },
+    "Schemes": {}
   }
 }


### PR DESCRIPTION
## Summary

Implements Phase 1 of MCP authentication support: configuration model and validation.

### Changes

- **PoshMcp.Server/Authentication/AuthenticationConfiguration.cs** — New POCO classes that bind to the Authentication section of ppsettings.json:
  - AuthenticationConfiguration (top-level, Enabled: false by default)
  - AuthorizationPolicyConfiguration
  - AuthSchemeConfiguration (JwtBearer and ApiKey types)
  - ClaimsMappingConfiguration
  - ApiKeyDefinition
  - ProtectedResourceConfiguration
  - CorsConfiguration

- **PoshMcp.Server/Authentication/AuthenticationConfigurationValidator.cs** — IValidateOptions<AuthenticationConfiguration> that validates schemes are present when enabled, JwtBearer has Authority, ApiKey has at least one key, and ProtectedResource.Resource is a valid absolute URI.

- **PoshMcp.Server/PowerShell/PerformanceConfiguration.cs** — Extended FunctionOverride with RequiredScopes, RequiredRoles, and AllowAnonymous for per-function auth overrides.

- **PoshMcp.Server/appsettings.json** — Added Authentication section with Enabled: false (zero behavior change).

- **PoshMcp.Server/Program.cs** — Registered AuthenticationConfiguration options with BindConfiguration + ValidateOnStart, and AuthenticationConfigurationValidator as singleton in both HTTP and stdio startup paths.

### Testing
- Build: clean (0 errors)
- Tests: 323 passed; 5 pre-existing failures in OutOfProcess and ModuleDiscovery integration tests (confirmed same failures on main)

Closes #69