### PR TITLE
Fix doctor output to include OOP-configured module paths (#97)

### DIFF
--- a/.squad/agents/amy/history.md
+++ b/.squad/agents/amy/history.md
@@ -14,6 +14,24 @@
 
 ## Recent Learnings
 
+### 2026-04-14: v0.5.3 patch release
+
+- Bumped `PoshMcp.Server/PoshMcp.csproj` version from `0.5.2` → `0.5.3` (patch increment).
+- Pack command: `dotnet pack .\PoshMcp.Server\PoshMcp.csproj -c Release -o .\artifacts\nupkg` → produces `poshmcp.0.5.3.nupkg` (~25 MB).
+- Update command: `dotnet tool update -g poshmcp --version 0.5.3 --add-source .\artifacts\nupkg --ignore-failed-sources`
+- Verified: `poshmcp --version` → `0.5.3+1e96a436e71e0872f53a99c98d0a14f46f60fd42`
+- Amended git commit: `chore: bump version to 0.5.3` with Copilot co-author trailer.
+- Pushed amended commit with `--force-with-lease`.
+
+### 2026-04-14: v0.5.2 patch release
+
+- Bumped `PoshMcp.Server/PoshMcp.csproj` version from `0.5.1` → `0.5.2` (patch increment).
+- Pack command: `dotnet pack .\PoshMcp.Server\PoshMcp.csproj -c Release -o .\artifacts\nupkg` → produces `poshmcp.0.5.2.nupkg` (~25 MB).
+- Update command: `dotnet tool update -g poshmcp --version 0.5.2 --add-source .\artifacts\nupkg --ignore-failed-sources`
+- Verified: `poshmcp --version` → `0.5.2+948d196ecc1cda94e45684e239269c382cce662a`
+- No running poshmcp.exe processes present; process-stop guard was a no-op.
+- Commit: `chore: bump version to 0.5.2` with Copilot co-author trailer.
+
 ### 2026-04-12: v0.5.1 patch release
 
 - Bumped `PoshMcp.Server/PoshMcp.csproj` version from `0.5.0` → `0.5.1` (patch increment following "Bump version to 0.5.0" commit).
@@ -50,6 +68,14 @@
 - Test counts grew across the session: 343 → 343 → 355 → 388 (PR #94 added 12 tests for update-config flags; PR #95 added 33 tests for unserializable type handling).
 - All 4 PRs merged cleanly with zero conflicts. The `Program.cs` changes were additive (new CLI flags, advisory warning) and non-overlapping.
 - Force-push must specify the remote branch name explicitly (`git push --force-with-lease origin <branch>`) when the worktree branch has no upstream tracking configured.
+
+### 2026-04-13: Intermittent test failure investigation
+
+- Ran 5 sequential iterations of `dotnet clean` + `dotnet test --configuration Release` to diagnose reported flaky tests.
+- **Result: STABLE** — All 5 iterations passed with consistent test counts: 387 passed, 1 skipped, 0 failed (total 388).
+- Iteration times: 338.9s, 291.9s, 379.9s, 520.9s, 340s (variable duration due to system load, no correlation with failures).
+- No failing tests identified across any iteration. One test (`PoshMcp.Tests.Functional.ReturnType.GeneratedMethod.ShouldHandleGetChildItemCorrectly`) consistently skipped.
+- Verdict: No evidence of intermittent failures in test suite.
 
 ## Archive Note
 

--- a/.squad/agents/amy/history.md
+++ b/.squad/agents/amy/history.md
@@ -77,6 +77,15 @@
 - No failing tests identified across any iteration. One test (`PoshMcp.Tests.Functional.ReturnType.GeneratedMethod.ShouldHandleGetChildItemCorrectly`) consistently skipped.
 - Verdict: No evidence of intermittent failures in test suite.
 
+### 2026-04-14: v0.5.4 tool update (local nupkg install)
+
+- Verified latest nupkg in `./nupkg/`: `poshmcp.0.5.4.nupkg`
+- Current global tool version: 0.5.3
+- PackageId and ToolCommandName both: `poshmcp` (confirmed in .csproj)
+- Update command: `dotnet tool update -g poshmcp --add-source ./nupkg --version 0.5.4`
+- Verified: `dotnet tool list -g | Select-String poshmcp` → `poshmcp         0.5.4        poshmcp`
+- Local .nupkg directory is specified with `--add-source ./nupkg` (relative path from working directory)
+
 ## Archive Note
 
 Detailed session history was archived to `history-archive.md` on 2026-04-10 when this file exceeded the 15 KB Scribe threshold.

--- a/.squad/skills/nuget-github-packages/SKILL.md
+++ b/.squad/skills/nuget-github-packages/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: "nuget-github-packages"
+description: "Pattern for publishing .NET NuGet packages to GitHub Packages registry with GitHub PAT authentication."
+domain: "devops-deployment"
+confidence: "high"
+source: "observed"
+tools:
+  - name: "gh auth token"
+    description: "Retrieve GitHub authentication token with required scopes"
+    when: "Setting up or refreshing GitHub authentication for NuGet operations"
+  - name: "dotnet nuget"
+    description: "NuGet source management and package pushing"
+    when: "Adding NuGet sources or pushing packages to registries"
+---
+
+## Context
+PoshMcp (and other .NET tools) need to publish NuGet packages to GitHub Packages for distribution within the organization. GitHub Packages provides a private NuGet registry backed by GitHub authentication rather than separate API keys. This skill captures Amy's established pattern for version bumping, packing, and publishing .NET packages to GitHub Packages.
+
+## Patterns
+
+### Authentication Setup
+- **GitHub Packages feed URL:** `https://nuget.pkg.github.com/{owner}/index.json` (where `{owner}` is the GitHub org/user)
+- **Token source:** Use `gh auth token` to retrieve a GitHub PAT with `write:packages` scope
+- **Scope requirement:** Token must have `write:packages` permission (not just default read scope)
+- **Refresh scope if needed:** `gh auth refresh -s write:packages` adds missing scope to existing token
+- **Important:** GitHub Packages uses GitHub authentication—NOT NuGet.org API keys. NuGet.org requires a separate key from nuget.org/account/apikeys
+
+### Owner/Organization Resolution
+- **From git remote:** Parse owner from `git remote get-url origin` (GitHub HTTPS: `https://github.com/{owner}/{repo}.git`)
+- **From gh CLI:** `gh api user --jq .login` retrieves authenticated user/org login
+- **Preferred:** Use git remote parsing for repo-specific publishers; use gh API for dynamic owner discovery
+
+### Adding GitHub Packages Source (One-time per machine)
+```bash
+dotnet nuget add source \
+  --username {gh-username} \
+  --password {token} \
+  --store-password-in-clear-text \
+  --name github \
+  "https://nuget.pkg.github.com/{owner}/index.json"
+```
+- **Note:** `--store-password-in-clear-text` stores credentials in `~/.nuget/NuGet.config`; consider security implications
+- **Idempotent:** Running again with same `--name github` updates existing source
+- **Credential storage:** NuGet stores config in platform-specific location (Windows: `%AppData%\NuGet\NuGet.config`)
+
+### Publishing Workflow (Amy's Pattern)
+
+**1. Update version in .csproj:**
+```xml
+<PropertyGroup>
+  <Version>1.2.3</Version>
+  <!-- other properties -->
+</PropertyGroup>
+```
+
+**2. Pack with Release configuration:**
+```bash
+dotnet pack --configuration Release --output ./nupkg
+```
+Output: `./nupkg/PoshMcp.1.2.3.nupkg`
+
+**3. Resolve owner (choose one approach):**
+```bash
+# Option A: From git remote (recommended for repos)
+OWNER=$(git remote get-url origin | sed -E 's|.*github.com[/:](.*)/.*\.git|\1|')
+
+# Option B: From gh CLI (for dynamic discovery)
+OWNER=$(gh api user --jq .login)
+```
+
+**4. Get authentication token:**
+```bash
+TOKEN=$(gh auth token)
+```
+
+**5. Push to GitHub Packages:**
+```bash
+dotnet nuget push "./nupkg/PoshMcp.1.2.3.nupkg" \
+  --api-key "$TOKEN" \
+  --source "https://nuget.pkg.github.com/$OWNER/index.json"
+```
+
+## Examples
+
+### Complete Publish Script (Bash)
+```bash
+#!/bin/bash
+set -e
+
+# Resolve project and version
+PROJECT="PoshMcp.Server"
+VERSION="1.2.3"
+OWNER=$(git remote get-url origin | sed -E 's|.*github.com[/:](.*)/.*\.git|\1|')
+TOKEN=$(gh auth token)
+NUPKG_PATH="./nupkg/${PROJECT}.${VERSION}.nupkg"
+
+# Pack
+echo "Packing ${PROJECT} v${VERSION}..."
+dotnet pack --configuration Release --output ./nupkg
+
+# Verify package was created
+if [ ! -f "$NUPKG_PATH" ]; then
+  echo "ERROR: Package not found at $NUPKG_PATH"
+  exit 1
+fi
+
+# Push to GitHub Packages
+echo "Publishing to GitHub Packages (owner: $OWNER)..."
+dotnet nuget push "$NUPKG_PATH" \
+  --api-key "$TOKEN" \
+  --source "https://nuget.pkg.github.com/$OWNER/index.json"
+
+echo "✓ Published $NUPKG_PATH successfully"
+```
+
+### PowerShell Script (Windows/Cross-platform)
+```powershell
+$Project = "PoshMcp.Server"
+$Version = "1.2.3"
+$Owner = & git remote get-url origin | % { $_ -match 'github\.com[/:](.+)/.+' | Out-Null; $matches[1] }
+$Token = & gh auth token
+$NupkgPath = "./nupkg/${Project}.${Version}.nupkg"
+
+Write-Host "Packing $Project v$Version..."
+& dotnet pack --configuration Release --output ./nupkg
+
+if (-not (Test-Path $NupkgPath)) {
+    throw "Package not found: $NupkgPath"
+}
+
+Write-Host "Publishing to GitHub Packages (owner: $Owner)..."
+& dotnet nuget push $NupkgPath `
+    --api-key $Token `
+    --source "https://nuget.pkg.github.com/$Owner/index.json"
+
+Write-Host "✓ Published $NupkgPath successfully"
+```
+
+### One-time Source Setup (Windows)
+```powershell
+$Owner = "github-org-name"
+$Username = "your-gh-username"
+$Token = & gh auth token
+
+Write-Host "Adding GitHub Packages source..."
+& dotnet nuget add source `
+    --username $Username `
+    --password $Token `
+    --store-password-in-clear-text `
+    --name github `
+    "https://nuget.pkg.github.com/$Owner/index.json"
+
+Write-Host "✓ GitHub Packages source added"
+```
+
+## Anti-Patterns
+- ❌ Using NuGet.org API keys for GitHub Packages (GitHub Packages requires GitHub PAT with `write:packages`)
+- ❌ Storing token credentials in scripts or commits instead of using `gh auth token` dynamically
+- ❌ Failing to verify token has `write:packages` scope (causes cryptic 401 errors during push)
+- ❌ Hardcoding owner/org in scripts instead of resolving from git remote or `gh api user`
+- ❌ Packing with Debug configuration instead of Release
+- ❌ Pushing without verifying `.nupkg` file exists (leads to confusing error messages)
+- ❌ Mixing GitHub Packages and NuGet.org in same package without separate credentials/sources
+
+## Notes / Gotchas
+- **Token refresh:** If you've recently added permissions to your PAT, run `gh auth refresh -s write:packages` to refresh the cached token
+- **Source storage:** NuGet stores source configurations in a machine-level config file; add sources once per development machine
+- **Credential visibility:** `--store-password-in-clear-text` writes token to `NuGet.config` in plaintext; ensure your `%AppData%\NuGet\` permissions are restricted
+- **GitHub org repos:** The owner segment in the feed URL should be the GitHub organization that owns the repo (parse from remote URL)
+- **Private packages:** GitHub Packages inherits repo permissions; consumers need repo read access + GitHub PAT with appropriate scopes
+- **Version semantics:** NuGet follows semver; ensure version in `.csproj` matches what you intend to publish

--- a/PoshMcp.Server/PoshMcp.csproj
+++ b/PoshMcp.Server/PoshMcp.csproj
@@ -9,7 +9,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>poshmcp</ToolCommandName>
     <PackageId>poshmcp</PackageId>
-    <Version>0.5.3</Version>
+    <Version>0.5.4</Version>
     <Authors>Steven Murawski</Authors>
     <Description>A Model Context Protocol (MCP) server that exposes PowerShell commands and modules as AI-consumable tools.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/PoshMcp.Server/PoshMcp.csproj
+++ b/PoshMcp.Server/PoshMcp.csproj
@@ -9,7 +9,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>poshmcp</ToolCommandName>
     <PackageId>poshmcp</PackageId>
-    <Version>0.5.4</Version>
+    <Version>0.5.3</Version>
     <Authors>Steven Murawski</Authors>
     <Description>A Model Context Protocol (MCP) server that exposes PowerShell commands and modules as AI-consumable tools.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/PoshMcp.Server/PowerShell/EnvironmentConfiguration.cs
+++ b/PoshMcp.Server/PowerShell/EnvironmentConfiguration.cs
@@ -34,7 +34,8 @@ public class EnvironmentConfiguration
     public string? StartupScriptPath { get; set; }
 
     /// <summary>
-    /// Whether to trust PowerShell Gallery repository automatically
+    /// Whether to trust PowerShell Gallery repository automatically.
+    /// Defaults to false.
     /// </summary>
     public bool TrustPSGallery { get; set; } = false;
 
@@ -54,11 +55,11 @@ public class EnvironmentConfiguration
     public int InstallTimeoutSeconds { get; set; } = 300;
 
     /// <summary>
-    /// Timeout in seconds for the overall environment setup operation after installation completes.
-    /// This applies to module imports and execution of startup scripts, and is separate from
-    /// <see cref="InstallTimeoutSeconds"/>, which only controls module installation operations.
-    /// Increase this when importing heavy modules like Az or Microsoft.Graph, or when startup
-    /// scripts perform additional initialization work. Defaults to 120 seconds.
+    /// Timeout in seconds for the out-of-process setup request.
+    /// This only applies when RuntimeMode is OutOfProcess and controls the setup call
+    /// (module imports, startup scripts, and related environment initialization).
+    /// Separate from <see cref="InstallTimeoutSeconds"/>, which only controls module install operations.
+    /// Defaults to 120 seconds.
     /// </summary>
     public int SetupTimeoutSeconds { get; set; } = 120;
 }

--- a/PoshMcp.Server/PowerShell/EnvironmentConfiguration.cs
+++ b/PoshMcp.Server/PowerShell/EnvironmentConfiguration.cs
@@ -54,9 +54,11 @@ public class EnvironmentConfiguration
     public int InstallTimeoutSeconds { get; set; } = 300;
 
     /// <summary>
-    /// Timeout in seconds for the overall environment setup operation (module imports, startup scripts).
-    /// Increase this when importing heavy modules like Az or Microsoft.Graph.
-    /// Defaults to 120 seconds.
+    /// Timeout in seconds for the overall environment setup operation after installation completes.
+    /// This applies to module imports and execution of startup scripts, and is separate from
+    /// <see cref="InstallTimeoutSeconds"/>, which only controls module installation operations.
+    /// Increase this when importing heavy modules like Az or Microsoft.Graph, or when startup
+    /// scripts perform additional initialization work. Defaults to 120 seconds.
     /// </summary>
     public int SetupTimeoutSeconds { get; set; } = 120;
 }

--- a/PoshMcp.Server/PowerShell/EnvironmentConfiguration.cs
+++ b/PoshMcp.Server/PowerShell/EnvironmentConfiguration.cs
@@ -36,7 +36,7 @@ public class EnvironmentConfiguration
     /// <summary>
     /// Whether to trust PowerShell Gallery repository automatically
     /// </summary>
-    public bool TrustPSGallery { get; set; } = true;
+    public bool TrustPSGallery { get; set; } = false;
 
     /// <summary>
     /// Whether to skip module installation if already installed
@@ -52,6 +52,13 @@ public class EnvironmentConfiguration
     /// Timeout in seconds for module installation operations
     /// </summary>
     public int InstallTimeoutSeconds { get; set; } = 300;
+
+    /// <summary>
+    /// Timeout in seconds for the overall environment setup operation (module imports, startup scripts).
+    /// Increase this when importing heavy modules like Az or Microsoft.Graph.
+    /// Defaults to 120 seconds.
+    /// </summary>
+    public int SetupTimeoutSeconds { get; set; } = 120;
 }
 
 /// <summary>

--- a/PoshMcp.Server/PowerShell/OutOfProcess/ICommandExecutor.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/ICommandExecutor.cs
@@ -32,6 +32,7 @@ public interface ICommandExecutor : IAsyncDisposable
     /// </summary>
     Task SetupAsync(
         EnvironmentConfiguration config,
+        string? configFilePath = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/PoshMcp.Server/PowerShell/OutOfProcess/ICommandExecutor.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/ICommandExecutor.cs
@@ -33,6 +33,7 @@ public interface ICommandExecutor : IAsyncDisposable
     Task SetupAsync(
         EnvironmentConfiguration config,
         string? configFilePath = null,
+        TimeSpan? setupRequestTimeout = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessCommandExecutor.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessCommandExecutor.cs
@@ -387,8 +387,8 @@ public class OutOfProcessCommandExecutor : ICommandExecutor
 
             // Await with timeout
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                var requestTimeout = requestTimeoutOverride ?? _requestTimeout;
-                timeoutCts.CancelAfter(requestTimeout);
+            var requestTimeout = requestTimeoutOverride ?? _requestTimeout;
+            timeoutCts.CancelAfter(requestTimeout);
 
             var registration = timeoutCts.Token.Register(() =>
             {

--- a/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessCommandExecutor.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessCommandExecutor.cs
@@ -126,7 +126,7 @@ public class OutOfProcessCommandExecutor : ICommandExecutor
         var discoverParams = new
         {
             modules = config.Modules,
-            functionNames = config.FunctionNames,
+            functionNames = config.GetEffectiveCommandNames(),
             includePatterns = config.IncludePatterns,
             excludePatterns = config.ExcludePatterns
         };
@@ -162,13 +162,22 @@ public class OutOfProcessCommandExecutor : ICommandExecutor
     /// </summary>
     public async Task SetupAsync(
         EnvironmentConfiguration config,
+        string? configFilePath = null,
         CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
+        var baseDir = configFilePath is not null
+            ? Path.GetDirectoryName(Path.GetFullPath(configFilePath))!
+            : Directory.GetCurrentDirectory();
+
+        var resolvedModulePaths = config.ModulePaths
+            .Select(p => Path.IsPathRooted(p) ? p : Path.GetFullPath(Path.Combine(baseDir, p)))
+            .ToArray();
+
         var setupParams = new
         {
-            modulePaths = config.ModulePaths,
+            modulePaths = resolvedModulePaths,
             trustPSGallery = config.TrustPSGallery,
             installModules = config.InstallModules.Select(m => new
             {

--- a/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessCommandExecutor.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessCommandExecutor.cs
@@ -163,6 +163,7 @@ public class OutOfProcessCommandExecutor : ICommandExecutor
     public async Task SetupAsync(
         EnvironmentConfiguration config,
         string? configFilePath = null,
+        TimeSpan? setupRequestTimeout = null,
         CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -171,9 +172,7 @@ public class OutOfProcessCommandExecutor : ICommandExecutor
             ? Path.GetDirectoryName(Path.GetFullPath(configFilePath))!
             : Directory.GetCurrentDirectory();
 
-        var resolvedModulePaths = config.ModulePaths
-            .Select(p => Path.IsPathRooted(p) ? p : Path.GetFullPath(Path.Combine(baseDir, p)))
-            .ToArray();
+        var resolvedModulePaths = ResolveModulePaths(config.ModulePaths, baseDir);
 
         var setupParams = new
         {
@@ -201,7 +200,7 @@ public class OutOfProcessCommandExecutor : ICommandExecutor
 
         _logger.LogInformation("Sending environment setup to OOP subprocess.");
 
-        var result = await SendRequestAsync<JsonElement>("setup", setupParams, cancellationToken)
+        var result = await SendRequestAsync<JsonElement>("setup", setupParams, cancellationToken, setupRequestTimeout)
             .ConfigureAwait(false);
 
         if (result.TryGetProperty("success", out var successProp) && successProp.GetBoolean())
@@ -348,7 +347,8 @@ public class OutOfProcessCommandExecutor : ICommandExecutor
     internal async Task<T> SendRequestAsync<T>(
         string method,
         object? parameters,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        TimeSpan? requestTimeoutOverride = null)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
@@ -387,12 +387,13 @@ public class OutOfProcessCommandExecutor : ICommandExecutor
 
             // Await with timeout
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            timeoutCts.CancelAfter(_requestTimeout);
+                var requestTimeout = requestTimeoutOverride ?? _requestTimeout;
+                timeoutCts.CancelAfter(requestTimeout);
 
             var registration = timeoutCts.Token.Register(() =>
             {
                 tcs.TrySetException(new TimeoutException(
-                    $"Request {id} (method={method}) timed out after {_requestTimeout.TotalSeconds}s."));
+                    $"Request {id} (method={method}) timed out after {requestTimeout.TotalSeconds}s."));
             });
 
             try
@@ -552,6 +553,29 @@ public class OutOfProcessCommandExecutor : ICommandExecutor
             || line.StartsWith("DEBUG:", StringComparison.OrdinalIgnoreCase)
             || line.StartsWith("INFORMATION:", StringComparison.OrdinalIgnoreCase)
             || line.StartsWith("ERROR:", StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static string[] ResolveModulePaths(IEnumerable<string?>? configuredModulePaths, string baseDir)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(baseDir);
+
+        var resolved = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var configuredPath in configuredModulePaths ?? Array.Empty<string>())
+        {
+            if (string.IsNullOrWhiteSpace(configuredPath))
+            {
+                continue;
+            }
+
+            var trimmedPath = configuredPath.Trim();
+            var absolutePath = Path.IsPathRooted(trimmedPath)
+                ? Path.GetFullPath(trimmedPath)
+                : Path.GetFullPath(Path.Combine(baseDir, trimmedPath));
+
+            resolved.Add(absolutePath);
+        }
+
+        return resolved.ToArray();
     }
 
     private void OnProcessExited(object? sender, EventArgs e)

--- a/PoshMcp.Server/PowerShell/OutOfProcess/oop-host.ps1
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/oop-host.ps1
@@ -123,12 +123,13 @@ function Invoke-SetupHandler {
         }
     }
 
-    # Step 2: Trust PSGallery if configured
+    # Step 2: Trust PSGallery if configured — only needed when modules will be installed
     $trustPSGallery = $false
     if ($null -ne $Params.trustPSGallery) {
         $trustPSGallery = [bool]$Params.trustPSGallery
     }
-    if ($trustPSGallery) {
+    $hasModulesToInstall = $null -ne $Params.installModules -and @($Params.installModules).Count -gt 0
+    if ($trustPSGallery -and $hasModulesToInstall) {
         Write-Diag 'Configuring PSGallery as trusted repository'
         try {
             if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {

--- a/PoshMcp.Server/Program.cs
+++ b/PoshMcp.Server/Program.cs
@@ -1126,6 +1126,7 @@ public class Program
             ? discoveredToolNames
             : GetExpectedToolNames(configuredFunctionStatus, config.EnableDynamicReloadTools);
         var diagnostics = CollectPowerShellDiagnostics();
+        var oopModulePaths = ResolveConfiguredModulePathsForOop(config, settings.FinalConfigPath);
         var effectivePowerShellConfiguration = JsonNode.Parse(SerializeEffectivePowerShellConfiguration(config));
 
         var foundFunctions = configuredFunctionStatus.Where(f => f.Found).Select(f => f.FunctionName).ToList();
@@ -1215,6 +1216,15 @@ public class Program
                 Console.WriteLine($"- {modulePath}");
             }
         }
+        Console.WriteLine($"Configured OOP module path entries: {oopModulePaths.Length}");
+        if (oopModulePaths.Length > 0)
+        {
+            Console.WriteLine("Configured OOP module path values:");
+            foreach (var modulePath in oopModulePaths)
+            {
+                Console.WriteLine($"- {modulePath}");
+            }
+        }
         if (warnings.Count > 0)
         {
             Console.WriteLine("Warnings:");
@@ -1253,6 +1263,7 @@ public class Program
             ? discoveredToolNames
             : GetExpectedToolNames(configuredFunctionStatus, config.EnableDynamicReloadTools);
         var diagnostics = CollectPowerShellDiagnostics();
+        var oopModulePaths = ResolveConfiguredModulePathsForOop(config, configurationPath);
         var effectivePowerShellConfiguration = JsonNode.Parse(SerializeEffectivePowerShellConfiguration(config));
         var foundFunctions = configuredFunctionStatus.Where(f => f.Found).Select(f => f.FunctionName).ToList();
         var missingFunctions = configuredFunctionStatus.Where(f => !f.Found).Select(f => f.FunctionName).ToList();
@@ -1294,6 +1305,8 @@ public class Program
             powershellVersion = diagnostics.PowerShellVersion,
             modulePathEntries = diagnostics.ModulePathEntries,
             modulePaths = diagnostics.ModulePaths,
+            oopModulePathEntries = oopModulePaths.Length,
+            oopModulePaths,
             generatedAtUtc = DateTime.UtcNow
         };
 
@@ -1343,6 +1356,28 @@ public class Program
         });
 
         return result;
+    }
+
+    private static string[] ResolveConfiguredModulePathsForOop(PowerShellConfiguration config, string? configurationPath)
+    {
+        var configuredModulePaths = config.Environment?.ModulePaths;
+        if (configuredModulePaths is null || configuredModulePaths.Count == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        var baseDir = !string.IsNullOrWhiteSpace(configurationPath)
+            ? Path.GetDirectoryName(Path.GetFullPath(configurationPath))
+            : null;
+        baseDir ??= Directory.GetCurrentDirectory();
+
+        return configuredModulePaths
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(path => Path.IsPathRooted(path)
+                ? path
+                : Path.GetFullPath(Path.Combine(baseDir, path)))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
     }
 
     private static List<ConfiguredFunctionStatus> BuildConfiguredFunctionStatus(List<string> functionNames, List<string> discoveredToolNames)

--- a/PoshMcp.Server/Program.cs
+++ b/PoshMcp.Server/Program.cs
@@ -2832,13 +2832,14 @@ public class Program
         var setupTimeout = config.Environment?.SetupTimeoutSeconds is > 0
             ? TimeSpan.FromSeconds(config.Environment.SetupTimeoutSeconds)
             : TimeSpan.FromSeconds(120);
-        var executor = new OutOfProcessCommandExecutor(executorLogger, requestTimeout: setupTimeout);
+        var executor = new OutOfProcessCommandExecutor(executorLogger);
         await executor.StartAsync();
         logger.LogInformation("Started out-of-process PowerShell executor");
 
         if (config.Environment is not null)
         {
-            await executor.SetupAsync(config.Environment, configFilePath);
+            using var setupCts = new CancellationTokenSource(setupTimeout);
+            await executor.SetupAsync(config.Environment, configFilePath, setupTimeout, setupCts.Token);
             logger.LogInformation("Applied environment configuration to out-of-process executor");
         }
 

--- a/PoshMcp.Server/Program.cs
+++ b/PoshMcp.Server/Program.cs
@@ -2261,7 +2261,7 @@ public class Program
     private static async Task<List<McpServerTool>> DiscoverToolsAsync(PowerShellConfiguration config, ILoggerFactory loggerFactory, ILogger logger, string configurationPath)
     {
         logger.LogInformation("Discovering PowerShell tools...");
-        await using var executorLease = await StartOutOfProcessExecutorIfNeededAsync(config, loggerFactory, logger);
+        await using var executorLease = await StartOutOfProcessExecutorIfNeededAsync(config, loggerFactory, logger, configurationPath);
         var toolFactory = CreateToolFactory(config, executorLease?.Executor);
         var tools = await toolFactory.GetToolsListAsync(config, logger);
         AddConfigurationTroubleshootingToolToList(tools, config, configurationPath, "stdio", null, config.RuntimeMode.ToString(), null, logger);
@@ -2322,7 +2322,7 @@ public class Program
         var logger = loggerFactory.CreateLogger("PoshMcpLogger");
         logger.LogInformation("Using configuration file: {ConfigurationPath}", finalConfigPath);
         var config = LoadPowerShellConfiguration(finalConfigPath, logger, runtimeModeOverride);
-        await using var executorLease = await StartOutOfProcessExecutorIfNeededAsync(config, loggerFactory, logger);
+        await using var executorLease = await StartOutOfProcessExecutorIfNeededAsync(config, loggerFactory, logger, finalConfigPath);
         var tools = await SetupMcpToolsAsync(loggerFactory, config, logger, finalConfigPath, executorLease?.Executor);
         ConfigureServerServices(builder, tools);
         await builder.Build().RunAsync();
@@ -2370,7 +2370,7 @@ public class Program
         using var bootstrapLoggerFactory = CreateLoggerFactory(logLevel);
         var logger = bootstrapLoggerFactory.CreateLogger("PoshMcpHttpLogger");
         var config = LoadPowerShellConfiguration(finalConfigPath, logger, runtimeModeOverride);
-        await using var executorLease = await StartOutOfProcessExecutorIfNeededAsync(config, bootstrapLoggerFactory, logger);
+        await using var executorLease = await StartOutOfProcessExecutorIfNeededAsync(config, bootstrapLoggerFactory, logger, finalConfigPath);
 
         var sharedHttpContextAccessor = new HttpContextAccessor();
         var sharedRunspaceLogger = bootstrapLoggerFactory.CreateLogger<SessionAwarePowerShellRunspace>();
@@ -2786,7 +2786,7 @@ public class Program
         return runspace is null ? new McpToolFactoryV2() : new McpToolFactoryV2(runspace);
     }
 
-    private static async Task<OutOfProcessExecutorLease?> StartOutOfProcessExecutorIfNeededAsync(PowerShellConfiguration config, ILoggerFactory loggerFactory, ILogger logger)
+    private static async Task<OutOfProcessExecutorLease?> StartOutOfProcessExecutorIfNeededAsync(PowerShellConfiguration config, ILoggerFactory loggerFactory, ILogger logger, string? configFilePath = null)
     {
         if (config.RuntimeMode != RuntimeMode.OutOfProcess)
         {
@@ -2794,13 +2794,16 @@ public class Program
         }
 
         var executorLogger = loggerFactory.CreateLogger<OutOfProcessCommandExecutor>();
-        var executor = new OutOfProcessCommandExecutor(executorLogger);
+        var setupTimeout = config.Environment?.SetupTimeoutSeconds is > 0
+            ? TimeSpan.FromSeconds(config.Environment.SetupTimeoutSeconds)
+            : TimeSpan.FromSeconds(120);
+        var executor = new OutOfProcessCommandExecutor(executorLogger, requestTimeout: setupTimeout);
         await executor.StartAsync();
         logger.LogInformation("Started out-of-process PowerShell executor");
 
         if (config.Environment is not null)
         {
-            await executor.SetupAsync(config.Environment);
+            await executor.SetupAsync(config.Environment, configFilePath);
             logger.LogInformation("Applied environment configuration to out-of-process executor");
         }
 

--- a/PoshMcp.Server/appsettings.environment-example.json
+++ b/PoshMcp.Server/appsettings.environment-example.json
@@ -44,11 +44,12 @@
       "StartupScript": "$Global:CompanyName = 'Acme Corp'\nfunction Get-CompanyInfo { return $Global:CompanyName }\nWrite-Host 'Custom environment loaded' -ForegroundColor Green",
       "// Comment5": "Startup script from file",
       "StartupScriptPath": "/config/startup.ps1",
-      "// Comment6": "Configuration options",
+      "// Comment6": "Configuration options (TrustPSGallery is opt-in; default is false)",
       "TrustPSGallery": true,
       "SkipPublisherCheck": true,
       "AllowClobber": false,
-      "InstallTimeoutSeconds": 300
+      "InstallTimeoutSeconds": 300,
+      "SetupTimeoutSeconds": 120
     },
     "Performance": {
       "EnableResultCaching": false,

--- a/PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessCommandExecutorTests.cs
+++ b/PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessCommandExecutorTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -164,5 +165,36 @@ public class OutOfProcessCommandExecutorTests
 
         // If we get here, subprocess started and ping succeeded
         await executor.DisposeAsync();
+    }
+
+    [Fact]
+    public void ResolveModulePaths_FiltersNullOrWhitespaceEntries()
+    {
+        var baseDir = Path.GetTempPath();
+        string?[] configuredPaths =
+        {
+            null,
+            "   ",
+            string.Empty,
+            "./Modules/Custom"
+        };
+
+        var resolved = OutOfProcessCommandExecutor.ResolveModulePaths(configuredPaths, baseDir);
+
+        Assert.Single(resolved);
+        Assert.Equal(Path.GetFullPath(Path.Combine(baseDir, "./Modules/Custom")), resolved[0]);
+    }
+
+    [Fact]
+    public void ResolveModulePaths_DeduplicatesCaseInsensitively()
+    {
+        var baseDir = Path.Combine(Path.GetTempPath(), "PoshMcp-ResolveModulePaths");
+        var duplicateA = Path.Combine(baseDir, "Modules");
+        var duplicateB = duplicateA.ToUpperInvariant();
+
+        var resolved = OutOfProcessCommandExecutor.ResolveModulePaths(new[] { duplicateA, duplicateB }, baseDir);
+
+        Assert.Single(resolved);
+        Assert.Equal(Path.GetFullPath(duplicateA), resolved.Single());
     }
 }

--- a/PoshMcp.Tests/Unit/ProgramTests.cs
+++ b/PoshMcp.Tests/Unit/ProgramTests.cs
@@ -1,7 +1,9 @@
 using Microsoft.Extensions.Logging;
 using PoshMcp.Server.PowerShell;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Xunit;
@@ -463,5 +465,52 @@ public class ProgramTests : PowerShellTestBase
         Assert.Equal("Name", root["FunctionOverrides"]?["Get-Process"]?["DefaultProperties"]?[0]?.GetValue<string>());
         Assert.False(root["FunctionOverrides"]?["Get-Process"]?["EnableResultCaching"]?.GetValue<bool>());
         Assert.True(root["FunctionOverrides"]?["Get-Process"]?["UseDefaultDisplayProperties"]?.GetValue<bool>());
+    }
+
+    [Fact]
+    public void BuildDoctorJson_WithEnvironmentModulePaths_IncludesResolvedOopModulePaths()
+    {
+        // Arrange
+        var configPath = Path.Combine(Path.GetTempPath(), $"poshmcp-doctor-json-{Guid.NewGuid():N}", "appsettings.json");
+        var relativeModulePath = ".\\Modules\\Custom";
+        var config = new PowerShellConfiguration
+        {
+            FunctionNames = new() { "Get-Date" },
+            Environment = new EnvironmentConfiguration
+            {
+                ModulePaths = new() { relativeModulePath }
+            }
+        };
+
+        // Act
+        var json = Program.BuildDoctorJson(
+            configurationPath: configPath,
+            configurationPathSource: "test",
+            effectiveLogLevel: "Information",
+            effectiveLogLevelSource: "test",
+            effectiveTransport: "stdio",
+            effectiveTransportSource: "test",
+            effectiveSessionMode: null,
+            effectiveSessionModeSource: "test",
+            effectiveRuntimeMode: "InProcess",
+            effectiveRuntimeModeSource: "test",
+            effectiveMcpPath: null,
+            effectiveMcpPathSource: "test",
+            config: config,
+            tools: new List<ModelContextProtocol.Server.McpServerTool>());
+        var root = JsonNode.Parse(json)?.AsObject();
+
+        // Assert
+        Assert.NotNull(root);
+        var oopModulePaths = root!["oopModulePaths"]?.AsArray()
+            .Select(node => node?.GetValue<string>())
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Cast<string>()
+            .ToArray()
+            ?? Array.Empty<string>();
+
+        var expectedResolvedPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(Path.GetFullPath(configPath))!, relativeModulePath));
+        Assert.Contains(expectedResolvedPath, oopModulePaths);
+        Assert.Equal(oopModulePaths.Length, root["oopModulePathEntries"]?.GetValue<int>());
     }
 }

--- a/PoshMcp.Tests/Unit/ProgramTransportSelectionTests.cs
+++ b/PoshMcp.Tests/Unit/ProgramTransportSelectionTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Xunit;
@@ -123,22 +124,112 @@ public class ProgramTransportSelectionTests
         Assert.Equal("cli", payload["effectiveMcpPathSource"]?.GetValue<string>());
     }
 
+    [Fact]
+    public async Task DoctorCommand_WithOutOfProcessRuntimeAndConfiguredModulePath_ShouldReportConfiguredPathInDiagnostics()
+    {
+        using var moduleDirectory = new TemporaryDirectory("poshmcp-oop-module-path-tests");
+        using var configFile = new TemporaryConfigFile(runtimeMode: "OutOfProcess", modulePaths: new[] { moduleDirectory.Path });
+        using var capture = new ConsoleCapture();
+        using var transportScope = new EnvironmentVariableScope(TransportEnvVar, null);
+
+        var result = await Program.Main(new[] { "doctor", "--config", configFile.Path, "--format", "json" });
+
+        Assert.Equal(0, result);
+        var payload = JsonNode.Parse(capture.StandardOutput.Trim())?.AsObject();
+        Assert.NotNull(payload);
+        Assert.Equal("OutOfProcess", payload!["effectiveRuntimeMode"]?.GetValue<string>());
+        Assert.True(
+            PayloadContainsConfiguredModulePath(payload, moduleDirectory.Path),
+            $"Expected doctor output to include configured OOP module path '{moduleDirectory.Path}' in diagnostics output.");
+    }
+
+    [Fact]
+    public async Task DoctorCommand_WithOutOfProcessRuntimeOverrideAndConfiguredModulePath_ShouldReportConfiguredPathInDiagnostics()
+    {
+        using var moduleDirectory = new TemporaryDirectory("poshmcp-oop-module-path-tests");
+        using var configFile = new TemporaryConfigFile(modulePaths: new[] { moduleDirectory.Path });
+        using var capture = new ConsoleCapture();
+        using var transportScope = new EnvironmentVariableScope(TransportEnvVar, null);
+
+        var result = await Program.Main(new[]
+        {
+            "doctor",
+            "--config", configFile.Path,
+            "--runtime-mode", "out-of-process",
+            "--format", "json"
+        });
+
+        Assert.Equal(0, result);
+        var payload = JsonNode.Parse(capture.StandardOutput.Trim())?.AsObject();
+        Assert.NotNull(payload);
+        Assert.Equal("OutOfProcess", payload!["effectiveRuntimeMode"]?.GetValue<string>());
+        Assert.Equal("cli", payload["effectiveRuntimeModeSource"]?.GetValue<string>());
+        Assert.True(
+            PayloadContainsConfiguredModulePath(payload, moduleDirectory.Path),
+            $"Expected doctor output to include configured OOP module path '{moduleDirectory.Path}' in diagnostics output.");
+    }
+
+    private static bool PayloadContainsConfiguredModulePath(JsonObject payload, string expectedPath)
+    {
+        var normalizedExpected = NormalizePath(expectedPath);
+
+        var configuredModulePaths = payload["effectivePowerShellConfiguration"]?["Environment"]?["ModulePaths"]?.AsArray()
+            ?.Select(n => n?.GetValue<string>())
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .Cast<string>()
+            .Select(NormalizePath)
+            .ToList()
+            ?? new();
+
+        var oopModulePaths = payload["oopModulePaths"]?.AsArray()
+            ?.Select(n => n?.GetValue<string>())
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .Cast<string>()
+            .Select(NormalizePath)
+            .ToList()
+            ?? new();
+
+        if (!configuredModulePaths.Contains(normalizedExpected))
+        {
+            return false;
+        }
+
+        return oopModulePaths.Contains(normalizedExpected);
+    }
+
+    private static string NormalizePath(string path)
+    {
+        return path.Trim().Replace('\\', '/').TrimEnd('/').ToLowerInvariant();
+    }
+
     private sealed class TemporaryConfigFile : IDisposable
     {
         public string Path { get; }
 
-        public TemporaryConfigFile()
+        public TemporaryConfigFile(string? runtimeMode = null, string[]? modulePaths = null)
         {
             Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"poshmcp-transport-tests-{Guid.NewGuid():N}.json");
 
-            var json = @"{
-  ""PowerShellConfiguration"": {
+            var runtimeModeJson = string.IsNullOrWhiteSpace(runtimeMode)
+                ? string.Empty
+                : $",\n    \"RuntimeMode\": \"{runtimeMode}\"";
+
+            var modulePathEntries = (modulePaths ?? Array.Empty<string>())
+                .Select(p => $"\"{p.Replace("\\", "\\\\")}\"")
+                .ToArray();
+            var modulePathsJson = string.Join(", ", modulePathEntries);
+
+            var json = $@"{{
+  ""PowerShellConfiguration"": {{
     ""FunctionNames"": [""Get-Date""],
     ""Modules"": [],
     ""ExcludePatterns"": [],
-    ""IncludePatterns"": []
-  }
-}";
+    ""IncludePatterns"": []{runtimeModeJson},
+    ""Environment"": {{
+      ""ModulePaths"": [{modulePathsJson}]
+    }}
+  }}
+}}";
 
             File.WriteAllText(Path, json);
         }
@@ -148,6 +239,25 @@ public class ProgramTransportSelectionTests
             if (File.Exists(Path))
             {
                 File.Delete(Path);
+            }
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public string Path { get; }
+
+        public TemporaryDirectory(string namePrefix)
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"{namePrefix}-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ Install modules from PowerShell Gallery at startup:
 }
 ```
 
+Notes:
+- `TrustPSGallery` defaults to `false` and must be explicitly enabled if you want automatic PSGallery trust.
+- `SetupTimeoutSeconds` defaults to `120` and applies to out-of-process setup initialization.
+
 ### Custom Module Paths
 
 Load modules from local directories or mounted volumes:

--- a/docs/ENVIRONMENT-CUSTOMIZATION-SUMMARY.md
+++ b/docs/ENVIRONMENT-CUSTOMIZATION-SUMMARY.md
@@ -13,6 +13,8 @@ PoshMcp supports comprehensive environment customization through `appsettings.js
 
 All configuration is declarative and happens during PowerShell runspace initialization.
 
+Defaults: `TrustPSGallery` is `false` (opt-in) and `SetupTimeoutSeconds` is `120` for out-of-process setup.
+
 ## Feature Files Overview
 
 | Category | Files | Description |
@@ -238,6 +240,7 @@ docker logs <container-id> | grep -i "environment"
 ### Startup timeout exceeds container readiness probe
 
 - Reduce `InstallTimeoutSeconds` in configuration (default: 300s)
+- Increase `SetupTimeoutSeconds` when using out-of-process runtime and heavy setup steps
 - Pre-install modules at build time instead of runtime
 - Optimize startup script (remove unnecessary operations)
 

--- a/docs/ENVIRONMENT-CUSTOMIZATION.md
+++ b/docs/ENVIRONMENT-CUSTOMIZATION.md
@@ -32,9 +32,10 @@ All customization is configured through the `Environment` section in `appsetting
       "ModulePaths": [],
       "StartupScript": "",
       "StartupScriptPath": "",
-      "TrustPSGallery": true,
+      "TrustPSGallery": false,
       "AllowClobber": false,
-      "InstallTimeoutSeconds": 300
+      "InstallTimeoutSeconds": 300,
+      "SetupTimeoutSeconds": 120
     }
   }
 }
@@ -49,9 +50,10 @@ All customization is configured through the `Environment` section in `appsetting
 | `ModulePaths` | Array | Additional paths to add to `$env:PSModulePath` | `[]` |
 | `StartupScript` | String | Inline PowerShell script to execute | `null` |
 | `StartupScriptPath` | String | Path to PowerShell script file | `null` |
-| `TrustPSGallery` | Boolean | Automatically trust PSGallery | `true` |
+| `TrustPSGallery` | Boolean | Automatically trust PSGallery | `false` |
 | `AllowClobber` | Boolean | Allow module imports to overwrite existing commands | `false` |
 | `InstallTimeoutSeconds` | Integer | Timeout for module installation operations | `300` |
+| `SetupTimeoutSeconds` | Integer | Timeout for out-of-process setup request (module imports/startup scripts) | `120` |
 
 ---
 

--- a/docs/entra-id-auth-guide.md
+++ b/docs/entra-id-auth-guide.md
@@ -1,0 +1,1065 @@
+# PoshMcp Entra ID Authentication Guide
+
+**Secure your MCP server with Entra ID single sign-on and token-based access control.**
+
+This guide walks you through configuring PoshMcp to authenticate and authorize incoming requests using Azure Entra ID (formerly Azure Active Directory), implementing OAuth 2.1 with automatic client discovery via RFC 8414. Whether you're deploying on-premises, in a hybrid environment, or in Azure, we cover two complementary authentication paths.
+
+---
+
+## Table of Contents
+
+1. [Why Entra ID?](#why-entra-id)
+2. [Choosing Your Authentication Path](#choosing-your-authentication-path)
+3. [Path A: App Registration (General Purpose)](#path-a-app-registration-general-purpose)
+4. [Path B: Managed Identity (Azure-Hosted Deployments)](#path-b-managed-identity-azure-hosted-deployments)
+5. [Best Practice: Combining Both](#best-practice-combining-both)
+6. [Token Validation & Security](#token-validation--security)
+7. [Troubleshooting](#troubleshooting)
+
+---
+
+## Why Entra ID?
+
+Use Entra ID authentication when:
+
+- **Multi-user deployments** — HTTP mode with per-user isolation and audit trails
+- **Enterprise environments** — integrate with existing Azure AD/Microsoft 365 tenants
+- **Shared infrastructure** — prevent unauthorized access to sensitive PowerShell commands
+- **Compliance requirements** — token-based auth with signing key validation
+- **Automatic client discovery** — clients automatically fetch auth metadata without manual config
+
+PoshMcp implements OAuth 2.1 (RFC 8414) so MCP clients can discover auth requirements automatically:
+
+1. Client requests a resource → server responds `401 Unauthorized` + metadata URL
+2. Client fetches OAuth metadata from the server
+3. Client redirects user to Entra ID to authenticate
+4. User logs in and grants consent
+5. Client gets a token and makes authenticated requests
+6. PoshMcp validates the token (signature, issuer, audience) and allows access
+
+---
+
+## Choosing Your Authentication Path
+
+Two complementary approaches are available. Many production deployments use **both**.
+
+### Quick Comparison
+
+| Aspect | App Registration | Managed Identity | Best For |
+|--------|------------------|------------------|----------|
+| **Defines OAuth scopes?** | ✓ Yes (required) | ✗ No | OAuth API definition |
+| **Provides server credentials?** | ✓ Yes (client secret) | ✓ Yes (automatic) | Server calling Azure APIs |
+| **Setup complexity** | Medium (portal steps) | Low (enable on resource) | Ease of deployment |
+| **Secret rotation burden?** | High (manual) | None (automatic) | Reduced ops overhead |
+| **Works on-premises?** | ✓ Yes | ✗ No (requires Azure compute) | Non-Azure deployments |
+| **Works in Azure Container Apps/AKS?** | ✓ Yes | ✓ Yes | Azure-native deployments |
+
+### Decision Matrix
+
+- **On-premises or hybrid (non-Azure VMs, containers)**: Use **App Registration only**
+- **Azure Container Apps, AKS, or App Service**: Use **Managed Identity for server credentials** + **App Registration for OAuth scopes** (recommended)
+- **Simple testing or single-client access**: Use **App Registration only**
+- **Enterprise with audit/compliance requirements**: Use **both** for maximum flexibility and auditability
+
+---
+
+## Path A: App Registration (General Purpose)
+
+Use this path to define OAuth scopes and issue access tokens for clients. Works anywhere (on-premises, hybrid, cloud).
+
+### Prerequisites
+
+**Before starting:**
+
+- **Azure subscription** with Entra ID tenant (most Microsoft enterprise customers have this)
+- **Global Administrator or Application Administrator role** in your Entra ID tenant (to create app registrations)
+- **PoshMcp 1.1+** (includes JWT Bearer authentication support)
+- **HTTP mode deployment** (Entra ID auth works best with HTTP; stdio mode is single-connection, so less useful for multi-user scenarios)
+- **HTTPS URL for your PoshMcp server** (Entra ID requires token validation over HTTPS; HTTP is allowed only for local testing with `RequireHttpsMetadata: false`)
+
+**Optional but recommended:**
+
+- **Azure CLI** or **Microsoft Graph PowerShell** for app registration scripting
+- **curl** or **Postman** for testing token endpoints
+- **VS Code REST Client** for manual token acquisition
+
+### Setup in Azure Portal
+
+#### Step 1: Create the App Registration
+
+1. Go to [Azure Portal](https://portal.azure.com) → **Azure Active Directory** → **App registrations**
+2. Click **New registration**
+3. Fill in:
+   - **Name:** `PoshMcp Server` (or your app name)
+   - **Supported account types:** `Accounts in this organizational directory only` (single tenant) or `Accounts in any organizational directory` (multi-tenant)
+   - **Redirect URI:** Leave blank for now; not needed for server-to-server auth
+4. Click **Register**
+
+You now have:
+- **Application (client) ID** — copy this, you'll need it later
+- **Directory (tenant) ID** — copy this, you'll need it later
+- **Application ID URI** — auto-generated as `api://{client-id}`, customize if desired
+
+#### Step 2: Expose API Scopes
+
+Scopes define what permissions clients can request. Create at least one scope that clients will use:
+
+1. In the app registration, go to **Expose an API**
+2. Next to "Application ID URI," click **Set** (if not already set)
+3. Accept the default `api://{client-id}` or enter a custom URI like `api://poshmcp-prod`
+4. Click **Add a scope**
+5. Fill in:
+   - **Scope name:** `access_as_server` (or `read`, `write`, etc.)
+   - **Admin consent display name:** `Access PoshMcp Server`
+   - **Admin consent description:** `Allows authenticated users to execute PowerShell commands via PoshMcp`
+   - **User consent display name:** `Access PoshMcp Server`
+   - **User consent description:** `Allows you to execute PowerShell commands via PoshMcp`
+   - **State:** `Enabled`
+6. Click **Add scope**
+
+Now the scope URI is `api://poshmcp-prod/access_as_server` (or whatever you named it).
+
+#### Step 3: Create Credentials for M2M (Server-to-Server)
+
+If PoshMcp needs to act on behalf of itself (not just validate user tokens), create a client secret:
+
+1. Go to **Certificates & secrets**
+2. Click **New client secret**
+3. Set **Expires:** `24 months` or per your policy
+4. Click **Add**
+5. **Copy the secret value immediately** — you won't see it again
+6. Store it securely in your server's environment or key vault (e.g., Azure Key Vault)
+
+#### Step 4: API Permissions (Optional)
+
+If PoshMcp needs to call Azure APIs (e.g., via PowerShell `Connect-AzAccount`), grant API permissions:
+
+1. Go to **API permissions**
+2. Click **Add a permission**
+3. Select **Microsoft APIs** → **Microsoft Graph** (or the Azure service you need)
+4. Choose **Delegated permissions** or **Application permissions** as needed
+5. Search for and select permissions (e.g., `User.Read`, `AzureServiceManagement/user_impersonation`)
+6. Click **Add permissions**
+7. If you added **Application permissions**, click **Grant admin consent** (only admins can do this)
+
+### Configuration
+
+#### Edit `appsettings.json`
+
+Authentication configuration goes in the `Authentication` section of your PoshMcp config file. Here's a complete example:
+
+```json
+{
+  "Authentication": {
+    "Enabled": true,
+    "DefaultScheme": "Bearer",
+    "DefaultPolicy": {
+      "RequireAuthentication": true,
+      "RequiredScopes": ["api://poshmcp-prod/access_as_server"],
+      "RequiredRoles": []
+    },
+    "Schemes": {
+      "Bearer": {
+        "Type": "JwtBearer",
+        "Authority": "https://login.microsoftonline.com/{tenant-id}",
+        "Audience": "api://poshmcp-prod",
+        "RequireHttpsMetadata": true,
+        "ValidIssuers": ["https://login.microsoftonline.com/{tenant-id}/v2.0"],
+        "ClaimsMapping": {
+          "ScopeClaim": "scp",
+          "RoleClaim": "roles"
+        }
+      }
+    },
+    "ProtectedResource": {
+      "Resource": "api://poshmcp-prod",
+      "ResourceName": "PoshMcp Server",
+      "AuthorizationServers": ["https://login.microsoftonline.com/{tenant-id}"],
+      "ScopesSupported": ["api://poshmcp-prod/access_as_server"],
+      "BearerMethodsSupported": ["header"]
+    },
+    "Cors": {
+      "AllowedOrigins": ["http://localhost:3000"],
+      "AllowCredentials": false
+    }
+  },
+  "PowerShellConfiguration": {
+    "CommandNames": ["Get-Process", "Get-Service"]
+  }
+}
+```
+
+#### Replace Placeholders
+
+Update these values with your Azure AD app info:
+
+| Placeholder | Value | Example |
+|-------------|-------|---------|
+| `{tenant-id}` | Directory (tenant) ID from app registration | `12345678-1234-1234-1234-123456789012` |
+| `Authority` | Entra ID token endpoint | `https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012` |
+| `Audience` | App ID URI from "Expose an API" | `api://poshmcp-prod` |
+| `ValidIssuers[0]` | Entra ID issuer URL | `https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0` |
+| `Resource` | Same as Audience | `api://poshmcp-prod` |
+| `AuthorizationServers[0]` | Same as Authority | `https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012` |
+
+#### Production Configuration
+
+For production deployments on Azure Container Apps or AKS:
+
+**Use environment variables to store sensitive values:**
+
+```bash
+# Store in Azure Key Vault or Container Apps secrets
+AUTHENTICATION__SCHEMES__BEARER__AUTHORITY=https://login.microsoftonline.com/{tenant-id}
+AUTHENTICATION__SCHEMES__BEARER__AUDIENCE=api://poshmcp-prod
+AUTHENTICATION__SCHEMES__BEARER__VALIDISSUERS__0=https://login.microsoftonline.com/{tenant-id}/v2.0
+```
+
+Then update `appsettings.json` to reference them:
+
+```json
+{
+  "Authentication": {
+    "Schemes": {
+      "Bearer": {
+        "Authority": "${AUTHENTICATION__SCHEMES__BEARER__AUTHORITY}",
+        "Audience": "${AUTHENTICATION__SCHEMES__BEARER__AUDIENCE}"
+      }
+    }
+  }
+}
+```
+
+### Testing
+
+Have these values ready:
+
+- **Tenant ID**: `12345678-1234-1234-1234-123456789012`
+- **Client ID**: `87654321-4321-4321-4321-210987654321`
+- **Client Secret** (if M2M testing): `your-secret-value`
+- **Scope**: `api://poshmcp-prod/access_as_server`
+- **PoshMcp URL**: `https://poshmcp.example.com` or `https://localhost:8080`
+
+#### Test 1: Check Protected Resource Metadata
+
+Verify your server publishes auth metadata correctly:
+
+```bash
+curl https://poshmcp.example.com/.well-known/oauth-protected-resource
+```
+
+Expected response:
+
+```json
+{
+  "resource": "api://poshmcp-prod",
+  "resource_name": "PoshMcp Server",
+  "authorization_servers": ["https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012"],
+  "scopes_supported": ["api://poshmcp-prod/access_as_server"],
+  "bearer_methods_supported": ["header"]
+}
+```
+
+#### Test 2: Acquire a Token (M2M)
+
+If you created a client secret, test server-to-server authentication:
+
+```bash
+curl -X POST \
+  https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "client_id=87654321-4321-4321-4321-210987654321" \
+  -d "client_secret=your-secret-value" \
+  -d "scope=api://poshmcp-prod/.default" \
+  -d "grant_type=client_credentials"
+```
+
+Response:
+
+```json
+{
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "access_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjEyMzQ1Njc4OTBhYmNkZWYifQ.eyJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vMTIzNDU2Nzg4OTAxMi92Mi4wIiwiYXVkIjoiYXBpOi8vcG9zaC1tY3AtcHJvZCIsInN1YiI6IjEyMzQ1Njc4OTAiLCJpYXQiOjE3MTAwMDAwMDAsImV4cCI6MTcxMDAwMzYwMH0.example_signature"
+}
+```
+
+#### Test 3: Make Authenticated Request
+
+Use the token to call PoshMcp:
+
+```bash
+curl -H "Authorization: Bearer eyJhbGc..." \
+  https://poshmcp.example.com/tools
+```
+
+Expected response: list of available tools (if token is valid).
+
+Without the token or with an invalid token:
+
+```bash
+curl https://poshmcp.example.com/tools
+```
+
+Response:
+
+```
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer resource_metadata="https://poshmcp.example.com/.well-known/oauth-protected-resource"
+```
+
+#### Test 4: Check Server Health
+
+Verify authentication is configured correctly:
+
+```bash
+curl https://poshmcp.example.com/health
+```
+
+If authentication config is invalid, you'll see errors in the response or in server logs. Valid output indicates auth is running.
+
+---
+
+## Path B: Managed Identity (Azure-Hosted Deployments)
+
+Use managed identity when PoshMcp runs on Azure-hosted compute (Container Apps, AKS, App Service, Azure VMs) and needs to call other Azure services with its own identity. Managed identity eliminates the need for secret management on the server side, but **does not replace the app registration** for OAuth API definition.
+
+### Prerequisites
+
+**Before starting:**
+
+- **PoshMcp 1.1+** (includes JWT Bearer authentication support)
+- **Azure-hosted compute resource** with managed identity support:
+  - Azure Container Apps
+  - Azure Kubernetes Service (AKS)
+  - Azure App Service
+  - Azure Virtual Machines
+  - Azure Logic Apps
+- **HTTP mode deployment** (same as app registration path)
+- **HTTPS URL for your PoshMcp server** (same as app registration path)
+- **App registration still required** (for OAuth scopes and client discovery)
+
+### Infrastructure Setup
+
+Enable managed identity on your Azure compute resource. Here are examples for common scenarios:
+
+#### Azure Container Apps (Azure CLI)
+
+```bash
+# Create container app with managed identity
+az containerapp create \
+  --name poshmcp \
+  --resource-group MyResourceGroup \
+  --image myregistry.azurecr.io/poshmcp:latest \
+  --system-assigned  # Enable system-assigned managed identity
+```
+
+Or, if creating via Bicep:
+
+```bicep
+param location string = resourceGroup().location
+param containerAppName string = 'poshmcp'
+
+resource containerApp 'Microsoft.App/containerApps@2023-05-01' = {
+  name: containerAppName
+  location: location
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    managedEnvironmentId: managedEnv.id
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 8080
+      }
+    }
+    template: {
+      containers: [
+        {
+          name: 'poshmcp'
+          image: 'myregistry.azurecr.io/poshmcp:latest'
+          env: [
+            {
+              name: 'AUTHENTICATION__ENABLED'
+              value: 'true'
+            }
+            {
+              name: 'AUTHENTICATION__SCHEMES__BEARER__AUTHORITY'
+              value: 'https://login.microsoftonline.com/${tenant().tenantId}'
+            }
+            {
+              name: 'AUTHENTICATION__SCHEMES__BEARER__AUDIENCE'
+              value: 'api://poshmcp-prod'
+            }
+          ]
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+        }
+      ]
+    }
+  }
+}
+
+output principalId string = containerApp.identity.principalId
+```
+
+After deployment, note the **principal ID** — you'll use it to grant permissions.
+
+#### Azure Kubernetes Service (AKS) with Workload Identity
+
+AKS pods can use workload identity as an alternative to managed identity:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: poshmcp
+  namespace: default
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: poshmcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: poshmcp
+  template:
+    metadata:
+      labels:
+        app: poshmcp
+    spec:
+      serviceAccountName: poshmcp
+      containers:
+      - name: poshmcp
+        image: myregistry.azurecr.io/poshmcp:latest
+        ports:
+        - containerPort: 8080
+        env:
+        - name: AUTHENTICATION__ENABLED
+          value: "true"
+        - name: AUTHENTICATION__SCHEMES__BEARER__AUTHORITY
+          value: "https://login.microsoftonline.com/$(TENANT_ID)"
+        - name: AUTHENTICATION__SCHEMES__BEARER__AUDIENCE
+          value: "api://poshmcp-prod"
+```
+
+For workload identity, link the Kubernetes ServiceAccount to an Entra ID app registration:
+
+```bash
+az aks workload-identity association create \
+  --resource-group MyResourceGroup \
+  --cluster-name MyAksCluster \
+  --namespace default \
+  --service-account-name poshmcp \
+  --identity-resource-id /subscriptions/{subscription-id}/resourceGroups/{rg}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/poshmcp
+```
+
+### What Managed Identity Does NOT Replace
+
+**App registration is still required** for:
+
+- **OAuth scope definition** — clients need to know what scopes are available
+- **Client discovery** — the `/.well-known/oauth-protected-resource` endpoint publishes the app registration's scopes
+- **Token validation configuration** — PoshMcp still needs to know the `Audience` and `ValidIssuers` from your app registration
+
+Managed identity **only** provides the server's own credentials for calling other Azure services.
+
+### Using Managed Identity for Server-Side Azure Credentials
+
+If PoshMcp needs to call Azure APIs (e.g., Key Vault, Storage, Azure CLI), use managed identity instead of storing secrets:
+
+#### Example: PoshMcp Calling Azure Key Vault
+
+**Without managed identity (old way, not recommended):**
+
+```json
+{
+  "KeyVault": {
+    "ClientId": "87654321-4321-4321-4321-210987654321",
+    "ClientSecret": "your-secret-value",
+    "TenantId": "12345678-1234-1234-1234-123456789012",
+    "VaultUri": "https://mykeyvault.vault.azure.net"
+  }
+}
+```
+
+**With managed identity (recommended):**
+
+```json
+{
+  "KeyVault": {
+    "VaultUri": "https://mykeyvault.vault.azure.net",
+    "UseManagedIdentity": true
+  }
+}
+```
+
+In PowerShell code, use the Azure SDK with managed identity:
+
+```powershell
+# Azure SDK automatically uses managed identity when running in Azure
+$credential = New-Object Azure.Identity.DefaultAzureCredential
+$client = New-Object Azure.Security.KeyVault.Secrets.SecretClient -ArgumentList @("https://mykeyvault.vault.azure.net", $credential)
+$secret = $client.GetSecret("my-secret")
+```
+
+#### Grant Managed Identity Permissions
+
+After enabling managed identity on your compute resource, grant it access to the resources it needs:
+
+```bash
+# Get the managed identity's principal ID
+principalId="12345678-1234-1234-1234-123456789012"
+
+# Grant access to Key Vault
+az keyvault set-policy \
+  --name mykeyvault \
+  --object-id $principalId \
+  --secret-permissions get list
+
+# Or grant access to a storage account
+az role assignment create \
+  --assignee $principalId \
+  --role "Storage Blob Data Reader" \
+  --scope /subscriptions/{subscription}/resourceGroups/{rg}/providers/Microsoft.Storage/storageAccounts/mystorageacct
+```
+
+### Configuration
+
+The configuration is identical to app registration; the difference is where credentials come from:
+
+```json
+{
+  "Authentication": {
+    "Enabled": true,
+    "DefaultScheme": "Bearer",
+    "DefaultPolicy": {
+      "RequireAuthentication": true,
+      "RequiredScopes": ["api://poshmcp-prod/access_as_server"],
+      "RequiredRoles": []
+    },
+    "Schemes": {
+      "Bearer": {
+        "Type": "JwtBearer",
+        "Authority": "https://login.microsoftonline.com/{tenant-id}",
+        "Audience": "api://poshmcp-prod",
+        "RequireHttpsMetadata": true,
+        "ValidIssuers": ["https://login.microsoftonline.com/{tenant-id}/v2.0"],
+        "ClaimsMapping": {
+          "ScopeClaim": "scp",
+          "RoleClaim": "roles"
+        }
+      }
+    },
+    "ProtectedResource": {
+      "Resource": "api://poshmcp-prod",
+      "ResourceName": "PoshMcp Server",
+      "AuthorizationServers": ["https://login.microsoftonline.com/{tenant-id}"],
+      "ScopesSupported": ["api://poshmcp-prod/access_as_server"],
+      "BearerMethodsSupported": ["header"]
+    },
+    "Cors": {
+      "AllowedOrigins": ["http://localhost:3000"],
+      "AllowCredentials": false
+    }
+  },
+  "PowerShellConfiguration": {
+    "CommandNames": ["Get-Process", "Get-Service"]
+  }
+}
+```
+
+**Key difference:** You don't need to store or rotate client secrets. The Azure compute platform provides credentials transparently.
+
+### Testing
+
+#### Test 1: Verify Managed Identity is Active
+
+```bash
+# From inside the container or VM, query the Azure Instance Metadata Service (IMDS)
+curl http://169.254.169.254/metadata/identity/oauth2/token?api-version=2017-12-01&resource=https://management.azure.com \
+  -H "Metadata:true" | jq .
+```
+
+You should see a token with claims pointing to your managed identity.
+
+#### Test 2: Verify Key Vault Access
+
+If PoshMcp accesses Key Vault via managed identity:
+
+```powershell
+# In a PoshMcp PowerShell script
+$credential = New-Object Azure.Identity.DefaultAzureCredential
+$client = New-Object Azure.Security.KeyVault.Secrets.SecretClient -ArgumentList @("https://mykeyvault.vault.azure.net", $credential)
+$secret = $client.GetSecret("my-secret")
+Write-Host "Retrieved secret: $($secret.Value)"
+```
+
+If this works, managed identity is properly configured.
+
+#### Test 3: OAuth Flow (Same as App Registration Path)
+
+Client authentication flow is identical. Clients still acquire tokens via app registration and send them to PoshMcp. See [Path A Testing](#testing) for details.
+
+---
+
+## Best Practice: Combining Both
+
+**Recommended for production Azure deployments:** Use managed identity for server credentials + app registration for OAuth API definition.
+
+### Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ MCP Client (e.g., Claude.dev, external app)                 │
+│ - Acquires token via app registration                        │
+│ - Sends token in Authorization header                        │
+└──────────────────────┬──────────────────────────────────────┘
+                       │ HTTP request + Bearer token
+                       ▼
+┌─────────────────────────────────────────────────────────────┐
+│ PoshMcp Server (Azure Container Apps / AKS)                │
+│                                                              │
+│ ┌──────────────────────────────────────────────────────┐   │
+│ │ Token Validation (App Registration)                 │   │
+│ │ - Validates client's token signature                │   │
+│ │ - Checks audience: api://poshmcp-prod               │   │
+│ │ - Checks scopes: api://poshmcp-prod/access_as_server│   │
+│ └──────────────────────────────────────────────────────┘   │
+│                       │                                      │
+│                       ▼ (if token is valid)                 │
+│ ┌──────────────────────────────────────────────────────┐   │
+│ │ PowerShell Execution                                 │   │
+│ │ - Runs command with client's user context           │   │
+│ │ - If needs Azure services...                         │   │
+│ │   └─> Uses managed identity for service credentials │   │
+│ └──────────────────────────────────────────────────────┘   │
+│                       │                                      │
+│ ┌──────────────────────────────────────────────────────┐   │
+│ │ Azure Service Calls (Managed Identity)               │   │
+│ │ - Accesses Key Vault, Storage, etc.                 │   │
+│ │ - Uses server's managed identity (no secrets!)       │   │
+│ └──────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+                       │
+                       ▼
+            Azure services (Key Vault, Storage, etc.)
+```
+
+### Setup Steps
+
+1. **Create app registration** (see [Path A](#path-a-app-registration-general-purpose)) to define OAuth scopes
+2. **Enable managed identity** on your Azure compute resource (see [Infrastructure Setup](#infrastructure-setup))
+3. **Grant managed identity permissions** to Azure services it needs (see [Grant Managed Identity Permissions](#grant-managed-identity-permissions))
+4. **Configure PoshMcp** with app registration details (same `appsettings.json` for both paths)
+5. **Update PowerShell code** to use managed identity for Azure service calls (see [Using Managed Identity for Server-Side Azure Credentials](#using-managed-identity-for-server-side-azure-credentials))
+
+### Benefits
+
+- **No secret management for the server** — managed identity handles rotation automatically
+- **Audit trail for server actions** — Azure logs show which managed identity accessed which service
+- **OAuth still works** — clients still authenticate via app registration; the server's internal calls use managed identity
+- **Least privilege** — the server has only the permissions it needs, via managed identity role assignments
+
+---
+
+## Token Validation & Security
+
+### How Token Validation Works
+
+PoshMcp's JWT validation pipeline is scheme-agnostic — it works the same way regardless of whether tokens come from app registration or managed identity. For each request with a token:
+
+1. Extract token from `Authorization: Bearer {token}` header
+2. Validate signature using Entra ID's public keys
+3. Check issuer matches `ValidIssuers`
+4. Check audience matches `Audience`
+5. Check expiration
+6. Extract scopes from `scp` claim
+7. Verify required scopes are present (from `DefaultPolicy.RequiredScopes`)
+8. Allow or deny the request
+
+### Client Authentication Flow
+
+#### Automatic Discovery (Recommended)
+
+When authentication is enabled, MCP clients discover auth requirements automatically. Here's the flow:
+
+##### 1. Client requests a resource
+
+```http
+GET /tools HTTP/1.1
+Host: poshmcp.example.com
+```
+
+##### 2. Server responds with metadata URL
+
+```http
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer resource_metadata="https://poshmcp.example.com/.well-known/oauth-protected-resource"
+```
+
+##### 3. Client fetches protected resource metadata
+
+```http
+GET /.well-known/oauth-protected-resource HTTP/1.1
+Host: poshmcp.example.com
+```
+
+Server responds:
+
+```json
+{
+  "resource": "api://poshmcp-prod",
+  "resource_name": "PoshMcp Server",
+  "authorization_servers": [
+    "https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012"
+  ],
+  "scopes_supported": [
+    "api://poshmcp-prod/access_as_server"
+  ],
+  "bearer_methods_supported": ["header"]
+}
+```
+
+##### 4. Client fetches OAuth authorization server metadata
+
+Client fetches RFC 8414 metadata from the authorization server:
+
+```http
+GET /.well-known/oauth-authorization-server HTTP/1.1
+Host: login.microsoftonline.com
+```
+
+Entra ID responds:
+
+```json
+{
+  "token_endpoint": "https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token",
+  "authorization_endpoint": "https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/authorize",
+  "code_challenge_methods_supported": ["S256"],
+  "scopes_supported": ["openid", "profile", "email"]
+}
+```
+
+##### 5. Client runs OAuth 2.1 PKCE flow
+
+- **Authorization Code flow**: Client redirects user to Entra ID login
+- **PKCE (Proof Key for Code Exchange)**: Client generates code verifier and challenge for security
+- **Token acquisition**: User authenticates and grants consent; client receives access token
+- **Authenticated requests**: Client includes token in `Authorization: Bearer {token}` header
+
+##### 6. PoshMcp validates the token
+
+Validation happens automatically (see "How Token Validation Works" above).
+
+### Security Best Practices
+
+#### 1. Use HTTPS in Production
+
+Always use HTTPS for the PoshMcp server URL in production. Token validation requires HTTPS, and Entra ID will reject HTTP requests.
+
+```bash
+# Production: Use HTTPS
+poshmcp serve --transport http --port 443 --config ./appsettings.prod.json
+
+# Or use a reverse proxy (nginx, API Gateway) to handle SSL/TLS
+```
+
+#### 2. Scope Design: Least Privilege
+
+Define scopes that map to PowerShell tool groups, not "admin" or "full access":
+
+```json
+{
+  "Authentication": {
+    "DefaultPolicy": {
+      "RequiredScopes": [
+        "api://poshmcp-prod/read.diagnostics",
+        "api://poshmcp-prod/execute.storage"
+      ]
+    }
+  }
+}
+```
+
+In Entra ID, create granular scopes:
+
+| Scope | Tools Allowed | Example |
+|-------|---------------|---------|
+| `read.diagnostics` | `Get-Process`, `Get-Service`, `Get-Disk` | View-only monitoring |
+| `execute.storage` | `New-StorageAccount`, `Set-StorageBlob` | Storage operations |
+| `execute.compute` | `Start-VM`, `Stop-VM`, `Restart-VM` | VM management |
+
+#### 3. Token Validation
+
+PoshMcp validates tokens by:
+
+- ✓ Checking signature (verifies token wasn't tampered with)
+- ✓ Checking issuer (ensures token came from your Entra ID)
+- ✓ Checking audience (ensures token is for your app)
+- ✓ Checking expiration (token must be fresh)
+- ✓ Checking scopes (user has required permissions)
+
+The server fetches Entra ID's public keys automatically, so signatures are always validated correctly.
+
+#### 4. Deny Dangerous Commands
+
+Combine Entra ID auth with command allowlists to prevent misuse:
+
+```json
+{
+  "Authentication": {
+    "DefaultPolicy": {
+      "RequiredScopes": ["api://poshmcp-prod/execute.diagnostics"]
+    }
+  },
+  "PowerShellConfiguration": {
+    "CommandNames": [
+      "Get-Process",
+      "Get-Service",
+      "Get-EventLog"
+    ],
+    "ExcludePatterns": [
+      "Remove-*",
+      "*-Credential",
+      "Invoke-Expression"
+    ]
+  }
+}
+```
+
+#### 5. Audit and Monitoring
+
+Use PoshMcp's built-in correlation IDs to audit who ran what:
+
+```bash
+# Enable structured logging
+export POSHMCP_LOG_LEVEL=Information
+
+# Log includes:
+# - Request headers (Authorization token hash, User-Agent)
+# - User claims (from token)
+# - Command executed
+# - Correlation ID (trace requests across your system)
+```
+
+Example log output:
+
+```
+info: PoshMcp.Server[1001]
+      User 'john@contoso.com' (oid=12345) executed Get-Process via API
+      Correlation ID: 550e8400-e29b-41d4-a716-446655440000
+      Scopes: api://poshmcp-prod/read.diagnostics
+```
+
+#### 6. Credentials in Environment
+
+Never embed secrets in `appsettings.json`. Use Azure Key Vault or Container Apps secrets:
+
+```bash
+# Store in Key Vault
+az keyvault secret set --vault-name MyKeyVault --name poshmcp-client-secret --value "..."
+
+# Reference in Container Apps
+az containerapp secret set --name poshmcp --secrets client-secret=keyvaultref:MyKeyVault/poshmcp-client-secret
+
+# Use in deployment
+AUTHENTICATION__SCHEMES__BEARER__AUTHORITY=...
+```
+
+#### 7. Regular Token Rotation
+
+Entra ID automatically rotates its signing keys. PoshMcp fetches new keys transparently, so no action needed. But for client secrets (app registration path only):
+
+- Rotate every 12–24 months (or per your policy)
+- Create a new secret before deleting the old one (for zero-downtime rotation)
+- Disable old secrets in Entra ID once clients have migrated
+
+Managed identity has no secrets to rotate.
+
+---
+
+## Troubleshooting
+
+### App Registration Issues
+
+#### Issue: `401 Unauthorized` on every request
+
+**Check:**
+
+1. Is `Authentication.Enabled` set to `true` in `appsettings.json`?
+2. Is the token in the request? Add the `Authorization: Bearer {token}` header.
+3. Is the token expired? Check the token's `exp` claim:
+   ```bash
+   # Decode token at https://jwt.io (for testing only!)
+   ```
+
+#### Issue: Invalid token signature
+
+**Check:**
+
+1. Did you acquire the token from the correct Entra ID tenant? Token issuer must match `ValidIssuers`.
+2. Is the server URL HTTPS? (Entra ID won't issue tokens for HTTP except localhost with `RequireHttpsMetadata: false`)
+3. Are the token's `iss`, `aud`, and `scp` claims correct? Decode at jwt.io to inspect.
+
+#### Issue: Insufficient permissions / scope mismatch
+
+**Error in logs:**
+
+```
+The claim 'scp' does not contain any of the required values (the claim value was 'xxx').
+```
+
+**Fix:**
+
+1. Verify the token includes the required scope. Decode the token and check the `scp` claim.
+2. In Entra ID, verify the app registration has the scope defined in "Expose an API."
+3. Verify the client requested the correct scope when acquiring the token (e.g., `scope=api://poshmcp-prod/access_as_server`).
+4. In `appsettings.json`, check `DefaultPolicy.RequiredScopes` matches what you're testing.
+
+#### Issue: `RequireHttpsMetadata` validation failure
+
+**Error:**
+
+```
+IDX20108: The address must use HTTPS, not HTTP.
+```
+
+**Fix for production:** Use HTTPS and set `RequireHttpsMetadata: true`.
+
+**For local testing only:**
+
+```json
+{
+  "Authentication": {
+    "Schemes": {
+      "Bearer": {
+        "RequireHttpsMetadata": false
+      }
+    }
+  }
+}
+```
+
+#### Issue: Server won't start due to auth config errors
+
+**Check logs:**
+
+```bash
+poshmcp serve --transport http --port 8080 --log-level debug
+```
+
+Look for validation errors like:
+
+```
+Authentication.Schemes[Bearer].Authority is required for JwtBearer.
+```
+
+**Fix:** Ensure all required fields are populated in `appsettings.json`:
+- `Authority` (Entra ID token endpoint)
+- `Audience` (App ID URI)
+- At least one item in `ValidIssuers`
+
+### Managed Identity Issues
+
+#### Issue: IMDS endpoint not found (`http://169.254.169.254/...`)
+
+**Symptoms:** PoshMcp can't access Key Vault or other Azure services despite having managed identity enabled.
+
+**Check:**
+
+1. Is your compute resource running in Azure (Container Apps, AKS, App Service)?
+2. Is managed identity enabled on the resource? Check:
+   ```bash
+   az containerapp identity show --name poshmcp --resource-group MyResourceGroup
+   ```
+3. Is there a proxy or network policy blocking access to IMDS (169.254.169.254)?
+
+**Fix:**
+
+- If using a proxy, configure it to allow IMDS access
+- If using network policies, add a rule allowing `169.254.169.254:80`
+- Verify managed identity is enabled (see [Infrastructure Setup](#infrastructure-setup))
+
+#### Issue: Access denied when calling Azure services
+
+**Symptoms:** PoshMcp can access IMDS but gets 403 Forbidden when calling Key Vault, Storage, etc.
+
+**Check:**
+
+1. Did you grant the managed identity permissions to that service? See [Grant Managed Identity Permissions](#grant-managed-identity-permissions).
+2. Is the principal ID correct?
+   ```bash
+   # Get the managed identity's principal ID
+   az containerapp identity show --name poshmcp --resource-group MyResourceGroup --query principalId
+   ```
+3. Is the role assignment correctly applied?
+   ```bash
+   az role assignment list --assignee {principal-id}
+   ```
+
+**Fix:** Grant the managed identity the appropriate role:
+
+```bash
+principalId="12345678-1234-1234-1234-123456789012"
+az role assignment create \
+  --assignee $principalId \
+  --role "Key Vault Secrets User" \
+  --scope /subscriptions/{subscription}/resourceGroups/{rg}/providers/Microsoft.KeyVault/vaults/mykeyvault
+```
+
+#### Issue: Token claims don't include expected identity
+
+**Symptoms:** Managed identity is working, but token `sub` or `oid` claims don't match your managed identity's principal ID.
+
+**Check:**
+
+1. Decode the IMDS token and inspect claims:
+   ```bash
+   curl http://169.254.169.254/metadata/identity/oauth2/token?api-version=2017-12-01&resource=https://management.azure.com -H "Metadata:true" | jq '.access_token' | cut -d. -f2 | base64 -d | jq .
+   ```
+2. Does the `sub` or `oid` claim match the managed identity's principal ID?
+
+**Fix:** Ensure managed identity is enabled on the correct resource. If you created a new resource, you may need to redeploy.
+
+#### Issue: Can't use Azure SDK with managed identity in PoshMcp
+
+**Symptoms:** PowerShell code using `New-Object Azure.Identity.DefaultAzureCredential` throws errors.
+
+**Check:**
+
+1. Is the Azure SDK installed in the PoshMcp container?
+   ```bash
+   pip list | grep azure
+   # or
+   Get-InstalledModule | grep Azure
+   ```
+2. Is the Azure SDK version recent (supports managed identity via IMDS)?
+
+**Fix:** Update or install the Azure SDK:
+
+```dockerfile
+# In your Dockerfile
+RUN pip install --upgrade azure-identity azure-keyvault-secrets
+# or for PowerShell
+RUN Install-Module -Name Az.Identity -Force
+```
+
+---
+
+## Next Steps
+
+1. **Decide on your path** — app registration only, managed identity + app registration, or both (see [Choosing Your Authentication Path](#choosing-your-authentication-path))
+2. **Set up app registration** (see [Path A](#path-a-app-registration-general-purpose))
+3. **If using Azure compute:** Enable managed identity and grant permissions (see [Path B](#path-b-managed-identity-azure-hosted-deployments))
+4. **Configure PoshMcp** with `appsettings.json` (see [Configuration](#configuration))
+5. **Test the auth flow** (see [Testing](#testing) in each path)
+6. **Deploy to production** with HTTPS and secrets in Key Vault (see [Production Configuration](#production-configuration))
+7. **Monitor and audit** using correlation IDs and structured logs (see [Audit and Monitoring](#5-audit-and-monitoring))
+
+For questions or issues, check [Troubleshooting](#troubleshooting) or open an issue on [GitHub](https://github.com/microsoft/poshmcp).


### PR DESCRIPTION
## Summary
- include resolved Environment.ModulePaths in doctor output for OOP scenarios
- add doctor JSON fields oopModulePathEntries and oopModulePaths
- add unit coverage for doctor JSON and transport-selection OOP diagnostics

## Validation
- dotnet test PoshMcp.Tests/PoshMcp.Tests.csproj --filter FullyQualifiedName~ProgramTests
- dotnet test PoshMcp.Tests/PoshMcp.Tests.csproj --filter FullyQualifiedName~ProgramTransportSelectionTests

Closes #97