### PR TITLE
Add runtime-aware configuration guidance MCP tool (#111)

### DIFF
--- a/PoshMcp.Server/PoshMcp.csproj
+++ b/PoshMcp.Server/PoshMcp.csproj
@@ -9,7 +9,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>poshmcp</ToolCommandName>
     <PackageId>poshmcp</PackageId>
-    <Version>0.5.3</Version>
+    <Version>0.5.4</Version>
     <Authors>Steven Murawski</Authors>
     <Description>A Model Context Protocol (MCP) server that exposes PowerShell commands and modules as AI-consumable tools.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/PoshMcp.Server/PowerShell/ConfigurationGuidanceTools.cs
+++ b/PoshMcp.Server/PowerShell/ConfigurationGuidanceTools.cs
@@ -1,0 +1,370 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using PoshMcp.Server.Authentication;
+
+namespace PoshMcp.Server.PowerShell;
+
+public class ConfigurationGuidanceTools
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private readonly string _configurationPath;
+    private readonly string _effectiveTransport;
+    private readonly string? _effectiveRuntimeMode;
+    private readonly string? _effectiveMcpPath;
+    private readonly ILogger<ConfigurationGuidanceTools> _logger;
+
+    public ConfigurationGuidanceTools(
+        string configurationPath,
+        string effectiveTransport,
+        string? effectiveRuntimeMode,
+        string? effectiveMcpPath,
+        ILogger<ConfigurationGuidanceTools> logger)
+    {
+        _configurationPath = configurationPath ?? throw new ArgumentNullException(nameof(configurationPath));
+        _effectiveTransport = effectiveTransport ?? throw new ArgumentNullException(nameof(effectiveTransport));
+        _effectiveRuntimeMode = effectiveRuntimeMode;
+        _effectiveMcpPath = effectiveMcpPath;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public Task<string> GetConfigurationGuidance(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            _logger.LogInformation("Processing configuration guidance request");
+
+            var rootConfiguration = new ConfigurationBuilder()
+                .AddJsonFile(_configurationPath, optional: false, reloadOnChange: false)
+                .Build();
+
+            var powerShellConfiguration = new PowerShellConfiguration();
+            rootConfiguration.GetSection("PowerShellConfiguration").Bind(powerShellConfiguration);
+
+            var authenticationConfiguration = new AuthenticationConfiguration();
+            rootConfiguration.GetSection("Authentication").Bind(authenticationConfiguration);
+
+            var sections = BuildSections(powerShellConfiguration, authenticationConfiguration);
+            var sources = sections
+                .SelectMany(section => section.References)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            return Task.FromResult(JsonSerializer.Serialize(new
+            {
+                success = true,
+                runtimeContext = new
+                {
+                    configurationPath = _configurationPath,
+                    transport = _effectiveTransport,
+                    runtimeMode = _effectiveRuntimeMode,
+                    mcpPath = _effectiveMcpPath,
+                    commandCount = powerShellConfiguration.GetEffectiveCommandNames().Count,
+                    moduleCount = powerShellConfiguration.Modules.Count,
+                    authenticationEnabled = authenticationConfiguration.Enabled,
+                    dynamicReloadToolsEnabled = powerShellConfiguration.EnableDynamicReloadTools,
+                    configurationTroubleshootingToolEnabled = powerShellConfiguration.EnableConfigurationTroubleshootingTool,
+                    environmentCustomizationConfigured = IsEnvironmentCustomizationConfigured(powerShellConfiguration)
+                },
+                runtimeHints = BuildRuntimeHints(powerShellConfiguration, authenticationConfiguration),
+                sections,
+                suggestedNextSteps = BuildSuggestedNextSteps(powerShellConfiguration, authenticationConfiguration),
+                sources
+            }, SerializerOptions));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error generating configuration guidance output");
+            return Task.FromResult(JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = $"Unexpected error: {ex.Message}"
+            }, SerializerOptions));
+        }
+    }
+
+    private string[] BuildRuntimeHints(PowerShellConfiguration powerShellConfiguration, AuthenticationConfiguration authenticationConfiguration)
+    {
+        var hints = new List<string>();
+
+        if (string.Equals(_effectiveTransport, "http", StringComparison.OrdinalIgnoreCase))
+        {
+            hints.Add(authenticationConfiguration.Enabled
+                ? "HTTP transport is active and authentication is enabled. Keep scopes, issuer settings, protected resource metadata, and CORS aligned with the deployment URL."
+                : "HTTP transport is active and authentication is disabled. Enable the Authentication section before exposing the server beyond a trusted local boundary.");
+        }
+        else
+        {
+            hints.Add("The server is currently running over stdio. Authentication settings are usually unnecessary for a local single-client connection, but they should be planned before switching to HTTP transport.");
+        }
+
+        if (string.Equals(_effectiveRuntimeMode, "OutOfProcess", StringComparison.OrdinalIgnoreCase))
+        {
+            hints.Add("PowerShell is running out of process, so module installation, module paths, and startup scripts are applied to the persistent subprocess host.");
+        }
+        else
+        {
+            hints.Add("PowerShell is running in process, so startup scripts and imported modules affect the shared server runspace directly.");
+        }
+
+        if (IsEnvironmentCustomizationConfigured(powerShellConfiguration))
+        {
+            hints.Add("Environment customization is already configured. Prefer additive updates so startup scripts, module paths, and module install or import settings stay consistent with the current runspace setup.");
+        }
+        else
+        {
+            hints.Add("Environment customization is not configured yet. Start with ImportModules for pre-installed modules, then add InstallModules or StartupScriptPath only where needed.");
+        }
+
+        if (powerShellConfiguration.EnableDynamicReloadTools)
+        {
+            hints.Add("Dynamic reload tools are enabled, so configuration changes can be reloaded without restarting the process after the underlying file is updated.");
+        }
+        else
+        {
+            hints.Add("Dynamic reload tools are disabled. Configuration file changes typically require a restart, or the feature must be enabled before using live reload helpers.");
+        }
+
+        return hints.ToArray();
+    }
+
+    private GuidanceSection[] BuildSections(PowerShellConfiguration powerShellConfiguration, AuthenticationConfiguration authenticationConfiguration)
+    {
+        return new[]
+        {
+            BuildCreateSection(),
+            BuildUpdateSection(powerShellConfiguration),
+            BuildEnvironmentSection(),
+            BuildAuthenticationSection(authenticationConfiguration)
+        };
+    }
+
+    private static GuidanceSection BuildCreateSection()
+    {
+        return new GuidanceSection(
+            "create",
+            "Create or bootstrap configuration",
+            "Start from the generated appsettings.json and then narrow the exposed commands. The docs favor CommandNames over the legacy FunctionNames field and keep most customization under PowerShellConfiguration.",
+            new[]
+            {
+                "Use poshmcp create-config to generate the initial file instead of hand-authoring the full schema.",
+                "Prefer PowerShellConfiguration.CommandNames when choosing commands to expose.",
+                "Keep include and exclude patterns focused so tool discovery stays predictable."
+            },
+            new[]
+            {
+                "PowerShellConfiguration.CommandNames",
+                "PowerShellConfiguration.FunctionNames",
+                "PowerShellConfiguration.Modules",
+                "PowerShellConfiguration.IncludePatterns",
+                "PowerShellConfiguration.ExcludePatterns"
+            },
+            new[]
+            {
+                "poshmcp create-config",
+                "poshmcp update-config --add-command Get-Process"
+            },
+            "{\n  \"PowerShellConfiguration\": {\n    \"CommandNames\": [\"Get-Process\"],\n    \"Modules\": [],\n    \"IncludePatterns\": [],\n    \"ExcludePatterns\": []\n  }\n}",
+            new[]
+            {
+                "./docs/user-guide.md"
+            });
+    }
+
+    private static GuidanceSection BuildUpdateSection(PowerShellConfiguration powerShellConfiguration)
+    {
+        var recommendations = new List<string>
+        {
+            "Use poshmcp update-config for command, module, and feature-flag changes before editing JSON by hand.",
+            "Treat the configuration file as the source of truth even when dynamic reload tools are enabled.",
+            "Regenerate or reload tools after changing the commands that should be exposed."
+        };
+
+        if (powerShellConfiguration.EnableDynamicReloadTools)
+        {
+            recommendations.Add("Because dynamic reload tools are enabled, you can update the file and then call reload-configuration-from-file to refresh the active toolset.");
+        }
+        else
+        {
+            recommendations.Add("If you need live updates, enable PowerShellConfiguration.EnableDynamicReloadTools before relying on runtime reload behavior.");
+        }
+
+        return new GuidanceSection(
+            "update",
+            "Update an existing configuration",
+            "Use the CLI for common edits and reserve manual JSON changes for advanced environment or authentication sections. This keeps the config shape aligned with the server's current conventions.",
+            recommendations.ToArray(),
+            new[]
+            {
+                "PowerShellConfiguration.EnableDynamicReloadTools",
+                "PowerShellConfiguration.EnableConfigurationTroubleshootingTool",
+                "PowerShellConfiguration.Performance.EnableResultCaching",
+                "Authentication.Enabled"
+            },
+            new[]
+            {
+                "poshmcp update-config --add-command Get-Service",
+                "poshmcp update-config --set-auth-enabled true",
+                "poshmcp update-config --enable-dynamic-reload-tools true"
+            },
+            null,
+            new[]
+            {
+                "./docs/user-guide.md"
+            });
+    }
+
+    private GuidanceSection BuildEnvironmentSection()
+    {
+        var recommendations = new List<string>
+        {
+            "Use ImportModules for modules that are already present in the image or host environment because it avoids install-time delays.",
+            "Use InstallModules only when runtime installation is required and keep install timeouts conservative for container readiness.",
+            "Prefer StartupScriptPath for substantial initialization logic and StartupScript only for short inline setup.",
+            "Add custom module directories through ModulePaths when modules come from mounted volumes or shared locations."
+        };
+
+        if (string.Equals(_effectiveRuntimeMode, "OutOfProcess", StringComparison.OrdinalIgnoreCase))
+        {
+            recommendations.Add("Out-of-process mode is a good fit when module isolation matters or startup scripts need to avoid polluting the host process.");
+        }
+
+        return new GuidanceSection(
+            "environment",
+            "Customize the PowerShell environment",
+            "Environment customization lives under PowerShellConfiguration.Environment. The docs split this into module installation, importing pre-installed modules, module path extension, and startup scripts.",
+            recommendations.ToArray(),
+            new[]
+            {
+                "PowerShellConfiguration.Environment.InstallModules",
+                "PowerShellConfiguration.Environment.ImportModules",
+                "PowerShellConfiguration.Environment.ModulePaths",
+                "PowerShellConfiguration.Environment.StartupScript",
+                "PowerShellConfiguration.Environment.StartupScriptPath",
+                "PowerShellConfiguration.Environment.TrustPSGallery",
+                "PowerShellConfiguration.Environment.InstallTimeoutSeconds"
+            },
+            new[]
+            {
+                "poshmcp update-config --add-module Az.Accounts"
+            },
+            "{\n  \"PowerShellConfiguration\": {\n    \"Environment\": {\n      \"ImportModules\": [\"Az.Accounts\"],\n      \"ModulePaths\": [\"./custom-modules\"],\n      \"StartupScriptPath\": \"/app/startup.ps1\",\n      \"TrustPSGallery\": true\n    }\n  }\n}",
+            new[]
+            {
+                "./docs/ENVIRONMENT-CUSTOMIZATION.md",
+                "./docs/ENVIRONMENT-CUSTOMIZATION-SUMMARY.md"
+            });
+    }
+
+    private GuidanceSection BuildAuthenticationSection(AuthenticationConfiguration authenticationConfiguration)
+    {
+        string summary;
+        var recommendations = new List<string>();
+
+        if (string.Equals(_effectiveTransport, "http", StringComparison.OrdinalIgnoreCase))
+        {
+            summary = authenticationConfiguration.Enabled
+                ? "HTTP transport is active and authentication is enabled. Keep bearer configuration, required scopes, protected resource metadata, and any CORS settings aligned with the deployed endpoint."
+                : "HTTP transport is active and authentication is disabled. For shared or remote deployments, enable Authentication and define bearer metadata before exposing the server outside a trusted local boundary.";
+
+            recommendations.Add("Set Authentication.Enabled to true for authenticated HTTP access.");
+            recommendations.Add("Configure Authentication.DefaultPolicy.RequiredScopes and RequiredRoles to match the audience you expect clients to present.");
+            recommendations.Add("For Entra ID, set Schemes.Bearer.Authority, Audience, ValidIssuers, and ProtectedResource metadata together.");
+            recommendations.Add("Configure Cors.AllowedOrigins only for browser-based callers that actually need cross-origin access.");
+        }
+        else
+        {
+            summary = "The server is currently running over stdio. Authentication settings mainly matter when planning an HTTP deployment, especially if you intend to use Entra ID, OAuth metadata discovery, or browser-based clients.";
+
+            recommendations.Add("Keep Authentication disabled for purely local stdio usage unless you are preparing the same config for HTTP deployment.");
+            recommendations.Add("Before switching to HTTP, define the Authentication and ProtectedResource sections together so clients can discover scopes and authorization servers consistently.");
+            recommendations.Add("Use the Entra ID guide when the deployment needs OAuth scopes, managed identity, or enterprise sign-in.");
+        }
+
+        return new GuidanceSection(
+            "authentication",
+            "Secure the server",
+            summary,
+            recommendations.ToArray(),
+            new[]
+            {
+                "Authentication.Enabled",
+                "Authentication.DefaultScheme",
+                "Authentication.DefaultPolicy.RequiredScopes",
+                "Authentication.DefaultPolicy.RequiredRoles",
+                "Authentication.Schemes.Bearer.Authority",
+                "Authentication.Schemes.Bearer.Audience",
+                "Authentication.Schemes.Bearer.ValidIssuers",
+                "Authentication.ProtectedResource.Resource",
+                "Authentication.ProtectedResource.AuthorizationServers",
+                "Authentication.ProtectedResource.ScopesSupported",
+                "Authentication.Cors.AllowedOrigins"
+            },
+            new[]
+            {
+                "poshmcp update-config --set-auth-enabled true"
+            },
+            "{\n  \"Authentication\": {\n    \"Enabled\": true,\n    \"DefaultScheme\": \"Bearer\",\n    \"DefaultPolicy\": {\n      \"RequireAuthentication\": true,\n      \"RequiredScopes\": [\"api://poshmcp-prod/access_as_server\"]\n    },\n    \"Schemes\": {\n      \"Bearer\": {\n        \"Type\": \"JwtBearer\",\n        \"Authority\": \"https://login.microsoftonline.com/<tenant-id>\",\n        \"Audience\": \"api://poshmcp-prod\"\n      }\n    }\n  }\n}",
+            new[]
+            {
+                "./docs/entra-id-auth-guide.md",
+                "./docs/user-guide.md"
+            });
+    }
+
+    private string[] BuildSuggestedNextSteps(PowerShellConfiguration powerShellConfiguration, AuthenticationConfiguration authenticationConfiguration)
+    {
+        var nextSteps = new List<string>
+        {
+            "Use the CLI create-config and update-config commands for common edits, then keep advanced Environment and Authentication sections in version-controlled JSON."
+        };
+
+        if (string.Equals(_effectiveTransport, "http", StringComparison.OrdinalIgnoreCase) && !authenticationConfiguration.Enabled)
+        {
+            nextSteps.Add("Prioritize the Authentication section before treating the current HTTP deployment as multi-user or internet reachable.");
+        }
+
+        if (!IsEnvironmentCustomizationConfigured(powerShellConfiguration))
+        {
+            nextSteps.Add("If you need modules or session bootstrap logic, add a minimal Environment section before growing the command surface.");
+        }
+
+        if (!powerShellConfiguration.EnableDynamicReloadTools)
+        {
+            nextSteps.Add("Enable dynamic reload tools if operators need to refresh tool discovery without restarting the process.");
+        }
+
+        return nextSteps.ToArray();
+    }
+
+    private static bool IsEnvironmentCustomizationConfigured(PowerShellConfiguration powerShellConfiguration)
+    {
+        var environment = powerShellConfiguration.Environment;
+
+        return environment.InstallModules.Count > 0
+            || environment.ImportModules.Count > 0
+            || environment.ModulePaths.Count > 0
+            || !string.IsNullOrWhiteSpace(environment.StartupScript)
+            || !string.IsNullOrWhiteSpace(environment.StartupScriptPath);
+    }
+
+    public sealed record GuidanceSection(
+        string Topic,
+        string Title,
+        string Summary,
+        string[] Recommendations,
+        string[] ConfigurationPaths,
+        string[] SuggestedCommands,
+        string? ExampleJson,
+        string[] References);
+}

--- a/PoshMcp.Server/PowerShell/ConfigurationGuidanceTools.cs
+++ b/PoshMcp.Server/PowerShell/ConfigurationGuidanceTools.cs
@@ -40,6 +40,12 @@ public class ConfigurationGuidanceTools
 
     public Task<string> GetConfigurationGuidance(CancellationToken cancellationToken = default)
     {
+        // Check cancellation early
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<string>(cancellationToken);
+        }
+
         try
         {
             _logger.LogInformation("Processing configuration guidance request");
@@ -60,22 +66,27 @@ public class ConfigurationGuidanceTools
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToArray();
 
+            // Build runtime context. Note: configurationPath and mcpPath may expose sensitive information
+            // (file paths, deployment structure). Only share this tool with trusted clients or gate it
+            // behind authentication. In HTTP mode with untrusted networks, consider redacting these fields.
+            var runtimeContext = new
+            {
+                configurationPath = _configurationPath,
+                transport = _effectiveTransport,
+                runtimeMode = _effectiveRuntimeMode,
+                mcpPath = _effectiveMcpPath,
+                commandCount = powerShellConfiguration.GetEffectiveCommandNames().Count,
+                moduleCount = powerShellConfiguration.Modules.Count,
+                authenticationEnabled = authenticationConfiguration.Enabled,
+                dynamicReloadToolsEnabled = powerShellConfiguration.EnableDynamicReloadTools,
+                configurationTroubleshootingToolEnabled = powerShellConfiguration.EnableConfigurationTroubleshootingTool,
+                environmentCustomizationConfigured = IsEnvironmentCustomizationConfigured(powerShellConfiguration)
+            };
+
             return Task.FromResult(JsonSerializer.Serialize(new
             {
                 success = true,
-                runtimeContext = new
-                {
-                    configurationPath = _configurationPath,
-                    transport = _effectiveTransport,
-                    runtimeMode = _effectiveRuntimeMode,
-                    mcpPath = _effectiveMcpPath,
-                    commandCount = powerShellConfiguration.GetEffectiveCommandNames().Count,
-                    moduleCount = powerShellConfiguration.Modules.Count,
-                    authenticationEnabled = authenticationConfiguration.Enabled,
-                    dynamicReloadToolsEnabled = powerShellConfiguration.EnableDynamicReloadTools,
-                    configurationTroubleshootingToolEnabled = powerShellConfiguration.EnableConfigurationTroubleshootingTool,
-                    environmentCustomizationConfigured = IsEnvironmentCustomizationConfigured(powerShellConfiguration)
-                },
+                runtimeContext,
                 runtimeHints = BuildRuntimeHints(powerShellConfiguration, authenticationConfiguration),
                 sections,
                 suggestedNextSteps = BuildSuggestedNextSteps(powerShellConfiguration, authenticationConfiguration),

--- a/PoshMcp.Server/PowerShell/EnvironmentConfiguration.cs
+++ b/PoshMcp.Server/PowerShell/EnvironmentConfiguration.cs
@@ -59,6 +59,7 @@ public class EnvironmentConfiguration
     /// This only applies when RuntimeMode is OutOfProcess and controls the setup call
     /// (module imports, startup scripts, and related environment initialization).
     /// Separate from <see cref="InstallTimeoutSeconds"/>, which only controls module install operations.
+    /// Increase this when importing heavy modules like Az or Microsoft.Graph.
     /// Defaults to 120 seconds.
     /// </summary>
     public int SetupTimeoutSeconds { get; set; } = 120;

--- a/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessCommandExecutor.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessCommandExecutor.cs
@@ -172,7 +172,9 @@ public class OutOfProcessCommandExecutor : ICommandExecutor
             ? Path.GetDirectoryName(Path.GetFullPath(configFilePath))!
             : Directory.GetCurrentDirectory();
 
-        var resolvedModulePaths = ResolveModulePaths(config.ModulePaths, baseDir);
+        var resolvedModulePaths = config.ModulePaths
+            .Select(p => Path.IsPathRooted(p) ? p : Path.GetFullPath(Path.Combine(baseDir, p)))
+            .ToArray();
 
         var setupParams = new
         {

--- a/PoshMcp.Server/Program.cs
+++ b/PoshMcp.Server/Program.cs
@@ -2885,7 +2885,7 @@ public class Program
         var setupTimeout = config.Environment?.SetupTimeoutSeconds is > 0
             ? TimeSpan.FromSeconds(config.Environment.SetupTimeoutSeconds)
             : TimeSpan.FromSeconds(120);
-        var executor = new OutOfProcessCommandExecutor(executorLogger, requestTimeout: setupTimeout);
+        var executor = new OutOfProcessCommandExecutor(executorLogger);
         await executor.StartAsync();
         logger.LogInformation("Started out-of-process PowerShell executor");
 

--- a/PoshMcp.Server/Program.cs
+++ b/PoshMcp.Server/Program.cs
@@ -2299,6 +2299,7 @@ public class Program
         await using var executorLease = await StartOutOfProcessExecutorIfNeededAsync(config, loggerFactory, logger, configurationPath);
         var toolFactory = CreateToolFactory(config, executorLease?.Executor);
         var tools = await toolFactory.GetToolsListAsync(config, logger);
+        AddConfigurationGuidanceToolToList(tools, config, configurationPath, "stdio", config.RuntimeMode.ToString(), null, loggerFactory);
         AddConfigurationTroubleshootingToolToList(tools, config, configurationPath, "stdio", null, config.RuntimeMode.ToString(), null, logger);
         return tools;
     }
@@ -2622,6 +2623,7 @@ public class Program
         tools.Add(setResultCachingTool);
         logger.LogInformation("Registered set-result-caching tool (always enabled)");
 
+        AddConfigurationGuidanceToolToList(tools, config, finalConfigPath, "http", config.RuntimeMode.ToString(), null, loggerFactory);
         AddConfigurationTroubleshootingToolToList(tools, config, finalConfigPath, "http", null, config.RuntimeMode.ToString(), null, logger);
 
         return tools;
@@ -2693,9 +2695,32 @@ public class Program
         tools.Add(setResultCachingTool);
         logger.LogInformation("Registered set-result-caching tool (always enabled)");
 
+        AddConfigurationGuidanceToolToList(tools, config, finalConfigPath, "stdio", config.RuntimeMode.ToString(), null, loggerFactory);
         AddConfigurationTroubleshootingToolToList(tools, config, finalConfigPath, "stdio", null, config.RuntimeMode.ToString(), null, logger);
 
         return tools;
+    }
+
+    private static void AddConfigurationGuidanceToolToList(
+        List<McpServerTool> tools,
+        PowerShellConfiguration config,
+        string configurationPath,
+        string effectiveTransport,
+        string? effectiveRuntimeMode,
+        string? effectiveMcpPath,
+        ILoggerFactory loggerFactory)
+    {
+        if (!config.EnableConfigurationTroubleshootingTool)
+        {
+            return;
+        }
+
+        tools.Add(CreateConfigurationGuidanceToolInstance(
+            configurationPath,
+            effectiveTransport,
+            effectiveRuntimeMode,
+            effectiveMcpPath,
+            loggerFactory));
     }
 
     private static void AddConfigurationTroubleshootingToolToList(
@@ -2771,6 +2796,34 @@ public class Program
             Name = "get-configuration-troubleshooting",
             Description = "Returns doctor-style configuration diagnostics for the running server",
             Title = "Get Configuration Troubleshooting",
+            ReadOnly = true,
+            Destructive = false,
+            Idempotent = true,
+            OpenWorld = false,
+            UseStructuredContent = true
+        });
+    }
+
+    private static McpServerTool CreateConfigurationGuidanceToolInstance(
+        string configurationPath,
+        string effectiveTransport,
+        string? effectiveRuntimeMode,
+        string? effectiveMcpPath,
+        ILoggerFactory loggerFactory)
+    {
+        var guidanceLogger = loggerFactory.CreateLogger<ConfigurationGuidanceTools>();
+        var guidanceTools = new ConfigurationGuidanceTools(
+            configurationPath,
+            effectiveTransport,
+            effectiveRuntimeMode,
+            effectiveMcpPath,
+            guidanceLogger);
+
+        return McpServerTool.Create(guidanceTools.GetConfigurationGuidance, new McpServerToolCreateOptions
+        {
+            Name = "get-configuration-guidance",
+            Description = "Returns configuration guidance for creating and updating appsettings.json, including environment customization and authentication recommendations based on the current runtime transport.",
+            Title = "Get Configuration Guidance",
             ReadOnly = true,
             Destructive = false,
             Idempotent = true,

--- a/PoshMcp.Server/Program.cs
+++ b/PoshMcp.Server/Program.cs
@@ -2832,7 +2832,7 @@ public class Program
         var setupTimeout = config.Environment?.SetupTimeoutSeconds is > 0
             ? TimeSpan.FromSeconds(config.Environment.SetupTimeoutSeconds)
             : TimeSpan.FromSeconds(120);
-        var executor = new OutOfProcessCommandExecutor(executorLogger);
+        var executor = new OutOfProcessCommandExecutor(executorLogger, requestTimeout: setupTimeout);
         await executor.StartAsync();
         logger.LogInformation("Started out-of-process PowerShell executor");
 

--- a/PoshMcp.Tests/Integration/ConfigurationGuidanceIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/ConfigurationGuidanceIntegrationTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PoshMcp.Tests.Integration;
+
+public class ConfigurationGuidanceIntegrationTests : PowerShellTestBase
+{
+    public ConfigurationGuidanceIntegrationTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [Fact]
+    public async Task StdioServer_WithConfigurationGuidanceEnabled_ShouldListAndCallTool()
+    {
+        using var configFile = new TemporaryConfigFile();
+        using var server = new InProcessMcpServer(Logger, explicitConfigPath: configFile.Path);
+        await server.StartAsync();
+
+        using var client = new ExternalMcpClient(Logger, server);
+        await client.StartAsync();
+
+        var toolsResponse = await client.SendListToolsAsync();
+        var tools = toolsResponse["result"]?["tools"] as JArray;
+
+        Assert.NotNull(tools);
+        Assert.Contains(tools!, tool => string.Equals(tool?["name"]?.ToString(), "get-configuration-guidance", StringComparison.OrdinalIgnoreCase));
+
+        var callResponse = await client.SendToolCallAsync("get-configuration-guidance", new { });
+        var content = callResponse["result"]?["content"] as JArray;
+
+        Assert.NotNull(content);
+        Assert.NotEmpty(content!);
+
+        var textContent = content![0]?["text"]?.ToString();
+        Assert.False(string.IsNullOrWhiteSpace(textContent));
+        Assert.Contains("PowerShellConfiguration.Environment.InstallModules", textContent, StringComparison.Ordinal);
+        Assert.Contains("Authentication.Enabled", textContent, StringComparison.Ordinal);
+    }
+
+    private sealed class TemporaryConfigFile : IDisposable
+    {
+        public string Path { get; }
+
+        public TemporaryConfigFile()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"poshmcp-guidance-integration-{Guid.NewGuid():N}.json");
+
+            var json = """
+{
+  "PowerShellConfiguration": {
+    "CommandNames": ["Get-Date"],
+    "Modules": [],
+    "IncludePatterns": [],
+    "ExcludePatterns": [],
+    "EnableConfigurationTroubleshootingTool": true
+  },
+  "Authentication": {
+    "Enabled": false,
+    "DefaultScheme": "Bearer",
+    "DefaultPolicy": {
+      "RequireAuthentication": true,
+      "RequiredScopes": [],
+      "RequiredRoles": []
+    },
+    "Schemes": {}
+  }
+}
+""";
+
+            File.WriteAllText(Path, json);
+        }
+
+        public void Dispose()
+        {
+            if (File.Exists(Path))
+            {
+                File.Delete(Path);
+            }
+        }
+    }
+}

--- a/PoshMcp.Tests/Unit/ConfigurationGuidanceToolsTests.cs
+++ b/PoshMcp.Tests/Unit/ConfigurationGuidanceToolsTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using PoshMcp.Server.PowerShell;
+using Xunit;
+
+namespace PoshMcp.Tests.Unit;
+
+public class ConfigurationGuidanceToolsTests
+{
+    [Fact]
+    public async Task GetConfigurationGuidance_WithStdioRuntime_ExplainsHttpAuthenticationPlanning()
+    {
+        using var configFile = new TemporaryConfigFile(authenticationEnabled: false, includeEnvironmentCustomization: false);
+        var tool = new ConfigurationGuidanceTools(
+            configFile.Path,
+            "stdio",
+            "InProcess",
+            null,
+            NullLogger<ConfigurationGuidanceTools>.Instance);
+
+        var payload = JsonNode.Parse(await tool.GetConfigurationGuidance())?.AsObject();
+
+        Assert.NotNull(payload);
+        Assert.True(payload!["success"]?.GetValue<bool>());
+        Assert.Equal("stdio", payload["runtimeContext"]?["transport"]?.GetValue<string>());
+
+        var runtimeHints = payload["runtimeHints"]?.AsArray().Select(node => node?.GetValue<string>()).OfType<string>().ToArray();
+        Assert.NotNull(runtimeHints);
+        Assert.Contains(runtimeHints!, hint => hint.Contains("switching to HTTP transport", StringComparison.OrdinalIgnoreCase));
+
+        var authenticationSection = GetSection(payload, "authentication");
+        Assert.NotNull(authenticationSection);
+        Assert.Contains("stdio", authenticationSection!["summary"]?.GetValue<string>() ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(authenticationSection["configurationPaths"]?.AsArray() ?? new JsonArray(), item =>
+            string.Equals(item?.GetValue<string>(), "Authentication.Enabled", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task GetConfigurationGuidance_WithHttpRuntime_ListsEnvironmentAndAuthenticationFields()
+    {
+        using var configFile = new TemporaryConfigFile(authenticationEnabled: true, includeEnvironmentCustomization: true);
+        var tool = new ConfigurationGuidanceTools(
+            configFile.Path,
+            "http",
+            "OutOfProcess",
+            "/mcp",
+            NullLogger<ConfigurationGuidanceTools>.Instance);
+
+        var payload = JsonNode.Parse(await tool.GetConfigurationGuidance())?.AsObject();
+
+        Assert.NotNull(payload);
+        Assert.True(payload!["runtimeContext"]?["environmentCustomizationConfigured"]?.GetValue<bool>());
+        Assert.Equal("http", payload["runtimeContext"]?["transport"]?.GetValue<string>());
+        Assert.Equal("/mcp", payload["runtimeContext"]?["mcpPath"]?.GetValue<string>());
+
+        var environmentSection = GetSection(payload, "environment");
+        Assert.NotNull(environmentSection);
+        Assert.Contains(environmentSection!["configurationPaths"]?.AsArray() ?? new JsonArray(), item =>
+            string.Equals(item?.GetValue<string>(), "PowerShellConfiguration.Environment.InstallModules", StringComparison.OrdinalIgnoreCase));
+
+        var authenticationSection = GetSection(payload, "authentication");
+        Assert.NotNull(authenticationSection);
+        Assert.Contains("HTTP transport is active", authenticationSection!["summary"]?.GetValue<string>() ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(authenticationSection["configurationPaths"]?.AsArray() ?? new JsonArray(), item =>
+            string.Equals(item?.GetValue<string>(), "Authentication.ProtectedResource.Resource", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static JsonObject? GetSection(JsonObject payload, string topic)
+    {
+        return payload["sections"]?.AsArray()
+            .Select(node => node as JsonObject)
+            .FirstOrDefault(section => string.Equals(section?["topic"]?.GetValue<string>(), topic, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private sealed class TemporaryConfigFile : IDisposable
+    {
+        public string Path { get; }
+
+        public TemporaryConfigFile(bool authenticationEnabled, bool includeEnvironmentCustomization)
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"poshmcp-guidance-tests-{Guid.NewGuid():N}.json");
+
+            var powerShellConfiguration = new JsonObject
+            {
+                ["CommandNames"] = new JsonArray("Get-Date"),
+                ["Modules"] = new JsonArray(),
+                ["IncludePatterns"] = new JsonArray(),
+                ["ExcludePatterns"] = new JsonArray(),
+                ["EnableConfigurationTroubleshootingTool"] = true
+            };
+
+            if (includeEnvironmentCustomization)
+            {
+                powerShellConfiguration["Environment"] = new JsonObject
+                {
+                    ["InstallModules"] = new JsonArray
+                    {
+                        new JsonObject
+                        {
+                            ["Name"] = "Az.Accounts"
+                        }
+                    },
+                    ["ImportModules"] = new JsonArray("Az.Accounts"),
+                    ["ModulePaths"] = new JsonArray("./modules"),
+                    ["StartupScriptPath"] = "/app/startup.ps1"
+                };
+            }
+
+            var authentication = authenticationEnabled
+                ? new JsonObject
+                {
+                    ["Enabled"] = true,
+                    ["DefaultScheme"] = "Bearer",
+                    ["DefaultPolicy"] = new JsonObject
+                    {
+                        ["RequireAuthentication"] = true,
+                        ["RequiredScopes"] = new JsonArray("api://poshmcp/access_as_server"),
+                        ["RequiredRoles"] = new JsonArray()
+                    },
+                    ["Schemes"] = new JsonObject
+                    {
+                        ["Bearer"] = new JsonObject
+                        {
+                            ["Type"] = "JwtBearer",
+                            ["Authority"] = "https://login.microsoftonline.com/test-tenant",
+                            ["Audience"] = "api://poshmcp",
+                            ["ValidIssuers"] = new JsonArray("https://login.microsoftonline.com/test-tenant/v2.0")
+                        }
+                    },
+                    ["ProtectedResource"] = new JsonObject
+                    {
+                        ["Resource"] = "api://poshmcp",
+                        ["AuthorizationServers"] = new JsonArray("https://login.microsoftonline.com/test-tenant"),
+                        ["ScopesSupported"] = new JsonArray("api://poshmcp/access_as_server")
+                    }
+                }
+                : new JsonObject
+                {
+                    ["Enabled"] = false,
+                    ["DefaultScheme"] = "Bearer",
+                    ["DefaultPolicy"] = new JsonObject
+                    {
+                        ["RequireAuthentication"] = true,
+                        ["RequiredScopes"] = new JsonArray(),
+                        ["RequiredRoles"] = new JsonArray()
+                    },
+                    ["Schemes"] = new JsonObject()
+                };
+
+            var json = new JsonObject
+            {
+                ["PowerShellConfiguration"] = powerShellConfiguration,
+                ["Authentication"] = authentication,
+                ["Logging"] = new JsonObject
+                {
+                    ["LogLevel"] = new JsonObject
+                    {
+                        ["Default"] = "Information"
+                    }
+                }
+            };
+
+            File.WriteAllText(Path, json.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+        }
+
+        public void Dispose()
+        {
+            if (File.Exists(Path))
+            {
+                File.Delete(Path);
+            }
+        }
+    }
+}

--- a/PoshMcp.Tests/Unit/ProgramConfigurationGuidanceToolExposureTests.cs
+++ b/PoshMcp.Tests/Unit/ProgramConfigurationGuidanceToolExposureTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PoshMcp.Tests.Unit;
+
+[Collection("TransportSelectionTests")]
+public class ProgramConfigurationGuidanceToolExposureTests
+{
+    private const string TroubleshootingToolEnvVar = "POSHMCP_ENABLE_CONFIGURATION_TROUBLESHOOTING_TOOL";
+
+    [Fact]
+    public async Task DoctorCommand_WithConfigurationTroubleshootingToolDisabled_OmitsConfigurationGuidanceTool()
+    {
+        using var configFile = new TemporaryConfigFile(enableConfigurationTroubleshootingTool: false);
+        using var capture = new ConsoleCapture();
+        using var envScope = new EnvironmentVariableScope(TroubleshootingToolEnvVar, null);
+
+        var result = await Program.Main(new[] { "doctor", "--config", configFile.Path, "--format", "json" });
+
+        Assert.Equal(0, result);
+        var toolNames = GetToolNames(capture.StandardOutput);
+        Assert.DoesNotContain("get-configuration-guidance", toolNames);
+    }
+
+    [Fact]
+    public async Task DoctorCommand_WithConfigurationTroubleshootingToolEnabled_IncludesConfigurationGuidanceTool()
+    {
+        using var configFile = new TemporaryConfigFile(enableConfigurationTroubleshootingTool: true);
+        using var capture = new ConsoleCapture();
+        using var envScope = new EnvironmentVariableScope(TroubleshootingToolEnvVar, null);
+
+        var result = await Program.Main(new[] { "doctor", "--config", configFile.Path, "--format", "json" });
+
+        Assert.Equal(0, result);
+        var toolNames = GetToolNames(capture.StandardOutput);
+        Assert.Contains("get-configuration-guidance", toolNames);
+    }
+
+    private static string[] GetToolNames(string standardOutput)
+    {
+        return JsonNode.Parse(standardOutput.Trim())?["toolNames"]?.AsArray()
+            .Select(node => node?.GetValue<string>())
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Cast<string>()
+            .ToArray()
+            ?? Array.Empty<string>();
+    }
+
+    private sealed class TemporaryConfigFile : IDisposable
+    {
+        public string Path { get; }
+
+        public TemporaryConfigFile(bool enableConfigurationTroubleshootingTool)
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"poshmcp-guidance-exposure-tests-{Guid.NewGuid():N}.json");
+
+            var json = $$"""
+{
+  "PowerShellConfiguration": {
+    "CommandNames": ["Get-Date"],
+    "Modules": [],
+    "ExcludePatterns": [],
+    "IncludePatterns": [],
+    "EnableConfigurationTroubleshootingTool": {{enableConfigurationTroubleshootingTool.ToString().ToLowerInvariant()}}
+  },
+  "Authentication": {
+    "Enabled": false,
+    "DefaultScheme": "Bearer",
+    "DefaultPolicy": {
+      "RequireAuthentication": true,
+      "RequiredScopes": [],
+      "RequiredRoles": []
+    },
+    "Schemes": {}
+  }
+}
+""";
+
+            File.WriteAllText(Path, json);
+        }
+
+        public void Dispose()
+        {
+            if (File.Exists(Path))
+            {
+                File.Delete(Path);
+            }
+        }
+    }
+
+    private sealed class ConsoleCapture : IDisposable
+    {
+        private readonly TextWriter _originalOut;
+        private readonly TextWriter _originalError;
+        private readonly StringWriter _capturedOut;
+        private readonly StringWriter _capturedError;
+
+        public string StandardOutput => _capturedOut.ToString();
+
+        public ConsoleCapture()
+        {
+            _originalOut = Console.Out;
+            _originalError = Console.Error;
+            _capturedOut = new StringWriter();
+            _capturedError = new StringWriter();
+
+            Console.SetOut(_capturedOut);
+            Console.SetError(_capturedError);
+        }
+
+        public void Dispose()
+        {
+            Console.SetOut(_originalOut);
+            Console.SetError(_originalError);
+            _capturedOut.Dispose();
+            _capturedError.Dispose();
+        }
+    }
+
+    private sealed class EnvironmentVariableScope : IDisposable
+    {
+        private readonly string _name;
+        private readonly string? _originalValue;
+
+        public EnvironmentVariableScope(string name, string? value)
+        {
+            _name = name;
+            _originalValue = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(_name, _originalValue);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new built-in MCP helper tool: get-configuration-guidance
- provide docs-backed guidance for create/update config workflows
- include context-aware guidance based on active transport/runtime/auth settings
- include coverage for tool behavior, exposure, and integration paths

## Validation
- dotnet test PoshMcp.Tests/PoshMcp.Tests.csproj --filter FullyQualifiedName~ConfigurationGuidanceToolsTests|FullyQualifiedName~ProgramConfigurationGuidanceToolExposureTests|FullyQualifiedName~ConfigurationGuidanceIntegrationTests

Closes #111