### PR TITLE
feat: skip unserializable parameter types in MCP tool schema generation

### DIFF
--- a/PoshMcp.Server/PowerShell/PowerShellAssemblyGenerator.cs
+++ b/PoshMcp.Server/PowerShell/PowerShellAssemblyGenerator.cs
@@ -207,16 +207,24 @@ public class PowerShellAssemblyGenerator
                 var commandList = commands.ToList();
                 foreach (var command in commandList)
                 {
+                    var anyParameterSetGenerated = false;
                     foreach (var parameterSet in command.ParameterSets)
                     {
                         try
                         {
-                            GenerateMethodForCommand(typeBuilder, command, loggerField, runspaceField, logger, parameterSet);
+                            var generated = GenerateMethodForCommand(typeBuilder, command, loggerField, runspaceField, logger, parameterSet);
+                            if (generated)
+                                anyParameterSetGenerated = true;
                         }
                         catch (Exception ex)
                         {
                             logger.LogError(ex, $"Failed to generate method for command {command.Name}: {ex.Message}");
                         }
+                    }
+
+                    if (!anyParameterSetGenerated)
+                    {
+                        logger.LogWarning($"Skipping command '{command.Name}' — all parameter sets were skipped due to unserializable mandatory parameter types");
                     }
                 }
 
@@ -340,7 +348,11 @@ public class PowerShellAssemblyGenerator
         il.Emit(OpCodes.Ret);
     }
 
-    private static void GenerateMethodForCommand(TypeBuilder typeBuilder, CommandInfo commandInfo, FieldBuilder loggerField, FieldBuilder runspaceField, ILogger logger, CommandParameterSetInfo parameterSet)
+    /// <returns>
+    /// <c>true</c> if the method was generated; <c>false</c> if the parameter set was skipped
+    /// because one or more mandatory parameters have unserializable types.
+    /// </returns>
+    private static bool GenerateMethodForCommand(TypeBuilder typeBuilder, CommandInfo commandInfo, FieldBuilder loggerField, FieldBuilder runspaceField, ILogger logger, CommandParameterSetInfo parameterSet)
     {
         // Get command parameters for this specific parameter set (excluding common parameters) and order by position
         var parameters = commandInfo.Parameters
@@ -366,6 +378,34 @@ public class PowerShellAssemblyGenerator
             })
             .ThenBy(p => p.Key) // Secondary sort by name for stable ordering
             .ToList();
+
+        // Skip the parameter set if any mandatory parameter has an unserializable type.
+        var mandatoryUnserializable = parameters
+            .Where(p => p.Value.Attributes.OfType<ParameterAttribute>().Any(attr => attr.Mandatory)
+                     && PowerShellParameterUtils.IsUnserializableType(p.Value.ParameterType))
+            .ToList();
+
+        if (mandatoryUnserializable.Count > 0)
+        {
+            logger.LogDebug(
+                $"Skipping parameter set '{parameterSet.Name}' of '{commandInfo.Name}' — mandatory parameters with unserializable types: " +
+                string.Join(", ", mandatoryUnserializable.Select(p => $"{p.Key} ({p.Value.ParameterType.Name})")));
+            return false;
+        }
+
+        // Drop optional parameters whose types cannot be serialized to JSON.
+        var skippedOptional = parameters
+            .Where(p => !p.Value.Attributes.OfType<ParameterAttribute>().Any(attr => attr.Mandatory)
+                     && PowerShellParameterUtils.IsUnserializableType(p.Value.ParameterType))
+            .ToList();
+
+        if (skippedOptional.Count > 0)
+        {
+            logger.LogDebug(
+                $"Dropping optional parameters with unserializable types from '{commandInfo.Name}' ({parameterSet.Name}): " +
+                string.Join(", ", skippedOptional.Select(p => $"{p.Key} ({p.Value.ParameterType.Name})")));
+            parameters = parameters.Except(skippedOptional).ToList();
+        }
 
         // Create method name (sanitized) - append parameter set name unless it's __AllParameterSets
         var methodName = PowerShellAssemblyGenerator.SanitizeMethodName(commandInfo.Name, parameterSet.Name);
@@ -494,6 +534,7 @@ public class PowerShellAssemblyGenerator
 
         // Generate method body
         GenerateMethodBody(methodBuilder, commandInfo, parameters, loggerField, runspaceField);
+        return true;
     }
 
     private static void GenerateMethodBody(MethodBuilder methodBuilder, CommandInfo commandInfo, List<KeyValuePair<string, ParameterMetadata>> parameters, FieldBuilder loggerField, FieldBuilder runspaceField)

--- a/PoshMcp.Server/PowerShell/PowerShellParameterUtils.cs
+++ b/PoshMcp.Server/PowerShell/PowerShellParameterUtils.cs
@@ -170,6 +170,71 @@ public static class PowerShellParameterUtils
     }
 
     /// <summary>
+    /// Returns true when a PowerShell parameter type cannot be meaningfully represented as a JSON
+    /// schema value and therefore should not be exposed as an MCP tool parameter.
+    ///
+    /// Unserializable categories:
+    ///   - Pointer / by-ref types (IntPtr, UIntPtr, T*)
+    ///   - PSObject — opaque wrapper with no fixed schema
+    ///   - ScriptBlock — executable code, not data
+    ///   - System.Object — too generic to produce a useful schema
+    ///   - Delegate-derived types — callbacks / function references
+    ///   - Stream-derived types — binary data channels
+    ///   - WaitHandle-derived types — OS synchronisation primitives
+    ///   - System.Reflection.Assembly — reflection handle
+    ///   - System.Management.Automation.PowerShell — runspace instance
+    ///   - Any type in the Runspaces namespace (Runspace, RunspacePool, …)
+    ///   - Arrays whose element type is unserializable
+    /// </summary>
+    public static bool IsUnserializableType(Type type)
+    {
+        var t = Nullable.GetUnderlyingType(type) ?? type;
+
+        if (t.IsPointer || t.IsByRef)
+            return true;
+
+        if (t == typeof(IntPtr) || t == typeof(UIntPtr))
+            return true;
+
+        if (t == typeof(PSObject))
+            return true;
+
+        if (t == typeof(ScriptBlock))
+            return true;
+
+        if (t == typeof(object))
+            return true;
+
+        if (typeof(Delegate).IsAssignableFrom(t))
+            return true;
+
+        if (typeof(System.IO.Stream).IsAssignableFrom(t))
+            return true;
+
+        if (typeof(System.Threading.WaitHandle).IsAssignableFrom(t))
+            return true;
+
+        if (typeof(System.Reflection.Assembly).IsAssignableFrom(t))
+            return true;
+
+        if (t == typeof(System.Management.Automation.PowerShell))
+            return true;
+
+        var fullName = t.FullName ?? string.Empty;
+        if (fullName.StartsWith("System.Management.Automation.Runspaces.", StringComparison.Ordinal))
+            return true;
+
+        if (t.IsArray)
+        {
+            var elementType = t.GetElementType();
+            if (elementType != null && IsUnserializableType(elementType))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Gets the default value for a given type
     /// </summary>
     public static object? GetDefaultValueForType(Type type)

--- a/PoshMcp.Tests/Unit/UnserializableTypeTests.cs
+++ b/PoshMcp.Tests/Unit/UnserializableTypeTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.IO;
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+using System.Threading;
+using PoshMcp.Server.PowerShell;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PoshMcp.Tests.Unit;
+
+/// <summary>
+/// Unit tests for PowerShellParameterUtils.IsUnserializableType — verifies that the method
+/// correctly identifies types that cannot be meaningfully represented in a JSON schema.
+/// </summary>
+public class UnserializableTypeTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public UnserializableTypeTests(ITestOutputHelper output) => _output = output;
+
+    // ── Serializable types (IsUnserializableType must return false) ──────────
+
+    [Theory]
+    [InlineData(typeof(string))]
+    [InlineData(typeof(int))]
+    [InlineData(typeof(long))]
+    [InlineData(typeof(double))]
+    [InlineData(typeof(float))]
+    [InlineData(typeof(decimal))]
+    [InlineData(typeof(bool))]
+    [InlineData(typeof(DateTime))]
+    [InlineData(typeof(Guid))]
+    [InlineData(typeof(Uri))]
+    [InlineData(typeof(SwitchParameter))]
+    [InlineData(typeof(CancellationToken))]
+    [InlineData(typeof(string[]))]
+    [InlineData(typeof(int[]))]
+    public void IsUnserializableType_ReturnsFalse_ForSerializableTypes(Type type)
+    {
+        Assert.False(PowerShellParameterUtils.IsUnserializableType(type),
+            $"{type.Name} should be considered serializable");
+    }
+
+    [Fact]
+    public void IsUnserializableType_ReturnsFalse_ForNullableInt()
+    {
+        Assert.False(PowerShellParameterUtils.IsUnserializableType(typeof(int?)));
+    }
+
+    [Fact]
+    public void IsUnserializableType_ReturnsFalse_ForEnumType()
+    {
+        Assert.False(PowerShellParameterUtils.IsUnserializableType(typeof(ActionPreference)));
+    }
+
+    // ── Unserializable types (IsUnserializableType must return true) ─────────
+
+    [Fact]
+    public void IsUnserializableType_ReturnsTrue_ForPSObject()
+    {
+        Assert.True(PowerShellParameterUtils.IsUnserializableType(typeof(PSObject)));
+    }
+
+    [Fact]
+    public void IsUnserializableType_ReturnsTrue_ForScriptBlock()
+    {
+        Assert.True(PowerShellParameterUtils.IsUnserializableType(typeof(ScriptBlock)));
+    }
+
+    [Fact]
+    public void IsUnserializableType_ReturnsTrue_ForSystemObject()
+    {
+        Assert.True(PowerShellParameterUtils.IsUnserializableType(typeof(object)));
+    }
+
+    [Fact]
+    public void IsUnserializableType_ReturnsTrue_ForIntPtr()
+    {
+        Assert.True(PowerShellParameterUtils.IsUnserializableType(typeof(IntPtr)));
+    }
+
+    [Fact]
+    public void IsUnserializableType_ReturnsTrue_ForUIntPtr()
+    {
+        Assert.True(PowerShellParameterUtils.IsUnserializableType(typeof(UIntPtr)));
+    }
+
+    [Fact]
+    public void IsUnserializableType_ReturnsTrue_ForStream()
+    {
+        Assert.True(PowerShellParameterUtils.IsUnserializableType(typeof(Stream)));
+    }
+
+    [Fact]
+    public void IsUnserializableType_ReturnsTrue_ForFileStream()
+    {
+        Assert.True(PowerShellParameterUtils.IsUnserializableType(typeof(FileStream)));
+    }
+
+    [Fact]
+    public void IsUnserializableType_ReturnsTrue_ForWaitHandle()
+    {
+        Assert.True(PowerShellParameterUtils.IsUnserializableType(typeof(WaitHandle)));
+    }
+
+    [Fact]
+    public void IsUnserializableType_ReturnsTrue_ForDelegate()
+    {
+        Assert.True(PowerShellParameterUtils.IsUnserializableType(typeof(Delegate)));
+    }
+
+    [Fact]
+    public void IsUnserializableType_ReturnsTrue_ForAction()
+    {
+        Assert.True(PowerShellParameterUtils.IsUnserializableType(typeof(Action)));
+    }
+
+    [Fact]
+    public void IsUnserializableType_ReturnsTrue_ForFuncOfString()
+    {
+        Assert.True(PowerShellParameterUtils.IsUnserializableType(typeof(Func<string>)));
+    }
+
+    [Fact]
+    public void IsUnserializableType_ReturnsTrue_ForSystemReflectionAssembly()
+    {
+        Assert.True(PowerShellParameterUtils.IsUnserializableType(typeof(System.Reflection.Assembly)));
+    }
+
+    [Fact]
+    public void IsUnserializableType_ReturnsTrue_ForPowerShellInstance()
+    {
+        Assert.True(PowerShellParameterUtils.IsUnserializableType(typeof(System.Management.Automation.PowerShell)));
+    }
+
+    [Fact]
+    public void IsUnserializableType_ReturnsTrue_ForRunspace()
+    {
+        Assert.True(PowerShellParameterUtils.IsUnserializableType(typeof(Runspace)));
+    }
+
+    [Fact]
+    public void IsUnserializableType_ReturnsTrue_ForRunspacePool()
+    {
+        Assert.True(PowerShellParameterUtils.IsUnserializableType(typeof(RunspacePool)));
+    }
+
+    [Fact]
+    public void IsUnserializableType_ReturnsTrue_ForArrayOfPSObject()
+    {
+        Assert.True(PowerShellParameterUtils.IsUnserializableType(typeof(PSObject[])));
+    }
+
+    [Fact]
+    public void IsUnserializableType_ReturnsTrue_ForArrayOfScriptBlock()
+    {
+        Assert.True(PowerShellParameterUtils.IsUnserializableType(typeof(ScriptBlock[])));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #89

When a PowerShell command has parameters whose types cannot be meaningfully serialized to JSON, PoshMcp now handles them gracefully instead of exposing broken or misleading schema entries.

## Behavior

| Scenario | Action |
|---|---|
| Optional parameter with unserializable type | Drop that parameter from the schema silently |
| Mandatory parameter with unserializable type in a parameter set | Skip the entire parameter set |
| All parameter sets skipped for a command | Skip the command (no MCP tool exposed); warning logged |

## Unserializable Types

PowerShellParameterUtils.IsUnserializableType() returns 	rue for:
- PSObject — opaque wrapper with no fixed schema
- ScriptBlock — executable code, not data
- System.Object — too generic for a meaningful schema
- Pointer types (IntPtr, UIntPtr, T*, T&)
- Delegate-derived types (callbacks, Action, Func<>, …)
- Stream-derived types (binary channels)
- WaitHandle-derived types (OS sync primitives)
- System.Reflection.Assembly — reflection handle
- System.Management.Automation.PowerShell — PS automation instance
- All System.Management.Automation.Runspaces.* types (Runspace, RunspacePool, …)
- Arrays whose element type is unserializable

## Tests

Added UnserializableTypeTests.cs with 33 unit tests covering both the positive (serializable) and negative (unserializable) categories.