### PR TITLE
fix(#136): restore and build only PoshMcp.Server in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY PoshMcp.Server/PoshMcp.csproj ./PoshMcp.Server/
 
 # Restore dependencies in one stage for efficiency
 # This layer is cached unless project files change
-RUN dotnet restore PoshMcp.sln \
+RUN dotnet restore PoshMcp.Server/PoshMcp.csproj \
     && dotnet nuget locals http-cache --clear
 
 # Copy all source code (changes frequently - placed after stable dependencies)
@@ -19,7 +19,7 @@ COPY . .
 
 # Build and publish the PoshMcp.Server application in Release configuration
 # Use /p:UseAppHost=false for portability across architectures
-RUN dotnet build PoshMcp.sln -c Release --no-restore \
+RUN dotnet build PoshMcp.Server/PoshMcp.csproj -c Release --no-restore \
     && dotnet publish PoshMcp.Server/PoshMcp.csproj -c Release -o /app/publish/server /p:UseAppHost=false
 
 # Copy startup script to publish output

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 WORKDIR /src
 
-# Copy solution and project files first (stable layer - benefits from layer caching)
-COPY PoshMcp.sln ./
+# Copy project files first (stable layer - benefits from layer caching)
 COPY PoshMcp.Server/PoshMcp.csproj ./PoshMcp.Server/
 
 # Restore dependencies in one stage for efficiency


### PR DESCRIPTION
Fixes #136

The Dockerfile was restoring the full solution but only the server project files were copied into the build stage. TestClient and PoshMcp.Tests csproj files were missing, causing dotnet restore to fail.

This PR switches to restoring and building only PoshMcp.Server/PoshMcp.csproj, which is the only project needed for the Docker image.