### PR TITLE
Warn when --set-auth-enabled true is used with no Authentication.Schemes configured

### DIFF
--- a/PoshMcp.Server/Program.cs
+++ b/PoshMcp.Server/Program.cs
@@ -1653,6 +1653,15 @@ public class Program
             var authentication = GetOrCreateObject(root, "Authentication");
             authentication["Enabled"] = request.SetAuthEnabled.Value;
             boolUpdateApplied++;
+
+            if (request.SetAuthEnabled.Value)
+            {
+                var schemes = authentication["Schemes"]?.AsArray();
+                if (schemes == null || schemes.Count == 0)
+                {
+                    Console.Error.WriteLine("WARNING: Authentication.Enabled set to true but Authentication.Schemes is empty. Run 'poshmcp validate-config' to verify your configuration.");
+                }
+            }
         }
 
         var advancedPromptedFunctionCount = 0;


### PR DESCRIPTION
## Summary

When a user runs \poshmcp update-config --set-auth-enabled true\ without any \Authentication.Schemes\ configured, the server will fail \AuthenticationConfigurationValidator\ at startup — but the user gets no warning at the time of the change.

## Changes

In \UpdateConfigurationFileAsync\, after writing \Authentication.Enabled = true\, added a check: if \Authentication.Schemes\ is null or an empty array, emit a warning to stderr:

\\\
WARNING: Authentication.Enabled set to true but Authentication.Schemes is empty. Run 'poshmcp validate-config' to verify your configuration.
\\\

The check is **advisory only** — the write proceeds unconditionally.

Fixes #87