### PR TITLE
fix: handle warning stream content during OOP server startup

### DIFF
--- a/.squad/agents/farnsworth/history.md
+++ b/.squad/agents/farnsworth/history.md
@@ -113,3 +113,9 @@ Current Priorities:
 - #86: Enhancement — add `--use-default-display-properties` global flag (consistency with other Performance bool flags)
 - #87: Tech debt — warn when `--set-auth-enabled true` used with empty `Authentication.Schemes`
 - #88: Tests — add unit tests for all 4 new flags and `settingsChanged` counter in `ProgramCliConfigCommandsTests`
+### 2026-07-15: PR #83 re-review (auth metrics Phase 6)
+
+**Verdict:** APPROVED
+**Issue resolved:** McpMetrics dual-instance bug fixed by Bender. Auth filters now registered as DI singletons with factory lambdas resolving `McpMetrics` via `sp.GetRequiredService<McpMetrics>()`. No manual `new McpMetrics()` construction in auth path. Deferred capture pattern for filter variables (assigned post-`app.Build()`) is safe — lambdas execute only at request time.
+**Non-blocking nit:** Redundant LINQ lookup in `ApiKeyAuthenticationHandler` (`Options.Keys.FirstOrDefault(k => k.Key == apiKey).Key` after `TryGetValue` already succeeded).
+**Build:** 0 errors on branch.

--- a/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessCommandExecutor.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessCommandExecutor.cs
@@ -424,6 +424,15 @@ public class OutOfProcessCommandExecutor : ICommandExecutor
 
                 _logger.LogDebug("OOP stdout: {Line}", line);
 
+                // PowerShell warning/info/verbose/debug streams can leak to stdout from
+                // modules that call Write-Warning (or similar) directly. These lines are
+                // not JSON — skip them gracefully without an alarming log entry.
+                if (IsNonJsonPowerShellStreamLine(line))
+                {
+                    _logger.LogDebug("OOP subprocess non-JSON stream output (suppressed): {Line}", line);
+                    continue;
+                }
+
                 try
                 {
                     using var doc = JsonDocument.Parse(line);
@@ -466,9 +475,11 @@ public class OutOfProcessCommandExecutor : ICommandExecutor
                             "OOP response has neither 'result' nor 'error'."));
                     }
                 }
-                catch (JsonException ex)
+                catch (JsonException)
                 {
-                    _logger.LogWarning(ex, "Failed to parse OOP stdout JSON: {Line}", line);
+                    // Log at Debug — unexpected non-JSON output is not actionable for
+                    // operators and should not flood logs at Warning level.
+                    _logger.LogDebug("OOP stdout: skipping non-JSON line: {Line}", line);
                 }
             }
         }
@@ -511,6 +522,27 @@ public class OutOfProcessCommandExecutor : ICommandExecutor
         }
 
         _logger.LogDebug("OOP stderr read loop exited.");
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="line"/> looks like output from a
+    /// PowerShell informational stream (WARNING:, VERBOSE:, DEBUG:, INFORMATION:) rather than
+    /// a JSON object.  Some modules write directly to these streams — or even to
+    /// <see cref="Console.Out"/> — which can corrupt the ndjson protocol channel.
+    /// </summary>
+    private static bool IsNonJsonPowerShellStreamLine(string line)
+    {
+        // Fast path: JSON must start with '{' or '[' after optional whitespace.
+        var trimmed = line.AsSpan().TrimStart();
+        if (trimmed.IsEmpty) return false;
+        if (trimmed[0] == '{' || trimmed[0] == '[' || trimmed[0] == '"') return false;
+
+        // Known PowerShell stream prefixes emitted by the default console host.
+        return line.StartsWith("WARNING:", StringComparison.OrdinalIgnoreCase)
+            || line.StartsWith("VERBOSE:", StringComparison.OrdinalIgnoreCase)
+            || line.StartsWith("DEBUG:", StringComparison.OrdinalIgnoreCase)
+            || line.StartsWith("INFORMATION:", StringComparison.OrdinalIgnoreCase)
+            || line.StartsWith("ERROR:", StringComparison.OrdinalIgnoreCase);
     }
 
     private void OnProcessExited(object? sender, EventArgs e)

--- a/PoshMcp.Server/PowerShell/OutOfProcess/oop-host.ps1
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/oop-host.ps1
@@ -223,7 +223,8 @@ function Invoke-SetupHandler {
                 $installParams['AllowPrerelease'] = $true
             }
 
-            Install-Module @installParams
+            Install-Module @installParams -WarningAction SilentlyContinue -WarningVariable installWarnings
+            foreach ($w in $installWarnings) { Write-Diag "  Module install warning: $w" }
             $null = $installedModules.Add($modName)
             Write-Diag "  Successfully installed module: $modName"
         }
@@ -247,14 +248,17 @@ function Invoke-SetupHandler {
         Write-Diag "Importing module: $modName"
         try {
             $importParams = @{
-                Name        = $modName
-                ErrorAction = 'Stop'
-                PassThru    = $true
+                Name            = $modName
+                ErrorAction     = 'Stop'
+                PassThru        = $true
+                WarningAction   = 'SilentlyContinue'
+                WarningVariable = 'importWarnings'
             }
             if ($allowClobber) {
                 $importParams['Force'] = $true
             }
             Import-Module @importParams
+            foreach ($w in $importWarnings) { Write-Diag "  Module warning: $w" }
             $null = $importedModules.Add($modName)
             Write-Diag "  Successfully imported module: $modName"
         }
@@ -339,7 +343,8 @@ function Invoke-DiscoverHandler {
     foreach ($moduleName in $modules) {
         try {
             Write-Diag "Importing module: $moduleName"
-            Import-Module -Name $moduleName -ErrorAction Stop
+            Import-Module -Name $moduleName -ErrorAction Stop -WarningAction SilentlyContinue -WarningVariable discoverImportWarnings
+            foreach ($w in $discoverImportWarnings) { Write-Diag "  Module warning: $w" }
             Write-Diag "Imported module: $moduleName"
         }
         catch {


### PR DESCRIPTION
## Summary

Fixes the error that occurs when starting the out-of-process server when there is content on the warning stream.

## Root Cause

PowerShell modules (e.g., Az) emit Write-Warning during Import-Module, which in the OOP subprocess context leaks to stdout and corrupts the ndjson protocol channel. The C# ReadLoopAsync then tries to parse the WARNING: line as JSON, fails, and logs an alarming Warning-level entry with a full JsonReaderException stack trace.

## Changes

### oop-host.ps1 (primary fix)
- Added -WarningAction SilentlyContinue -WarningVariable to all Import-Module and Install-Module calls
- Captured warnings are forwarded to stderr via Write-Diag, preserving observability without polluting stdout

### OutOfProcessCommandExecutor.cs (defensive fix)
- Added IsNonJsonPowerShellStreamLine() helper detecting WARNING:, VERBOSE:, DEBUG:, INFORMATION:, ERROR: prefixes
- Such lines are skipped at Debug level with no exception thrown
- Demoted catch(JsonException) from LogWarning(ex,...) to LogDebug to eliminate alarm fatigue

## Testing

1. Configure PoshMcp to import an Az module that emits tenant-context warnings on import
2. Start the OOP server - previously shows 'Failed to parse OOP stdout JSON: WARNING:...' with stack trace
3. After fix: warnings routed to stderr/diagnostics, server starts cleanly

Fixes #78