### PR TITLE
fix(#133): add missing build context path to docker buildx build command

### DIFF
--- a/PoshMcp.Server/Program.cs
+++ b/PoshMcp.Server/Program.cs
@@ -689,7 +689,7 @@ public class Program
                     return;
                 }
 
-                var buildArgs = $"build -f {imageFile} -t {imageTag}";
+                var buildArgs = $"build -f {imageFile} -t {imageTag} .";
 
                 if (!string.IsNullOrWhiteSpace(modules))
                 {


### PR DESCRIPTION
Fixes #133

The docker buildx build invocation was missing the required PATH argument (build context). Added '.' as the default build context directory.