### PR TITLE
feat: MCP per-tool authorization filters (Phase 3)

### DIFF
--- a/PoshMcp.Server/Authentication/AuthorizationHelpers.cs
+++ b/PoshMcp.Server/Authentication/AuthorizationHelpers.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using PoshMcp.Server.PowerShell;
+
+namespace PoshMcp.Server.Authentication;
+
+public static class AuthorizationHelpers
+{
+    public static bool HasRequiredScopes(ClaimsPrincipal? user, List<string> requiredScopes, string scopeClaim)
+    {
+        if (requiredScopes.Count == 0) return true;
+        if (user == null) return false;
+        var userScopes = user.FindAll(scopeClaim).Select(c => c.Value).ToHashSet();
+        return requiredScopes.All(s => userScopes.Contains(s));
+    }
+
+    public static bool HasRequiredRoles(ClaimsPrincipal? user, List<string> requiredRoles)
+    {
+        if (requiredRoles.Count == 0) return true;
+        if (user == null) return false;
+        return requiredRoles.All(r => user.IsInRole(r));
+    }
+
+    public static FunctionOverride? GetToolOverride(string toolName, PowerShellConfiguration psConfig)
+    {
+        if (psConfig.FunctionOverrides.TryGetValue(toolName, out var exact)) return exact;
+        var normalized = toolName.Replace('_', '-');
+        if (psConfig.FunctionOverrides.TryGetValue(normalized, out var norm)) return norm;
+        return null;
+    }
+
+    public static string GetScopeClaim(AuthenticationConfiguration authConfig)
+    {
+        return authConfig.Schemes.TryGetValue(authConfig.DefaultScheme, out var scheme)
+            ? scheme.ClaimsMapping?.ScopeClaim ?? "scp"
+            : "scp";
+    }
+}

--- a/PoshMcp.Server/Authentication/ToolAuthorizationFilter.cs
+++ b/PoshMcp.Server/Authentication/ToolAuthorizationFilter.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using PoshMcp.Server.PowerShell;
+
+namespace PoshMcp.Server.Authentication;
+
+/// <summary>
+/// MCP request filter that enforces per-tool authorization policies for tools/call requests.
+/// When authentication is disabled, the filter is a no-op.
+/// </summary>
+public class ToolAuthorizationFilter(
+    AuthenticationConfiguration authConfig,
+    PowerShellConfiguration psConfig,
+    IHttpContextAccessor httpContextAccessor,
+    ILogger<ToolAuthorizationFilter> logger)
+{
+    private readonly string _scopeClaim = AuthorizationHelpers.GetScopeClaim(authConfig);
+
+    /// <summary>
+    /// Returns a <see cref="McpRequestFilter{TParams,TResult}"/> that enforces authorization
+    /// before forwarding the request to the next handler.
+    /// </summary>
+    public McpRequestFilter<CallToolRequestParams, CallToolResult> AsFilter() =>
+        (next) => async (context, ct) => await InvokeAsync(context, ct, next);
+
+    private async Task<CallToolResult> InvokeAsync(
+        RequestContext<CallToolRequestParams> context,
+        CancellationToken ct,
+        McpRequestHandler<CallToolRequestParams, CallToolResult> next)
+    {
+        if (!authConfig.Enabled)
+            return await next(context, ct);
+
+        var toolName = context.Params?.Name ?? string.Empty;
+        var toolOverride = AuthorizationHelpers.GetToolOverride(toolName, psConfig);
+
+        if (toolOverride?.AllowAnonymous == true)
+        {
+            logger.LogDebug("Tool '{ToolName}' allows anonymous access — bypassing authorization", toolName);
+            return await next(context, ct);
+        }
+
+        var user = context.User ?? httpContextAccessor.HttpContext?.User;
+
+        if (authConfig.DefaultPolicy.RequireAuthentication && user?.Identity?.IsAuthenticated != true)
+        {
+            logger.LogWarning("Unauthenticated request to tool '{ToolName}' denied", toolName);
+            return ErrorResult($"Authentication required to call tool '{toolName}'");
+        }
+
+        var requiredScopes = toolOverride?.RequiredScopes ?? authConfig.DefaultPolicy.RequiredScopes;
+        var requiredRoles = toolOverride?.RequiredRoles ?? authConfig.DefaultPolicy.RequiredRoles;
+
+        if (!AuthorizationHelpers.HasRequiredScopes(user, requiredScopes, _scopeClaim) ||
+            !AuthorizationHelpers.HasRequiredRoles(user, requiredRoles))
+        {
+            logger.LogWarning("Insufficient permissions for user calling tool '{ToolName}'", toolName);
+            return ErrorResult($"Insufficient permissions to call tool '{toolName}'");
+        }
+
+        logger.LogDebug("Authorization passed for tool '{ToolName}'", toolName);
+        return await next(context, ct);
+    }
+
+    private static CallToolResult ErrorResult(string message) => new()
+    {
+        IsError = true,
+        Content = [new TextContentBlock { Text = message }]
+    };
+}

--- a/PoshMcp.Server/Authentication/ToolListAuthorizationFilter.cs
+++ b/PoshMcp.Server/Authentication/ToolListAuthorizationFilter.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using PoshMcp.Server.PowerShell;
+
+namespace PoshMcp.Server.Authentication;
+
+/// <summary>
+/// MCP request filter that removes tools from tools/list responses that the caller
+/// is not authorized to invoke. Prevents information leakage about inaccessible tools.
+/// When authentication is disabled, the filter is a no-op.
+/// </summary>
+public class ToolListAuthorizationFilter(
+    AuthenticationConfiguration authConfig,
+    PowerShellConfiguration psConfig,
+    IHttpContextAccessor httpContextAccessor,
+    ILogger<ToolListAuthorizationFilter> logger)
+{
+    private readonly string _scopeClaim = AuthorizationHelpers.GetScopeClaim(authConfig);
+
+    /// <summary>
+    /// Returns a <see cref="McpRequestFilter{TParams,TResult}"/> that filters the tools list
+    /// to only include tools the caller is authorized to invoke.
+    /// </summary>
+    public McpRequestFilter<ListToolsRequestParams, ListToolsResult> AsFilter() =>
+        (next) => async (context, ct) => await InvokeAsync(context, ct, next);
+
+    private async Task<ListToolsResult> InvokeAsync(
+        RequestContext<ListToolsRequestParams> context,
+        CancellationToken ct,
+        McpRequestHandler<ListToolsRequestParams, ListToolsResult> next)
+    {
+        var result = await next(context, ct);
+
+        if (!authConfig.Enabled)
+            return result;
+
+        if (result.Tools == null || result.Tools.Count == 0)
+            return result;
+
+        var user = context.User ?? httpContextAccessor.HttpContext?.User;
+        var filtered = result.Tools.Where(tool => CanAccessTool(tool.Name, user)).ToList();
+        result.Tools = filtered;
+        return result;
+    }
+
+    private bool CanAccessTool(string toolName, ClaimsPrincipal? user)
+    {
+        var toolOverride = AuthorizationHelpers.GetToolOverride(toolName, psConfig);
+
+        if (toolOverride?.AllowAnonymous == true)
+            return true;
+
+        if (authConfig.DefaultPolicy.RequireAuthentication && user?.Identity?.IsAuthenticated != true)
+        {
+            logger.LogDebug("Tool '{ToolName}' excluded from list: unauthenticated user", toolName);
+            return false;
+        }
+
+        var requiredScopes = toolOverride?.RequiredScopes ?? authConfig.DefaultPolicy.RequiredScopes;
+        var requiredRoles = toolOverride?.RequiredRoles ?? authConfig.DefaultPolicy.RequiredRoles;
+
+        var hasAccess = AuthorizationHelpers.HasRequiredScopes(user, requiredScopes, _scopeClaim) &&
+                        AuthorizationHelpers.HasRequiredRoles(user, requiredRoles);
+
+        if (!hasAccess)
+            logger.LogDebug("Tool '{ToolName}' excluded from list: insufficient permissions", toolName);
+
+        return hasAccess;
+    }
+}

--- a/PoshMcp.Server/Program.cs
+++ b/PoshMcp.Server/Program.cs
@@ -2117,10 +2117,30 @@ public class Program
         logger.LogInformation("Using configuration file: {ConfigurationPath}", finalConfigPath);
 
         var tools = await SetupHttpMcpToolsAsync(bootstrapLoggerFactory, config, logger, finalConfigPath, sharedSessionRunspace, executorLease?.Executor);
-        builder.Services
+        var authConfigValue = builder.Configuration.GetSection("Authentication").Get<PoshMcp.Server.Authentication.AuthenticationConfiguration>() ?? new();
+        var mcpBuilder = builder.Services
             .AddMcpServer()
             .WithHttpTransport()
             .WithTools(tools);
+
+        if (authConfigValue.Enabled)
+        {
+            var callToolFilter = new PoshMcp.Server.Authentication.ToolAuthorizationFilter(
+                authConfigValue,
+                config,
+                sharedHttpContextAccessor,
+                bootstrapLoggerFactory.CreateLogger<PoshMcp.Server.Authentication.ToolAuthorizationFilter>());
+            var listToolFilter = new PoshMcp.Server.Authentication.ToolListAuthorizationFilter(
+                authConfigValue,
+                config,
+                sharedHttpContextAccessor,
+                bootstrapLoggerFactory.CreateLogger<PoshMcp.Server.Authentication.ToolListAuthorizationFilter>());
+            mcpBuilder.WithRequestFilters(fb =>
+            {
+                fb.AddCallToolFilter(callToolFilter.AsFilter());
+                fb.AddListToolsFilter(listToolFilter.AsFilter());
+            });
+        }
 
         RegisterCleanupServices(builder);
 


### PR DESCRIPTION
Implements CallTool and ListTools authorization filters. Depends on #80. Closes #71.