### PR TITLE
feat: CORS tightening + RFC 9728 protected resource metadata (Phase 4+5)

### DIFF
--- a/PoshMcp.Server/Authentication/ApiKeyAuthenticationHandler.cs
+++ b/PoshMcp.Server/Authentication/ApiKeyAuthenticationHandler.cs
@@ -4,6 +4,8 @@ using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -50,4 +52,27 @@ public class ApiKeyAuthenticationHandler(
 
         return Task.FromResult(AuthenticateResult.Success(ticket));
     }
+
+    protected override async Task HandleChallengeAsync(AuthenticationProperties properties)
+    {
+        Response.StatusCode = 401;
+
+        // Add WWW-Authenticate header pointing to resource metadata if configured
+        var authConfig = Context.RequestServices
+            .GetRequiredService<IOptions<AuthenticationConfiguration>>();
+
+        if (authConfig.Value.ProtectedResource?.Resource is not null)
+        {
+            var metadataUrl = $"{authConfig.Value.ProtectedResource.Resource}/.well-known/oauth-protected-resource";
+            Response.Headers["WWW-Authenticate"] =
+                $"Bearer resource_metadata=\"{metadataUrl}\"";
+        }
+        else
+        {
+            Response.Headers["WWW-Authenticate"] = "ApiKey";
+        }
+
+        await base.HandleChallengeAsync(properties);
+    }
 }
+

--- a/PoshMcp.Server/Authentication/ProtectedResourceMetadataEndpoint.cs
+++ b/PoshMcp.Server/Authentication/ProtectedResourceMetadataEndpoint.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace PoshMcp.Server.Authentication;
+
+public static class ProtectedResourceMetadataEndpoint
+{
+    public static IEndpointRouteBuilder MapProtectedResourceMetadata(
+        this IEndpointRouteBuilder app,
+        AuthenticationConfiguration config)
+    {
+        if (!config.Enabled || config.ProtectedResource is null)
+            return app;
+
+        app.MapGet("/.well-known/oauth-protected-resource", () =>
+        {
+            var metadata = new
+            {
+                resource = config.ProtectedResource.Resource,
+                resource_name = config.ProtectedResource.ResourceName,
+                authorization_servers = config.ProtectedResource.AuthorizationServers,
+                scopes_supported = config.ProtectedResource.ScopesSupported,
+                bearer_methods_supported = config.ProtectedResource.BearerMethodsSupported
+                    .Count > 0 ? config.ProtectedResource.BearerMethodsSupported : new List<string> { "header" }
+            };
+            return Results.Ok(metadata);
+        }).AllowAnonymous(); // Metadata endpoint is always public per RFC 9728
+
+        return app;
+    }
+}

--- a/PoshMcp.Server/Program.cs
+++ b/PoshMcp.Server/Program.cs
@@ -2191,19 +2191,43 @@ public class Program
             mcpEndpoint.RequireAuthorization("McpAccess");
         }
 
+        // RFC 9728 Protected Resource Metadata
+        var authConfigForEndpoints = app.Services
+            .GetRequiredService<IOptions<AuthenticationConfiguration>>();
+        app.MapProtectedResourceMetadata(authConfigForEndpoints.Value);
+
         await app.RunAsync();
     }
 
     private static void ConfigureCorsForMcp(WebApplicationBuilder builder)
     {
+        var authConfig = builder.Configuration.GetSection("Authentication").Get<AuthenticationConfiguration>()
+            ?? new AuthenticationConfiguration();
+
         builder.Services.AddCors(options =>
         {
             options.AddDefaultPolicy(policy =>
             {
-                policy.AllowAnyOrigin()
-                    .AllowAnyMethod()
-                    .AllowAnyHeader()
-                    .WithExposedHeaders("Mcp-Session-Id");
+                if (authConfig.Enabled && authConfig.Cors?.AllowedOrigins.Count > 0)
+                {
+                    policy.WithOrigins(authConfig.Cors.AllowedOrigins.ToArray());
+                    if (authConfig.Cors.AllowCredentials)
+                        policy.AllowCredentials();
+                    else
+                        policy.DisallowCredentials();
+                }
+                else if (authConfig.Enabled)
+                {
+                    // Auth enabled but no origins configured — same-origin only (no wildcard)
+                    // ASP.NET Core doesn't support "same-origin only" via CORS policy directly,
+                    // so we just don't add AllowAnyOrigin — this effectively blocks cross-origin
+                }
+                else
+                {
+                    // Auth disabled — keep wide-open for dev/stdio use
+                    policy.AllowAnyOrigin();
+                }
+                policy.AllowAnyMethod().AllowAnyHeader().WithExposedHeaders("Mcp-Session-Id");
             });
         });
     }


### PR DESCRIPTION
Tightens CORS when auth enabled, adds /.well-known/oauth-protected-resource endpoint per RFC 9728, adds WWW-Authenticate header on 401. Depends on #81. Closes #72. Closes #73.