### PR TITLE
feat(#137): add auth, logging, env vars, and MCP definitions to doctor

### DIFF
--- a/PoshMcp.Server/Program.cs
+++ b/PoshMcp.Server/Program.cs
@@ -896,6 +896,13 @@ public class Program
         var logger = loggerFactory.CreateLogger("Doctor");
 
         var config = ConfigurationLoader.LoadPowerShellConfiguration(settings.FinalConfigPath, logger, settings.RuntimeMode.Value);
+        var rawConfig = new ConfigurationBuilder()
+            .AddJsonFile(settings.FinalConfigPath, optional: true, reloadOnChange: false)
+            .Build();
+        var authenticationConfig = LoadFlatConfigSection(rawConfig, "Authentication");
+        var loggingConfig = LoadFlatConfigSection(rawConfig, "Logging");
+        var environmentVariables = CollectEnvironmentVariables();
+        var (resourcesDefinitionsConfig, promptsDefinitionsConfig) = TryLoadResourcesAndPromptsDefinitions(settings.FinalConfigPath);
         var tools = await DiscoverToolsAsync(config, loggerFactory, logger, settings.FinalConfigPath);
         var discoveredToolNames = GetDiscoveredToolNames(tools);
         var configuredFunctionStatus = BuildConfiguredFunctionStatus(config.GetEffectiveCommandNames(), discoveredToolNames);
@@ -939,7 +946,12 @@ public class Program
                 tools: tools,
                 precomputedFunctionStatus: configuredFunctionStatus,
                 resourcesDiagnostics: resourcesDiag,
-                promptsDiagnostics: promptsDiag));
+                promptsDiagnostics: promptsDiag,
+                authenticationConfig: authenticationConfig,
+                loggingConfig: loggingConfig,
+                environmentVariables: environmentVariables,
+                resourceDefinitions: resourcesDefinitionsConfig,
+                promptDefinitions: promptsDefinitionsConfig));
             return;
         }
 
@@ -1047,6 +1059,46 @@ public class Program
             foreach (var warning in promptsDiag.Warnings)
                 Console.WriteLine($"  ⚠ {warning}");
         }
+
+        Console.WriteLine("Environment variables:");
+        foreach (var kvp in environmentVariables)
+            Console.WriteLine($"  {kvp.Key}={kvp.Value ?? "(not set)"}");
+
+        Console.WriteLine("Authentication config:");
+        if (authenticationConfig.Count > 0)
+        {
+            foreach (var kvp in authenticationConfig)
+                Console.WriteLine($"  {kvp.Key}={kvp.Value}");
+        }
+        else
+        {
+            Console.WriteLine("  (none)");
+        }
+
+        Console.WriteLine("Logging config:");
+        if (loggingConfig.Count > 0)
+        {
+            foreach (var kvp in loggingConfig)
+                Console.WriteLine($"  {kvp.Key}={kvp.Value}");
+        }
+        else
+        {
+            Console.WriteLine("  (none)");
+        }
+
+        if (resourcesDefinitionsConfig.Count > 0)
+        {
+            Console.WriteLine("Resource definitions:");
+            foreach (var resource in resourcesDefinitionsConfig)
+                Console.WriteLine($"  - {resource.Uri} ({resource.Name})");
+        }
+
+        if (promptsDefinitionsConfig.Count > 0)
+        {
+            Console.WriteLine("Prompt definitions:");
+            foreach (var prompt in promptsDefinitionsConfig)
+                Console.WriteLine($"  - {prompt.Name}");
+        }
     }
 
     internal static string BuildDoctorJson(
@@ -1066,7 +1118,12 @@ public class Program
         List<McpServerTool> tools,
         List<ConfiguredFunctionStatus>? precomputedFunctionStatus = null,
         McpResourcesDiagnostics? resourcesDiagnostics = null,
-        McpPromptsDiagnostics? promptsDiagnostics = null)
+        McpPromptsDiagnostics? promptsDiagnostics = null,
+        Dictionary<string, string?>? authenticationConfig = null,
+        Dictionary<string, string?>? loggingConfig = null,
+        Dictionary<string, string?>? environmentVariables = null,
+        IReadOnlyList<McpResourceConfiguration>? resourceDefinitions = null,
+        IReadOnlyList<McpPromptConfiguration>? promptDefinitions = null)
     {
         var discoveredToolNames = GetDiscoveredToolNames(tools);
         var configuredFunctionStatus = precomputedFunctionStatus
@@ -1095,6 +1152,20 @@ public class Program
         // Compute resource/prompt diagnostics if not pre-supplied
         resourcesDiagnostics ??= ConfigurationLoader.TryValidateResourcesAndPrompts(configurationPath).Resources;
         promptsDiagnostics ??= ConfigurationLoader.TryValidateResourcesAndPrompts(configurationPath).Prompts;
+
+        // Compute new diagnostic sections if not pre-supplied
+        if (authenticationConfig is null || loggingConfig is null)
+        {
+            var rawConfig = new ConfigurationBuilder()
+                .AddJsonFile(configurationPath, optional: true, reloadOnChange: false)
+                .Build();
+            authenticationConfig ??= LoadFlatConfigSection(rawConfig, "Authentication");
+            loggingConfig ??= LoadFlatConfigSection(rawConfig, "Logging");
+        }
+        environmentVariables ??= CollectEnvironmentVariables();
+        var (resDefsConfig, promDefsConfig) = TryLoadResourcesAndPromptsDefinitions(configurationPath);
+        resourceDefinitions ??= resDefsConfig;
+        promptDefinitions ??= promDefsConfig;
 
         var resourcesSummary = new
         {
@@ -1141,6 +1212,11 @@ public class Program
             oopModulePaths,
             resources = resourcesSummary,
             prompts = promptsSummary,
+            environmentVariables,
+            authenticationConfig,
+            loggingConfig,
+            resourceDefinitions,
+            promptDefinitions,
             generatedAtUtc = DateTime.UtcNow
         };
 
@@ -1159,6 +1235,41 @@ public class Program
             warnings.Add("FunctionNames is deprecated. Migrate to CommandNames in your appsettings.json (rename the \"FunctionNames\" array to \"CommandNames\").");
         }
         return warnings;
+    }
+
+    private static Dictionary<string, string?> CollectEnvironmentVariables()
+    {
+        return new Dictionary<string, string?>
+        {
+            ["POSHMCP_CONFIG"] = Environment.GetEnvironmentVariable("POSHMCP_CONFIG"),
+            ["POSHMCP_TRANSPORT"] = Environment.GetEnvironmentVariable("POSHMCP_TRANSPORT"),
+            ["POSHMCP_LOG_LEVEL"] = Environment.GetEnvironmentVariable("POSHMCP_LOG_LEVEL"),
+            ["POSHMCP_SESSION_MODE"] = Environment.GetEnvironmentVariable("POSHMCP_SESSION_MODE"),
+            ["POSHMCP_RUNTIME_MODE"] = Environment.GetEnvironmentVariable("POSHMCP_RUNTIME_MODE"),
+            ["POSHMCP_MCP_PATH"] = Environment.GetEnvironmentVariable("POSHMCP_MCP_PATH"),
+            ["ASPNETCORE_ENVIRONMENT"] = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
+        };
+    }
+
+    private static Dictionary<string, string?> LoadFlatConfigSection(IConfiguration configuration, string sectionName)
+    {
+        return configuration.GetSection(sectionName)
+            .AsEnumerable(makePathsRelative: true)
+            .Where(kvp => kvp.Value is not null)
+            .ToDictionary(kvp => kvp.Key, kvp => (string?)kvp.Value);
+    }
+
+    private static (IReadOnlyList<McpResourceConfiguration> Resources, IReadOnlyList<McpPromptConfiguration> Prompts) TryLoadResourcesAndPromptsDefinitions(string configPath)
+    {
+        try
+        {
+            var (resourcesConfig, promptsConfig) = ConfigurationLoader.LoadResourcesAndPromptsConfiguration(configPath);
+            return (resourcesConfig.Resources, promptsConfig.Prompts);
+        }
+        catch
+        {
+            return (Array.Empty<McpResourceConfiguration>(), Array.Empty<McpPromptConfiguration>());
+        }
     }
 
     internal static string SerializeEffectivePowerShellConfiguration(PowerShellConfiguration config, bool writeIndented = false)

--- a/PoshMcp.Server/Program.cs
+++ b/PoshMcp.Server/Program.cs
@@ -899,8 +899,8 @@ public class Program
         var rawConfig = new ConfigurationBuilder()
             .AddJsonFile(settings.FinalConfigPath, optional: true, reloadOnChange: false)
             .Build();
-        var authenticationConfig = LoadFlatConfigSection(rawConfig, "Authentication");
-        var loggingConfig = LoadFlatConfigSection(rawConfig, "Logging");
+        var authenticationConfig = RedactSensitiveConfigValues(LoadFlatConfigSection(rawConfig, "Authentication"));
+        var loggingConfig = RedactSensitiveConfigValues(LoadFlatConfigSection(rawConfig, "Logging"));
         var environmentVariables = CollectEnvironmentVariables();
         var (resourcesDefinitionsConfig, promptsDefinitionsConfig) = TryLoadResourcesAndPromptsDefinitions(settings.FinalConfigPath);
         var tools = await DiscoverToolsAsync(config, loggerFactory, logger, settings.FinalConfigPath);
@@ -1159,13 +1159,16 @@ public class Program
             var rawConfig = new ConfigurationBuilder()
                 .AddJsonFile(configurationPath, optional: true, reloadOnChange: false)
                 .Build();
-            authenticationConfig ??= LoadFlatConfigSection(rawConfig, "Authentication");
-            loggingConfig ??= LoadFlatConfigSection(rawConfig, "Logging");
+            authenticationConfig ??= RedactSensitiveConfigValues(LoadFlatConfigSection(rawConfig, "Authentication"));
+            loggingConfig ??= RedactSensitiveConfigValues(LoadFlatConfigSection(rawConfig, "Logging"));
         }
         environmentVariables ??= CollectEnvironmentVariables();
-        var (resDefsConfig, promDefsConfig) = TryLoadResourcesAndPromptsDefinitions(configurationPath);
-        resourceDefinitions ??= resDefsConfig;
-        promptDefinitions ??= promDefsConfig;
+        if (resourceDefinitions is null || promptDefinitions is null)
+        {
+            var (resDefsConfig, promDefsConfig) = TryLoadResourcesAndPromptsDefinitions(configurationPath);
+            resourceDefinitions ??= resDefsConfig;
+            promptDefinitions ??= promDefsConfig;
+        }
 
         var resourcesSummary = new
         {
@@ -1250,6 +1253,16 @@ public class Program
             ["ASPNETCORE_ENVIRONMENT"] = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
         };
     }
+
+    private static readonly string[] _sensitiveKeyPatterns =
+        ["password", "secret", "key", "token", "connectionstring", "credential", "pwd", "apikey", "clientsecret"];
+
+    private static bool IsSensitiveKey(string key) =>
+        _sensitiveKeyPatterns.Any(pattern => key.Contains(pattern, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>Returns a copy of <paramref name="config"/> with values whose keys match sensitive patterns replaced with <c>[REDACTED]</c>.</summary>
+    private static Dictionary<string, string?> RedactSensitiveConfigValues(Dictionary<string, string?> config) =>
+        config.ToDictionary(kvp => kvp.Key, kvp => IsSensitiveKey(kvp.Key) ? "[REDACTED]" : kvp.Value);
 
     private static Dictionary<string, string?> LoadFlatConfigSection(IConfiguration configuration, string sectionName)
     {

--- a/PoshMcp.Tests/Unit/ProgramDoctorConfigCoverageTests.cs
+++ b/PoshMcp.Tests/Unit/ProgramDoctorConfigCoverageTests.cs
@@ -1,0 +1,312 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PoshMcp.Tests.Unit;
+
+[Collection("TransportSelectionTests")]
+public class ProgramDoctorConfigCoverageTests
+{
+    [Fact]
+    public async Task DoctorJson_IncludesEnvironmentVariables_WithSevenExpectedKeys()
+    {
+        using var configFile = new DoctorConfigFile();
+        using var capture = new DoctorConsoleCapture();
+
+        var result = await Program.Main(["doctor", "--config", configFile.Path, "--format", "json"]);
+
+        Assert.Equal(0, result);
+        var payload = JsonNode.Parse(capture.StandardOutput.Trim())?.AsObject();
+        Assert.NotNull(payload);
+        var envVars = payload!["environmentVariables"]?.AsObject();
+        Assert.NotNull(envVars);
+        Assert.True(envVars!.ContainsKey("POSHMCP_CONFIG"));
+        Assert.True(envVars.ContainsKey("POSHMCP_TRANSPORT"));
+        Assert.True(envVars.ContainsKey("POSHMCP_LOG_LEVEL"));
+        Assert.True(envVars.ContainsKey("POSHMCP_SESSION_MODE"));
+        Assert.True(envVars.ContainsKey("POSHMCP_RUNTIME_MODE"));
+        Assert.True(envVars.ContainsKey("POSHMCP_MCP_PATH"));
+        Assert.True(envVars.ContainsKey("ASPNETCORE_ENVIRONMENT"));
+    }
+
+    [Fact]
+    public async Task DoctorJson_EnvironmentVariables_ReflectsSetValues()
+    {
+        using var configFile = new DoctorConfigFile();
+        using var capture = new DoctorConsoleCapture();
+        using var envScope = new DoctorEnvVarScope("POSHMCP_TRANSPORT", "http");
+
+        var result = await Program.Main(["doctor", "--config", configFile.Path, "--format", "json"]);
+
+        Assert.Equal(0, result);
+        var payload = JsonNode.Parse(capture.StandardOutput.Trim())?.AsObject();
+        var envVars = payload!["environmentVariables"]?.AsObject();
+        Assert.NotNull(envVars);
+        Assert.Equal("http", envVars!["POSHMCP_TRANSPORT"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task DoctorJson_IncludesAuthenticationConfig()
+    {
+        using var configFile = new DoctorConfigFile(includeAuthentication: true);
+        using var capture = new DoctorConsoleCapture();
+
+        var result = await Program.Main(["doctor", "--config", configFile.Path, "--format", "json"]);
+
+        Assert.Equal(0, result);
+        var payload = JsonNode.Parse(capture.StandardOutput.Trim())?.AsObject();
+        Assert.NotNull(payload);
+        Assert.NotNull(payload!["authenticationConfig"]);
+    }
+
+    [Fact]
+    public async Task DoctorJson_IncludesLoggingConfig()
+    {
+        using var configFile = new DoctorConfigFile();
+        using var capture = new DoctorConsoleCapture();
+
+        var result = await Program.Main(["doctor", "--config", configFile.Path, "--format", "json"]);
+
+        Assert.Equal(0, result);
+        var payload = JsonNode.Parse(capture.StandardOutput.Trim())?.AsObject();
+        Assert.NotNull(payload);
+        Assert.NotNull(payload!["loggingConfig"]);
+    }
+
+    [Fact]
+    public async Task DoctorJson_IncludesResourceDefinitions()
+    {
+        using var configFile = new DoctorConfigFile(includeResource: true);
+        using var capture = new DoctorConsoleCapture();
+
+        var result = await Program.Main(["doctor", "--config", configFile.Path, "--format", "json"]);
+
+        Assert.Equal(0, result);
+        var payload = JsonNode.Parse(capture.StandardOutput.Trim())?.AsObject();
+        Assert.NotNull(payload);
+        var defs = payload!["resourceDefinitions"]?.AsArray();
+        Assert.NotNull(defs);
+        Assert.True(defs!.Count > 0);
+        Assert.Equal("poshmcp://test/resource", defs[0]?["Uri"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task DoctorJson_IncludesPromptDefinitions()
+    {
+        using var configFile = new DoctorConfigFile(includePrompt: true);
+        using var capture = new DoctorConsoleCapture();
+
+        var result = await Program.Main(["doctor", "--config", configFile.Path, "--format", "json"]);
+
+        Assert.Equal(0, result);
+        var payload = JsonNode.Parse(capture.StandardOutput.Trim())?.AsObject();
+        Assert.NotNull(payload);
+        var defs = payload!["promptDefinitions"]?.AsArray();
+        Assert.NotNull(defs);
+        Assert.True(defs!.Count > 0);
+        Assert.Equal("test-prompt", defs[0]?["Name"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task DoctorText_IncludesEnvironmentVariablesSection()
+    {
+        using var configFile = new DoctorConfigFile();
+        using var capture = new DoctorConsoleCapture();
+
+        var result = await Program.Main(["doctor", "--config", configFile.Path]);
+
+        Assert.Equal(0, result);
+        Assert.Contains("Environment variables:", capture.StandardOutput);
+        Assert.Contains("POSHMCP_TRANSPORT=", capture.StandardOutput);
+    }
+
+    [Fact]
+    public async Task DoctorText_IncludesAuthenticationConfigSection()
+    {
+        using var configFile = new DoctorConfigFile(includeAuthentication: true);
+        using var capture = new DoctorConsoleCapture();
+
+        var result = await Program.Main(["doctor", "--config", configFile.Path]);
+
+        Assert.Equal(0, result);
+        Assert.Contains("Authentication config:", capture.StandardOutput);
+    }
+
+    [Fact]
+    public async Task DoctorText_IncludesLoggingConfigSection()
+    {
+        using var configFile = new DoctorConfigFile();
+        using var capture = new DoctorConsoleCapture();
+
+        var result = await Program.Main(["doctor", "--config", configFile.Path]);
+
+        Assert.Equal(0, result);
+        Assert.Contains("Logging config:", capture.StandardOutput);
+    }
+
+    [Fact]
+    public async Task DoctorText_UnsetEnvVarDisplaysNotSet()
+    {
+        using var configFile = new DoctorConfigFile();
+        using var capture = new DoctorConsoleCapture();
+        using var envScope = new DoctorEnvVarScope("POSHMCP_MCP_PATH", null);
+
+        var result = await Program.Main(["doctor", "--config", configFile.Path]);
+
+        Assert.Equal(0, result);
+        Assert.Contains("POSHMCP_MCP_PATH=(not set)", capture.StandardOutput);
+    }
+
+    [Fact]
+    public async Task DoctorText_IncludesResourceDefinitionsSection()
+    {
+        using var configFile = new DoctorConfigFile(includeResource: true);
+        using var capture = new DoctorConsoleCapture();
+
+        var result = await Program.Main(["doctor", "--config", configFile.Path]);
+
+        Assert.Equal(0, result);
+        Assert.Contains("Resource definitions:", capture.StandardOutput);
+        Assert.Contains("poshmcp://test/resource", capture.StandardOutput);
+    }
+
+    [Fact]
+    public async Task DoctorText_IncludesPromptDefinitionsSection()
+    {
+        using var configFile = new DoctorConfigFile(includePrompt: true);
+        using var capture = new DoctorConsoleCapture();
+
+        var result = await Program.Main(["doctor", "--config", configFile.Path]);
+
+        Assert.Equal(0, result);
+        Assert.Contains("Prompt definitions:", capture.StandardOutput);
+        Assert.Contains("test-prompt", capture.StandardOutput);
+    }
+
+    private sealed class DoctorConfigFile : IDisposable
+    {
+        public string Path { get; }
+
+        public DoctorConfigFile(
+            bool includeAuthentication = false,
+            bool includeResource = false,
+            bool includePrompt = false)
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"poshmcp-doctor-coverage-{Guid.NewGuid():N}.json");
+
+            var authSection = includeAuthentication
+                ? """
+  "Authentication": {
+    "Enabled": false,
+    "DefaultScheme": "Bearer"
+  },
+"""
+                : string.Empty;
+
+            var resourceSection = includeResource
+                ? """
+  "McpResources": {
+    "Resources": [
+      {
+        "Uri": "poshmcp://test/resource",
+        "Name": "Test Resource",
+        "Source": "command",
+        "Command": "echo test"
+      }
+    ]
+  },
+"""
+                : string.Empty;
+
+            var promptSection = includePrompt
+                ? """
+  "McpPrompts": {
+    "Prompts": [
+      {
+        "Name": "test-prompt",
+        "Description": "A test prompt",
+        "Source": "command",
+        "Command": "echo prompt"
+      }
+    ]
+  },
+"""
+                : string.Empty;
+
+            var json = $$"""
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  },
+  {{authSection}}
+  {{resourceSection}}
+  {{promptSection}}
+  "PowerShellConfiguration": {
+    "FunctionNames": ["Get-Date"]
+  }
+}
+""";
+
+            File.WriteAllText(Path, json);
+        }
+
+        public void Dispose()
+        {
+            if (File.Exists(Path))
+                File.Delete(Path);
+        }
+    }
+
+    private sealed class DoctorConsoleCapture : IDisposable
+    {
+        private readonly TextWriter _originalOut;
+        private readonly TextWriter _originalError;
+        private readonly StringWriter _capturedOut;
+        private readonly StringWriter _capturedError;
+
+        public string StandardOutput => _capturedOut.ToString();
+
+        public DoctorConsoleCapture()
+        {
+            _originalOut = Console.Out;
+            _originalError = Console.Error;
+            _capturedOut = new StringWriter();
+            _capturedError = new StringWriter();
+            Console.SetOut(_capturedOut);
+            Console.SetError(_capturedError);
+        }
+
+        public void Dispose()
+        {
+            Console.SetOut(_originalOut);
+            Console.SetError(_originalError);
+            _capturedOut.Dispose();
+            _capturedError.Dispose();
+        }
+    }
+
+    private sealed class DoctorEnvVarScope : IDisposable
+    {
+        private readonly string _name;
+        private readonly string? _originalValue;
+
+        public DoctorEnvVarScope(string name, string? value)
+        {
+            _name = name;
+            _originalValue = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(_name, _originalValue);
+        }
+    }
+}

--- a/PoshMcp.Tests/Unit/ProgramDoctorConfigCoverageTests.cs
+++ b/PoshMcp.Tests/Unit/ProgramDoctorConfigCoverageTests.cs
@@ -186,12 +186,91 @@ public class ProgramDoctorConfigCoverageTests
         Assert.Contains("test-prompt", capture.StandardOutput);
     }
 
+    [Fact]
+    public async Task DoctorJson_SensitiveAuthConfigValues_AreRedacted()
+    {
+        using var configFile = new DoctorConfigFile(includeAuthWithSecret: true);
+        using var capture = new DoctorConsoleCapture();
+
+        var result = await Program.Main(["doctor", "--config", configFile.Path, "--format", "json"]);
+
+        Assert.Equal(0, result);
+        var payload = JsonNode.Parse(capture.StandardOutput.Trim())?.AsObject();
+        Assert.NotNull(payload);
+        var authConfig = payload!["authenticationConfig"]?.AsObject();
+        Assert.NotNull(authConfig);
+        Assert.Equal("[REDACTED]", authConfig!["ClientSecret"]?.GetValue<string>());
+        Assert.NotEqual("[REDACTED]", authConfig["ClientId"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task DoctorText_SensitiveAuthConfigValues_AreRedacted()
+    {
+        using var configFile = new DoctorConfigFile(includeAuthWithSecret: true);
+        using var capture = new DoctorConsoleCapture();
+
+        var result = await Program.Main(["doctor", "--config", configFile.Path]);
+
+        Assert.Equal(0, result);
+        Assert.Contains("ClientSecret=[REDACTED]", capture.StandardOutput);
+        Assert.DoesNotContain("super-secret-value", capture.StandardOutput);
+        Assert.Contains("ClientId=my-client-id", capture.StandardOutput);
+    }
+
+    [Fact]
+    public void BuildDoctorJson_WithPreSuppliedResourceAndPromptDefs_UsesPreSupplied()
+    {
+        var configFile = new DoctorConfigFile();
+        try
+        {
+            var preSuppliedResources = new List<PoshMcp.Server.McpResources.McpResourceConfiguration>
+            {
+                new() { Uri = "poshmcp://preloaded/res", Name = "Preloaded", Source = "command", Command = "echo" }
+            };
+            var preSuppliedPrompts = new List<PoshMcp.Server.McpPrompts.McpPromptConfiguration>
+            {
+                new() { Name = "preloaded-prompt", Description = "Pre", Source = "command", Command = "echo" }
+            };
+
+            var json = Program.BuildDoctorJson(
+                configurationPath: configFile.Path,
+                configurationPathSource: "test",
+                effectiveLogLevel: "Warning",
+                effectiveLogLevelSource: "default",
+                effectiveTransport: "stdio",
+                effectiveTransportSource: "default",
+                effectiveSessionMode: null,
+                effectiveSessionModeSource: "default",
+                effectiveRuntimeMode: "InProcess",
+                effectiveRuntimeModeSource: "default",
+                effectiveMcpPath: null,
+                effectiveMcpPathSource: "default",
+                config: PoshMcp.ConfigurationLoader.LoadPowerShellConfiguration(configFile.Path, Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance, "InProcess"),
+                tools: [],
+                resourceDefinitions: preSuppliedResources,
+                promptDefinitions: preSuppliedPrompts);
+
+            var payload = JsonNode.Parse(json)?.AsObject();
+            var resDefs = payload!["resourceDefinitions"]?.AsArray();
+            Assert.NotNull(resDefs);
+            Assert.Equal("poshmcp://preloaded/res", resDefs![0]?["Uri"]?.GetValue<string>());
+            var promptDefs = payload["promptDefinitions"]?.AsArray();
+            Assert.NotNull(promptDefs);
+            Assert.Equal("preloaded-prompt", promptDefs![0]?["Name"]?.GetValue<string>());
+        }
+        finally
+        {
+            configFile.Dispose();
+        }
+    }
+
     private sealed class DoctorConfigFile : IDisposable
     {
         public string Path { get; }
 
         public DoctorConfigFile(
             bool includeAuthentication = false,
+            bool includeAuthWithSecret = false,
             bool includeResource = false,
             bool includePrompt = false)
         {
@@ -199,13 +278,21 @@ public class ProgramDoctorConfigCoverageTests
                 System.IO.Path.GetTempPath(),
                 $"poshmcp-doctor-coverage-{Guid.NewGuid():N}.json");
 
-            var authSection = includeAuthentication
-                ? """
+            var authSection = (includeAuthentication || includeAuthWithSecret)
+                ? (includeAuthWithSecret
+                    ? """
+  "Authentication": {
+    "Enabled": false,
+    "ClientId": "my-client-id",
+    "ClientSecret": "super-secret-value"
+  },
+"""
+                    : """
   "Authentication": {
     "Enabled": false,
     "DefaultScheme": "Bearer"
   },
-"""
+""")
                 : string.Empty;
 
             var resourceSection = includeResource


### PR DESCRIPTION
Fixes #137

Adds 4 missing diagnostic sections to poshmcp doctor (both text and JSON output):
- Authentication config from appsettings
- Logging config from appsettings
- 7 environment variable values (POSHMCP_* + ASPNETCORE_ENVIRONMENT)
- MCP resource and prompt definitions