### PR TITLE
feat: Doctor validation for MCP Resources and Prompts (Spec 002 PR 3/4)

### DIFF
--- a/PoshMcp.Server/McpPrompts/McpPromptsValidator.cs
+++ b/PoshMcp.Server/McpPrompts/McpPromptsValidator.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace PoshMcp.Server.McpPrompts;
+
+/// <summary>
+/// Validates an <see cref="McpPromptsConfiguration"/> and returns structured diagnostics.
+/// </summary>
+public static class McpPromptsValidator
+{
+    private const string FileSource = "file";
+    private const string CommandSource = "command";
+    private static readonly string[] ValidSources = [FileSource, CommandSource];
+
+    /// <summary>
+    /// Validates all configured prompts and returns a diagnostics summary.
+    /// </summary>
+    /// <param name="promptsConfig">The prompts configuration to validate.</param>
+    /// <param name="configDirectory">
+    /// Base directory used to resolve relative file paths (typically the directory containing appsettings.json).
+    /// </param>
+    public static McpPromptsDiagnostics Validate(McpPromptsConfiguration promptsConfig, string configDirectory)
+    {
+        var errors = new List<string>();
+        var warnings = new List<string>();
+        var prompts = promptsConfig.Prompts;
+
+        // Duplicate Name check
+        var nameGroups = prompts
+            .Where(p => !string.IsNullOrWhiteSpace(p.Name))
+            .GroupBy(p => p.Name!, StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Count() > 1);
+        foreach (var group in nameGroups)
+        {
+            errors.Add($"Prompt name '{group.Key}' is duplicated across {group.Count()} entries.");
+        }
+
+        foreach (var prompt in prompts)
+        {
+            var label = string.IsNullOrWhiteSpace(prompt.Name)
+                ? $"(unnamed prompt at index {prompts.IndexOf(prompt)})"
+                : $"'{prompt.Name}'";
+
+            // Source validity
+            if (string.IsNullOrWhiteSpace(prompt.Source))
+            {
+                errors.Add($"Prompt {label}: Source is missing. Must be \"file\" or \"command\".");
+            }
+            else if (!ValidSources.Contains(prompt.Source, StringComparer.OrdinalIgnoreCase))
+            {
+                errors.Add($"Prompt {label}: Source \"{prompt.Source}\" is invalid. Must be \"file\" or \"command\".");
+            }
+            else if (string.Equals(prompt.Source, FileSource, StringComparison.OrdinalIgnoreCase))
+            {
+                if (string.IsNullOrWhiteSpace(prompt.Path))
+                {
+                    errors.Add($"Prompt {label}: Source is \"file\" but Path is missing.");
+                }
+                else
+                {
+                    var resolvedPath = ResolveFilePath(prompt.Path, configDirectory);
+                    if (!File.Exists(resolvedPath))
+                    {
+                        errors.Add($"Prompt {label}: Path '{prompt.Path}' does not resolve to an existing file (resolved: '{resolvedPath}').");
+                    }
+                }
+            }
+            else if (string.Equals(prompt.Source, CommandSource, StringComparison.OrdinalIgnoreCase))
+            {
+                if (string.IsNullOrWhiteSpace(prompt.Command))
+                {
+                    errors.Add($"Prompt {label}: Source is \"command\" but Command is empty.");
+                }
+            }
+
+            // Argument validation
+            foreach (var arg in prompt.Arguments)
+            {
+                if (string.IsNullOrWhiteSpace(arg.Name))
+                {
+                    if (arg.Required)
+                    {
+                        errors.Add($"Prompt {label}: A required argument has an empty Name — Required arguments must be named.");
+                    }
+                    else
+                    {
+                        errors.Add($"Prompt {label}: An argument has an empty Name — all argument Names must be non-empty.");
+                    }
+                }
+            }
+        }
+
+        var validCount = prompts.Count - CountAffectedEntries(prompts, errors);
+
+        return new McpPromptsDiagnostics(
+            Configured: prompts.Count,
+            Valid: Math.Max(0, validCount),
+            Errors: errors,
+            Warnings: warnings);
+    }
+
+    private static string ResolveFilePath(string path, string baseDirectory)
+    {
+        if (Path.IsPathRooted(path))
+            return path;
+        return Path.GetFullPath(Path.Combine(baseDirectory, path));
+    }
+
+    private static int CountAffectedEntries(List<McpPromptConfiguration> prompts, List<string> errors)
+    {
+        if (errors.Count == 0)
+            return 0;
+
+        var affected = 0;
+        foreach (var prompt in prompts)
+        {
+            var label = string.IsNullOrWhiteSpace(prompt.Name)
+                ? $"(unnamed prompt at index {prompts.IndexOf(prompt)})"
+                : $"'{prompt.Name}'";
+
+            if (errors.Any(e => e.Contains(label, StringComparison.OrdinalIgnoreCase)))
+                affected++;
+        }
+
+        return affected;
+    }
+}
+
+/// <summary>
+/// Structured diagnostics result for MCP prompt configuration validation.
+/// </summary>
+public record McpPromptsDiagnostics(
+    int Configured,
+    int Valid,
+    List<string> Errors,
+    List<string> Warnings);

--- a/PoshMcp.Server/McpResources/McpResourcesValidator.cs
+++ b/PoshMcp.Server/McpResources/McpResourcesValidator.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using PoshMcp.Server.McpPrompts;
+
+namespace PoshMcp.Server.McpResources;
+
+/// <summary>
+/// Validates an <see cref="McpResourcesConfiguration"/> and returns structured diagnostics.
+/// </summary>
+public static class McpResourcesValidator
+{
+    private const string FileSource = "file";
+    private const string CommandSource = "command";
+    private static readonly string[] ValidSources = [FileSource, CommandSource];
+    private const string RecommendedUriPrefix = "poshmcp://resources/";
+
+    /// <summary>
+    /// Validates all configured resources and returns a diagnostics summary.
+    /// </summary>
+    /// <param name="resourcesConfig">The resources configuration to validate.</param>
+    /// <param name="configDirectory">
+    /// Base directory used to resolve relative file paths (typically the directory containing appsettings.json).
+    /// </param>
+    public static McpResourcesDiagnostics Validate(McpResourcesConfiguration resourcesConfig, string configDirectory)
+    {
+        var errors = new List<string>();
+        var warnings = new List<string>();
+        var resources = resourcesConfig.Resources;
+
+        // Duplicate URI check
+        var uriGroups = resources
+            .Where(r => !string.IsNullOrWhiteSpace(r.Uri))
+            .GroupBy(r => r.Uri!, StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Count() > 1);
+        foreach (var group in uriGroups)
+        {
+            errors.Add($"Resource URI '{group.Key}' is duplicated across {group.Count()} entries.");
+        }
+
+        foreach (var resource in resources)
+        {
+            var label = string.IsNullOrWhiteSpace(resource.Uri)
+                ? $"(unnamed resource at index {resources.IndexOf(resource)})"
+                : $"'{resource.Uri}'";
+
+            // Source validity
+            if (string.IsNullOrWhiteSpace(resource.Source))
+            {
+                errors.Add($"Resource {label}: Source is missing. Must be \"file\" or \"command\".");
+            }
+            else if (!ValidSources.Contains(resource.Source, StringComparer.OrdinalIgnoreCase))
+            {
+                errors.Add($"Resource {label}: Source \"{resource.Source}\" is invalid. Must be \"file\" or \"command\".");
+            }
+            else if (string.Equals(resource.Source, FileSource, StringComparison.OrdinalIgnoreCase))
+            {
+                // File source: path must resolve to an existing file
+                if (string.IsNullOrWhiteSpace(resource.Path))
+                {
+                    errors.Add($"Resource {label}: Source is \"file\" but Path is missing.");
+                }
+                else
+                {
+                    var resolvedPath = ResolveFilePath(resource.Path, configDirectory);
+                    if (!File.Exists(resolvedPath))
+                    {
+                        errors.Add($"Resource {label}: Path '{resource.Path}' does not resolve to an existing file (resolved: '{resolvedPath}').");
+                    }
+                }
+            }
+            else if (string.Equals(resource.Source, CommandSource, StringComparison.OrdinalIgnoreCase))
+            {
+                // Command source: command must be non-empty
+                if (string.IsNullOrWhiteSpace(resource.Command))
+                {
+                    errors.Add($"Resource {label}: Source is \"command\" but Command is empty.");
+                }
+            }
+
+            // URI format recommendation
+            if (!string.IsNullOrWhiteSpace(resource.Uri) &&
+                !resource.Uri.StartsWith(RecommendedUriPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                warnings.Add($"Resource {label}: Uri does not follow the recommended '{RecommendedUriPrefix}{{slug}}' scheme.");
+            }
+
+            // MimeType presence recommendation
+            if (string.IsNullOrWhiteSpace(resource.MimeType))
+            {
+                warnings.Add($"Resource {label}: MimeType is not specified; will default to \"text/plain\".");
+            }
+        }
+
+        var validCount = resources.Count - CountAffectedEntries(resources, errors);
+
+        return new McpResourcesDiagnostics(
+            Configured: resources.Count,
+            Valid: Math.Max(0, validCount),
+            Errors: errors,
+            Warnings: warnings);
+    }
+
+    private static string ResolveFilePath(string path, string baseDirectory)
+    {
+        if (Path.IsPathRooted(path))
+            return path;
+        return Path.GetFullPath(Path.Combine(baseDirectory, path));
+    }
+
+    /// <summary>
+    /// Counts the number of resource entries that have at least one error mentioning their label.
+    /// Uses a simple heuristic: count distinct entries referenced in error messages.
+    /// </summary>
+    private static int CountAffectedEntries(List<McpResourceConfiguration> resources, List<string> errors)
+    {
+        if (errors.Count == 0)
+            return 0;
+
+        var affected = 0;
+        foreach (var resource in resources)
+        {
+            var label = string.IsNullOrWhiteSpace(resource.Uri)
+                ? $"(unnamed resource at index {resources.IndexOf(resource)})"
+                : $"'{resource.Uri}'";
+
+            if (errors.Any(e => e.Contains(label, StringComparison.OrdinalIgnoreCase)))
+                affected++;
+        }
+
+        // Duplicate URI errors affect all resources with that URI
+        var duplicateUriErrors = errors.Where(e => e.Contains("is duplicated", StringComparison.OrdinalIgnoreCase));
+        foreach (var dupError in duplicateUriErrors)
+        {
+            // Already counted above through the URI label logic
+        }
+
+        return affected;
+    }
+}
+
+/// <summary>
+/// Structured diagnostics result for MCP resource configuration validation.
+/// </summary>
+public record McpResourcesDiagnostics(
+    int Configured,
+    int Valid,
+    List<string> Errors,
+    List<string> Warnings);


### PR DESCRIPTION
## Summary
Implements FR-026 and FR-027 from Spec 002. Extends poshmcp doctor and validate-config with resource/prompt validation checks.

### Changes
- Config models for resources and prompts
- `McpResourcesValidator.cs` — 9 validation checks
- `McpPromptsValidator.cs` — argument and prompt checks
- `Program.cs` — doctor/validate-config JSON output extended with resources and prompts keys

### Farnsworth review: ✅ APPROVED (2 non-blocking nits noted)

Resolves Spec 002 FR-026, FR-027