### PR TITLE
feat: MCP Resources - resources/list and resources/read handlers (Spec 002 PR 1/4)

### DIFF
--- a/PoshMcp.Server/McpResources/McpResourceConfiguration.cs
+++ b/PoshMcp.Server/McpResources/McpResourceConfiguration.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace PoshMcp.Server.McpResources;
+
+/// <summary>
+/// Configuration for a single MCP resource entry, backed by a file or PowerShell command.
+/// </summary>
+public class McpResourceConfiguration
+{
+    /// <summary>
+    /// The MCP resource URI (e.g., "poshmcp://resources/my-resource"). Required; must be unique.
+    /// </summary>
+    public string Uri { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Human-readable name for the resource. Required.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional description of the resource.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// MIME type of the resource content. Defaults to "text/plain".
+    /// </summary>
+    public string MimeType { get; set; } = "text/plain";
+
+    /// <summary>
+    /// Source type: "file" or "command".
+    /// </summary>
+    public string Source { get; set; } = string.Empty;
+
+    /// <summary>
+    /// File path (absolute or relative to appsettings.json directory). Required when Source is "file".
+    /// </summary>
+    public string? Path { get; set; }
+
+    /// <summary>
+    /// PowerShell command to execute. Required when Source is "command".
+    /// </summary>
+    public string? Command { get; set; }
+}

--- a/PoshMcp.Server/McpResources/McpResourceHandler.cs
+++ b/PoshMcp.Server/McpResources/McpResourceHandler.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Management.Automation;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using PoshMcp.Server.PowerShell;
+using PSPowerShell = System.Management.Automation.PowerShell;
+
+namespace PoshMcp.Server.McpResources;
+
+/// <summary>
+/// Handles MCP resources/list and resources/read requests backed by file and command sources.
+/// </summary>
+public class McpResourceHandler
+{
+    private readonly McpResourcesConfiguration _config;
+    private readonly IPowerShellRunspace _runspace;
+    private readonly string _configDirectory;
+    private readonly ILogger<McpResourceHandler> _logger;
+
+    /// <summary>
+    /// Creates a new McpResourceHandler instance.
+    /// </summary>
+    /// <param name="config">The resources configuration loaded from appsettings.json.</param>
+    /// <param name="runspace">The shared PowerShell runspace for command-backed resources.</param>
+    /// <param name="configDirectory">Directory of appsettings.json, used for relative path resolution.</param>
+    /// <param name="logger">Logger for diagnostics.</param>
+    public McpResourceHandler(
+        McpResourcesConfiguration config,
+        IPowerShellRunspace runspace,
+        string configDirectory,
+        ILogger<McpResourceHandler> logger)
+    {
+        _config = config;
+        _runspace = runspace;
+        _configDirectory = configDirectory;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Handles the resources/list MCP request, returning all configured resources.
+    /// </summary>
+    public ValueTask<ListResourcesResult> HandleListAsync(
+        RequestContext<ListResourcesRequestParams> context,
+        CancellationToken cancellationToken)
+    {
+        var resources = _config.Resources
+            .Select(r => new Resource
+            {
+                Uri = r.Uri,
+                Name = r.Name,
+                Description = r.Description,
+                MimeType = string.IsNullOrWhiteSpace(r.MimeType) ? "text/plain" : r.MimeType,
+            })
+            .ToList();
+
+        _logger.LogDebug("resources/list returning {Count} resource(s)", resources.Count);
+
+        return ValueTask.FromResult(new ListResourcesResult { Resources = resources });
+    }
+
+    /// <summary>
+    /// Handles the resources/read MCP request, fetching content from a file or command source.
+    /// </summary>
+    public async ValueTask<ReadResourceResult> HandleReadAsync(
+        RequestContext<ReadResourceRequestParams> context,
+        CancellationToken cancellationToken)
+    {
+        var requestedUri = context.Params?.Uri;
+        if (string.IsNullOrWhiteSpace(requestedUri))
+        {
+            throw new McpProtocolException("resources/read requires a non-empty uri parameter", McpErrorCode.InvalidParams);
+        }
+
+        var resourceConfig = _config.Resources.FirstOrDefault(r =>
+            string.Equals(r.Uri, requestedUri, StringComparison.OrdinalIgnoreCase));
+
+        if (resourceConfig is null)
+        {
+            _logger.LogWarning("resources/read: unknown URI {Uri}", requestedUri);
+            throw new McpProtocolException($"Resource not found: {requestedUri}", McpErrorCode.ResourceNotFound);
+        }
+
+        _logger.LogDebug("resources/read {Uri} (source={Source})", requestedUri, resourceConfig.Source);
+
+        var mimeType = string.IsNullOrWhiteSpace(resourceConfig.MimeType) ? "text/plain" : resourceConfig.MimeType;
+        string content;
+
+        try
+        {
+            content = resourceConfig.Source.ToLowerInvariant() switch
+            {
+                "file" => await ReadFileResourceAsync(resourceConfig, cancellationToken),
+                "command" => await ReadCommandResourceAsync(resourceConfig, cancellationToken),
+                _ => throw new McpProtocolException(
+                    $"Unknown resource source '{resourceConfig.Source}' for URI {requestedUri}",
+                    McpErrorCode.InvalidParams)
+            };
+        }
+        catch (McpException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to read resource {Uri}", requestedUri);
+            throw new McpProtocolException(
+                $"Failed to read resource '{requestedUri}': {ex.Message}",
+                McpErrorCode.InternalError);
+        }
+
+        return new ReadResourceResult
+        {
+            Contents = new List<ResourceContents>
+            {
+                new TextResourceContents
+                {
+                    Uri = resourceConfig.Uri,
+                    MimeType = mimeType,
+                    Text = content,
+                }
+            }
+        };
+    }
+
+    private async Task<string> ReadFileResourceAsync(McpResourceConfiguration config, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(config.Path))
+        {
+            throw new McpProtocolException(
+                $"Resource '{config.Uri}' has source 'file' but no Path is configured.",
+                McpErrorCode.InvalidParams);
+        }
+
+        var resolvedPath = Path.IsPathRooted(config.Path)
+            ? config.Path
+            : Path.GetFullPath(Path.Combine(_configDirectory, config.Path));
+
+        _logger.LogDebug("Reading file resource at {Path}", resolvedPath);
+
+        return await File.ReadAllTextAsync(resolvedPath, cancellationToken);
+    }
+
+    private Task<string> ReadCommandResourceAsync(McpResourceConfiguration config, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(config.Command))
+        {
+            throw new McpProtocolException(
+                $"Resource '{config.Uri}' has source 'command' but no Command is configured.",
+                McpErrorCode.InvalidParams);
+        }
+
+        _logger.LogDebug("Executing command resource: {Command}", config.Command);
+
+        var result = _runspace.ExecuteThreadSafe(ps =>
+        {
+            ps.Commands.Clear();
+            ps.AddScript(config.Command);
+            var output = ps.Invoke();
+            ps.Commands.Clear();
+
+            if (ps.HadErrors)
+            {
+                var errors = ps.Streams.Error
+                    .Select(e => e.Exception?.Message ?? e.ToString())
+                    .ToList();
+                ps.Streams.ClearStreams();
+                throw new InvalidOperationException(
+                    $"Command execution failed: {string.Join("; ", errors)}");
+            }
+
+            ps.Streams.ClearStreams();
+            return output;
+        });
+
+        return Task.FromResult(SerializeCommandOutput(result));
+    }
+
+    private static string SerializeCommandOutput(System.Collections.ObjectModel.Collection<PSObject> results)
+    {
+        if (results is null || results.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        if (results.Count == 1)
+        {
+            var single = results[0];
+            if (single is null)
+            {
+                return string.Empty;
+            }
+
+            var baseObject = single.BaseObject;
+
+            if (baseObject is string s)
+            {
+                return s;
+            }
+
+            if (IsScalar(baseObject))
+            {
+                return baseObject.ToString() ?? string.Empty;
+            }
+        }
+
+        // Multiple results or complex objects — serialize to JSON
+        var normalized = results
+            .Where(r => r is not null)
+            .Select(r => PowerShellObjectSerializer.FlattenPSObject(r))
+            .ToArray();
+
+        if (normalized.Length == 1)
+        {
+            return JsonSerializer.Serialize(normalized[0]);
+        }
+
+        return JsonSerializer.Serialize(normalized);
+    }
+
+    private static bool IsScalar(object? value)
+    {
+        if (value is null)
+        {
+            return true;
+        }
+
+        var type = value.GetType();
+        return type.IsPrimitive
+            || type.IsEnum
+            || type == typeof(string)
+            || type == typeof(decimal)
+            || type == typeof(DateTime)
+            || type == typeof(DateTimeOffset)
+            || type == typeof(TimeSpan)
+            || type == typeof(Guid)
+            || type == typeof(Uri)
+            || type == typeof(Version);
+    }
+}

--- a/PoshMcp.Server/McpResources/McpResourcesConfiguration.cs
+++ b/PoshMcp.Server/McpResources/McpResourcesConfiguration.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace PoshMcp.Server.McpResources;
+
+/// <summary>
+/// Top-level configuration for MCP resources. Bound from the "McpResources" section of appsettings.json.
+/// </summary>
+public class McpResourcesConfiguration
+{
+    /// <summary>
+    /// The list of configured MCP resources.
+    /// </summary>
+    public List<McpResourceConfiguration> Resources { get; set; } = new();
+}

--- a/PoshMcp.Server/Program.cs
+++ b/PoshMcp.Server/Program.cs
@@ -30,6 +30,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using PoshMcp.Server.Authentication;
+using PoshMcp.Server.McpResources;
 
 namespace PoshMcp;
 
@@ -2293,6 +2294,19 @@ public class Program
         logger.LogTrace($"Runtime mode: {config.RuntimeMode}");
     }
 
+    internal static McpResourcesConfiguration LoadMcpResourcesConfiguration(string configPath, ILogger logger)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddJsonFile(configPath, optional: false, reloadOnChange: false)
+            .Build();
+
+        var config = new McpResourcesConfiguration();
+        configuration.GetSection("McpResources").Bind(config);
+
+        logger.LogDebug("McpResources configuration loaded: {Count} resource(s)", config.Resources.Count);
+        return config;
+    }
+
     private static async Task<List<McpServerTool>> DiscoverToolsAsync(PowerShellConfiguration config, ILoggerFactory loggerFactory, ILogger logger, string configurationPath)
     {
         logger.LogInformation("Discovering PowerShell tools...");
@@ -2358,9 +2372,10 @@ public class Program
         var logger = loggerFactory.CreateLogger("PoshMcpLogger");
         logger.LogInformation("Using configuration file: {ConfigurationPath}", finalConfigPath);
         var config = LoadPowerShellConfiguration(finalConfigPath, logger, runtimeModeOverride);
+        var resourcesConfig = LoadMcpResourcesConfiguration(finalConfigPath, logger);
         await using var executorLease = await StartOutOfProcessExecutorIfNeededAsync(config, loggerFactory, logger, finalConfigPath);
         var tools = await SetupMcpToolsAsync(loggerFactory, config, logger, finalConfigPath, executorLease?.Executor);
-        ConfigureServerServices(builder, tools);
+        ConfigureServerServices(builder, tools, resourcesConfig, finalConfigPath, loggerFactory);
         await builder.Build().RunAsync();
     }
 
@@ -2418,11 +2433,17 @@ public class Program
         logger.LogInformation("Using configuration file: {ConfigurationPath}", finalConfigPath);
 
         var tools = await SetupHttpMcpToolsAsync(bootstrapLoggerFactory, config, logger, finalConfigPath, sharedSessionRunspace, executorLease?.Executor);
+        var resourcesConfig = LoadMcpResourcesConfiguration(finalConfigPath, logger);
+        var resourcesConfigDirectory = Path.GetDirectoryName(finalConfigPath) ?? ".";
+        var resourceLogger = bootstrapLoggerFactory.CreateLogger<McpResourceHandler>();
+        var resourceHandler = new McpResourceHandler(resourcesConfig, sharedSessionRunspace, resourcesConfigDirectory, resourceLogger);
         var authConfigValue = builder.Configuration.GetSection("Authentication").Get<PoshMcp.Server.Authentication.AuthenticationConfiguration>() ?? new();
         var mcpBuilder = builder.Services
             .AddMcpServer()
             .WithHttpTransport()
-            .WithTools(tools);
+            .WithTools(tools)
+            .WithListResourcesHandler(resourceHandler.HandleListAsync)
+            .WithReadResourceHandler(resourceHandler.HandleReadAsync);
 
         ToolAuthorizationFilter? callToolFilter = null;
         ToolListAuthorizationFilter? listToolFilter = null;
@@ -3015,11 +3036,16 @@ public class Program
         return null;
     }
 
-    private static void ConfigureServerServices(HostApplicationBuilder builder, List<McpServerTool> tools)
+    private static void ConfigureServerServices(
+        HostApplicationBuilder builder,
+        List<McpServerTool> tools,
+        McpResourcesConfiguration resourcesConfig,
+        string configFilePath,
+        ILoggerFactory loggerFactory)
     {
         ConfigureJsonSerializerOptions(builder);
         ConfigureOpenTelemetry(builder);
-        RegisterMcpServerServices(builder, tools);
+        RegisterMcpServerServices(builder, tools, resourcesConfig, configFilePath, loggerFactory);
         RegisterCleanupServices(builder);
     }
 
@@ -3068,12 +3094,24 @@ public class Program
         });
     }
 
-    private static void RegisterMcpServerServices(HostApplicationBuilder builder, List<McpServerTool> tools)
+    private static void RegisterMcpServerServices(
+        HostApplicationBuilder builder,
+        List<McpServerTool> tools,
+        McpResourcesConfiguration resourcesConfig,
+        string configFilePath,
+        ILoggerFactory loggerFactory)
     {
+        var runspace = new SingletonPowerShellRunspace();
+        var configDirectory = Path.GetDirectoryName(configFilePath) ?? ".";
+        var resourceLogger = loggerFactory.CreateLogger<McpResourceHandler>();
+        var resourceHandler = new McpResourceHandler(resourcesConfig, runspace, configDirectory, resourceLogger);
+
         builder.Services
             .AddMcpServer()
             .WithStdioServerTransport()
-            .WithTools(tools);
+            .WithTools(tools)
+            .WithListResourcesHandler(resourceHandler.HandleListAsync)
+            .WithReadResourceHandler(resourceHandler.HandleReadAsync);
     }
 
     private static void RegisterCleanupServices(HostApplicationBuilder builder)

--- a/PoshMcp.Server/appsettings.json
+++ b/PoshMcp.Server/appsettings.json
@@ -20,6 +20,26 @@
       "UseDefaultDisplayProperties": true
     }
   },
+  "McpResources": {
+    "Resources": [
+      {
+        "Uri": "poshmcp://resources/server-config",
+        "Name": "Server Configuration",
+        "Description": "The active appsettings.json contents",
+        "MimeType": "application/json",
+        "Source": "file",
+        "Path": "./appsettings.json"
+      },
+      {
+        "Uri": "poshmcp://resources/process-list",
+        "Name": "Running Processes",
+        "Description": "Current process list as JSON",
+        "MimeType": "application/json",
+        "Source": "command",
+        "Command": "Get-Process | Select-Object Name, Id, CPU | ConvertTo-Json"
+      }
+    ]
+  },
   "Authentication": {
     "Enabled": false,
     "DefaultScheme": "Bearer",


### PR DESCRIPTION
## Summary
Implements FR-018 through FR-021 and FR-028, FR-030, FR-031, FR-033, FR-034 from Spec 002.

### Changes
- `McpResources/McpResourceConfiguration.cs` — config model
- `McpResources/McpResourcesConfiguration.cs` — top-level config
- `McpResources/McpResourceHandler.cs` — file/command handler logic
- `Program.cs` — wired WithListResourcesHandler + WithReadResourceHandler on both transports

### Farnsworth review: ✅ APPROVED (clean implementation)

Resolves Spec 002 FR-018, FR-019, FR-020, FR-021, FR-028, FR-030, FR-031, FR-033, FR-034