### PR TITLE
feat: auth metrics, logging, and health check integration (Phase 6)

### DIFF
--- a/PoshMcp.Server/Authentication/ApiKeyAuthenticationHandler.cs
+++ b/PoshMcp.Server/Authentication/ApiKeyAuthenticationHandler.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
@@ -8,13 +9,15 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using PoshMcp.Server.Metrics;
 
 namespace PoshMcp.Server.Authentication;
 
 public class ApiKeyAuthenticationHandler(
     IOptionsMonitor<ApiKeyAuthenticationOptions> options,
     ILoggerFactory logger,
-    UrlEncoder encoder)
+    UrlEncoder encoder,
+    McpMetrics metrics)
     : AuthenticationHandler<ApiKeyAuthenticationOptions>(options, logger, encoder)
 {
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
@@ -28,9 +31,23 @@ public class ApiKeyAuthenticationHandler(
 
         if (!Options.Keys.TryGetValue(apiKey, out var keyDef))
         {
-            Logger.LogWarning("Invalid API key presented");
+            Logger.LogWarning("Invalid API key presented from {RemoteIp}", Context.Connection.RemoteIpAddress);
+            metrics.AuthAttempts.Add(1,
+                new KeyValuePair<string, object?>("scheme", "ApiKey"),
+                new KeyValuePair<string, object?>("result", "failure"));
             return Task.FromResult(AuthenticateResult.Fail("Invalid API key"));
         }
+
+        var keyName = Options.Keys
+            .FirstOrDefault(k => k.Key == apiKey).Key ?? "unknown";
+        var maskedKeyName = keyName.Length > 4
+            ? keyName[..4] + "****"
+            : "****";
+
+        Logger.LogDebug("API key authentication succeeded for {KeyName}", maskedKeyName);
+        metrics.AuthAttempts.Add(1,
+            new KeyValuePair<string, object?>("scheme", "ApiKey"),
+            new KeyValuePair<string, object?>("result", "success"));
 
         var claims = new List<Claim>
         {

--- a/PoshMcp.Server/Authentication/ToolAuthorizationFilter.cs
+++ b/PoshMcp.Server/Authentication/ToolAuthorizationFilter.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
+using PoshMcp.Server.Metrics;
 using PoshMcp.Server.PowerShell;
 
 namespace PoshMcp.Server.Authentication;
@@ -18,6 +19,7 @@ public class ToolAuthorizationFilter(
     AuthenticationConfiguration authConfig,
     PowerShellConfiguration psConfig,
     IHttpContextAccessor httpContextAccessor,
+    McpMetrics metrics,
     ILogger<ToolAuthorizationFilter> logger)
 {
     private readonly string _scopeClaim = AuthorizationHelpers.GetScopeClaim(authConfig);
@@ -42,7 +44,7 @@ public class ToolAuthorizationFilter(
 
         if (toolOverride?.AllowAnonymous == true)
         {
-            logger.LogDebug("Tool '{ToolName}' allows anonymous access — bypassing authorization", toolName);
+            logger.LogDebug("Auth skipped for tool {ToolName} (AllowAnonymous)", toolName);
             return await next(context, ct);
         }
 
@@ -50,21 +52,35 @@ public class ToolAuthorizationFilter(
 
         if (authConfig.DefaultPolicy.RequireAuthentication && user?.Identity?.IsAuthenticated != true)
         {
-            logger.LogWarning("Unauthenticated request to tool '{ToolName}' denied", toolName);
+            logger.LogWarning("Authorization denied for tool {ToolName}: {Reason}", toolName, "unauthenticated");
+            metrics.AuthToolDenials.Add(1,
+                new KeyValuePair<string, object?>("tool_name", toolName),
+                new KeyValuePair<string, object?>("reason", "unauthenticated"));
             return ErrorResult($"Authentication required to call tool '{toolName}'");
         }
 
         var requiredScopes = toolOverride?.RequiredScopes ?? authConfig.DefaultPolicy.RequiredScopes;
         var requiredRoles = toolOverride?.RequiredRoles ?? authConfig.DefaultPolicy.RequiredRoles;
 
-        if (!AuthorizationHelpers.HasRequiredScopes(user, requiredScopes, _scopeClaim) ||
-            !AuthorizationHelpers.HasRequiredRoles(user, requiredRoles))
+        if (!AuthorizationHelpers.HasRequiredScopes(user, requiredScopes, _scopeClaim))
         {
-            logger.LogWarning("Insufficient permissions for user calling tool '{ToolName}'", toolName);
+            logger.LogWarning("Authorization denied for tool {ToolName}: {Reason}", toolName, "insufficient_scope");
+            metrics.AuthToolDenials.Add(1,
+                new KeyValuePair<string, object?>("tool_name", toolName),
+                new KeyValuePair<string, object?>("reason", "insufficient_scope"));
             return ErrorResult($"Insufficient permissions to call tool '{toolName}'");
         }
 
-        logger.LogDebug("Authorization passed for tool '{ToolName}'", toolName);
+        if (!AuthorizationHelpers.HasRequiredRoles(user, requiredRoles))
+        {
+            logger.LogWarning("Authorization denied for tool {ToolName}: {Reason}", toolName, "insufficient_role");
+            metrics.AuthToolDenials.Add(1,
+                new KeyValuePair<string, object?>("tool_name", toolName),
+                new KeyValuePair<string, object?>("reason", "insufficient_role"));
+            return ErrorResult($"Insufficient permissions to call tool '{toolName}'");
+        }
+
+        logger.LogDebug("Authorization granted for tool {ToolName}", toolName);
         return await next(context, ct);
     }
 

--- a/PoshMcp.Server/Health/ConfigurationHealthCheck.cs
+++ b/PoshMcp.Server/Health/ConfigurationHealthCheck.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using PoshMcp.Server.Authentication;
 using PoshMcp.Server.PowerShell;
 
 namespace PoshMcp.Server.Health;
@@ -15,13 +16,16 @@ namespace PoshMcp.Server.Health;
 public class ConfigurationHealthCheck : IHealthCheck
 {
     private readonly IOptions<PowerShellConfiguration> _configuration;
+    private readonly IOptions<AuthenticationConfiguration> _authConfiguration;
     private readonly ILogger<ConfigurationHealthCheck> _logger;
 
     public ConfigurationHealthCheck(
         IOptions<PowerShellConfiguration> configuration,
+        IOptions<AuthenticationConfiguration> authConfiguration,
         ILogger<ConfigurationHealthCheck> logger)
     {
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _authConfiguration = authConfiguration ?? throw new ArgumentNullException(nameof(authConfiguration));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -58,6 +62,14 @@ public class ConfigurationHealthCheck : IHealthCheck
                 ["IncludePatternCount"] = config.IncludePatterns?.Count ?? 0,
                 ["ExcludePatternCount"] = config.ExcludePatterns?.Count ?? 0
             };
+
+            var authConfig = _authConfiguration.Value;
+            data["AuthEnabled"] = authConfig?.Enabled ?? false;
+            data["AuthSchemes"] = authConfig?.Enabled == true && authConfig.Schemes.Count > 0
+                ? string.Join(", ", authConfig.Schemes.Keys)
+                : "none";
+            data["ToolsWithAuthOverrides"] = config.FunctionOverrides.Values
+                .Count(o => (o.RequiredScopes?.Count > 0) || (o.RequiredRoles?.Count > 0));
 
             _logger.LogDebug("Configuration health check passed");
             return Task.FromResult(HealthCheckResult.Healthy("Configuration is valid", data));

--- a/PoshMcp.Server/Metrics/McpMetrics.cs
+++ b/PoshMcp.Server/Metrics/McpMetrics.cs
@@ -28,6 +28,10 @@ public class McpMetrics
     public Counter<long> ToolUsageTotal { get; }
     public Counter<long> ToolUsageByAgentTotal { get; }
 
+    // Authentication Metrics
+    public Counter<long> AuthAttempts { get; }
+    public Counter<long> AuthToolDenials { get; }
+
     // Tool Registration & Lifecycle
     public Counter<long> ToolRegistrationTotal { get; }
     public Counter<long> ToolUpdateTotal { get; }
@@ -80,6 +84,15 @@ public class McpMetrics
         ToolUsageByAgentTotal = _meter.CreateCounter<long>(
             "mcp_tool_usage_by_agent_total",
             description: "Count of invocations by AI agent vs. human user");
+
+        // Authentication Metrics
+        AuthAttempts = _meter.CreateCounter<long>(
+            "poshmcp.auth.attempts",
+            description: "Number of authentication attempts");
+
+        AuthToolDenials = _meter.CreateCounter<long>(
+            "poshmcp.auth.tool_denials",
+            description: "Number of tool invocation denials due to authorization failure");
 
         // Tool Registration & Lifecycle
         ToolRegistrationTotal = _meter.CreateCounter<long>(

--- a/PoshMcp.Server/Program.cs
+++ b/PoshMcp.Server/Program.cs
@@ -2123,25 +2123,30 @@ public class Program
             .WithHttpTransport()
             .WithTools(tools);
 
+        ToolAuthorizationFilter? callToolFilter = null;
+        ToolListAuthorizationFilter? listToolFilter = null;
+
         if (authConfigValue.Enabled)
         {
-            var sharedMetrics = new McpMetrics();
-            builder.Services.AddSingleton(sharedMetrics);
-            var callToolFilter = new PoshMcp.Server.Authentication.ToolAuthorizationFilter(
-                authConfigValue,
-                config,
-                sharedHttpContextAccessor,
-                sharedMetrics,
-                bootstrapLoggerFactory.CreateLogger<PoshMcp.Server.Authentication.ToolAuthorizationFilter>());
-            var listToolFilter = new PoshMcp.Server.Authentication.ToolListAuthorizationFilter(
-                authConfigValue,
-                config,
-                sharedHttpContextAccessor,
-                bootstrapLoggerFactory.CreateLogger<PoshMcp.Server.Authentication.ToolListAuthorizationFilter>());
+            builder.Services.AddSingleton<ToolAuthorizationFilter>(sp =>
+                new ToolAuthorizationFilter(
+                    authConfigValue,
+                    config,
+                    sp.GetRequiredService<IHttpContextAccessor>(),
+                    sp.GetRequiredService<McpMetrics>(),
+                    sp.GetRequiredService<ILogger<ToolAuthorizationFilter>>()));
+            builder.Services.AddSingleton<ToolListAuthorizationFilter>(sp =>
+                new ToolListAuthorizationFilter(
+                    authConfigValue,
+                    config,
+                    sp.GetRequiredService<IHttpContextAccessor>(),
+                    sp.GetRequiredService<ILogger<ToolListAuthorizationFilter>>()));
             mcpBuilder.WithRequestFilters(fb =>
             {
-                fb.AddCallToolFilter(callToolFilter.AsFilter());
-                fb.AddListToolsFilter(listToolFilter.AsFilter());
+                fb.AddCallToolFilter((next) => async (context, ct) =>
+                    await callToolFilter!.AsFilter()(next)(context, ct));
+                fb.AddListToolsFilter((next) => async (context, ct) =>
+                    await listToolFilter!.AsFilter()(next)(context, ct));
             });
         }
 
@@ -2166,6 +2171,8 @@ public class Program
         var authConfigForMiddleware = app.Services.GetRequiredService<IOptions<AuthenticationConfiguration>>();
         if (authConfigForMiddleware.Value.Enabled)
         {
+            callToolFilter = app.Services.GetRequiredService<ToolAuthorizationFilter>();
+            listToolFilter = app.Services.GetRequiredService<ToolListAuthorizationFilter>();
             app.UseAuthentication();
             app.UseAuthorization();
         }

--- a/PoshMcp.Server/Program.cs
+++ b/PoshMcp.Server/Program.cs
@@ -2125,10 +2125,13 @@ public class Program
 
         if (authConfigValue.Enabled)
         {
+            var sharedMetrics = new McpMetrics();
+            builder.Services.AddSingleton(sharedMetrics);
             var callToolFilter = new PoshMcp.Server.Authentication.ToolAuthorizationFilter(
                 authConfigValue,
                 config,
                 sharedHttpContextAccessor,
+                sharedMetrics,
                 bootstrapLoggerFactory.CreateLogger<PoshMcp.Server.Authentication.ToolAuthorizationFilter>());
             var listToolFilter = new PoshMcp.Server.Authentication.ToolListAuthorizationFilter(
                 authConfigValue,


### PR DESCRIPTION
Adds poshmcp.auth.attempts and poshmcp.auth.tool_denials metrics, improves structured logging in auth handlers and filters, adds auth status to ConfigurationHealthCheck. Depends on #81. Closes #74.