### PR TITLE
feat: implement ConfigureApplicationInsights() in Program.cs (#172)

### DIFF
--- a/PoshMcp.Server/PowerShell/PowerShellAssemblyGenerator.cs
+++ b/PoshMcp.Server/PowerShell/PowerShellAssemblyGenerator.cs
@@ -44,6 +44,9 @@ public class PowerShellAssemblyGenerator
     // Static metrics instance for instrumentation
     private static McpMetrics? _metrics;
 
+    // ActivitySource for distributed tracing (FR-310: parameter names as custom properties)
+    internal static readonly ActivitySource ToolActivitySource = new("PoshMcp.Tools", "1.0.0");
+
     // Static configuration and runtime state for caching resolution
     private static PowerShellConfiguration? _powerShellConfig;
     private static RuntimeCachingState? _runtimeCachingState;
@@ -685,7 +688,18 @@ public class PowerShellAssemblyGenerator
         {
             using (OperationContext.BeginOperation(commandName))
             using (logger.BeginCorrelationScope())
+            using (var activity = ToolActivitySource.StartActivity("tool.invoke", ActivityKind.Internal))
             {
+                // FR-310: Add parameter names (NOT values) as custom properties for App Insights
+                activity?.SetTag("tool.name", commandName);
+                if (parameterInfos != null)
+                {
+                    var paramNames = string.Join(",", parameterInfos
+                        .Where(p => !p.Name.StartsWith("_", StringComparison.Ordinal))
+                        .Select(p => p.Name));
+                    activity?.SetTag("tool.parameter_names", paramNames);
+                }
+
                 var invocationId = OperationContext.CorrelationId;
                 var parameterCount = parameterValues?.Length ?? 0;
 

--- a/PoshMcp.Server/Program.cs
+++ b/PoshMcp.Server/Program.cs
@@ -2495,6 +2495,19 @@ public class Program
                     new KeyValuePair<string, object>("transport.mode", (object)transportMode)
                 }));
 
+        // FR-311/FR-312: Suppress OTel log export to Azure Monitor.
+        // UseAzureMonitor() registers an OpenTelemetryLoggerProvider that would export
+        // all ILogger output (including parameter values logged at Debug level) to App Insights.
+        // We only want traces and metrics exported — not logs.
+        services.Configure<LoggerFilterOptions>(opts =>
+        {
+            opts.Rules.Add(new LoggerFilterRule(
+                providerName: "OpenTelemetry",
+                categoryName: null,
+                logLevel: LogLevel.None,
+                filter: null));
+        });
+
         Console.Error.WriteLine($"[INFO] Application Insights enabled. Sampling: {samplingPercentage}%");
     }
 

--- a/PoshMcp.Server/Program.cs
+++ b/PoshMcp.Server/Program.cs
@@ -18,6 +18,8 @@ using PoshMcp.Server.PowerShell.OutOfProcess;
 using PoshMcp.Server.Metrics;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using Azure.Monitor.OpenTelemetry.AspNetCore;
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
@@ -37,7 +39,6 @@ using PoshMcp.Server.Authentication;
 using PoshMcp.Server.McpPrompts;
 using PoshMcp.Server.McpResources;
 using ModelContextProtocol.Protocol;
-
 namespace PoshMcp;
 
 public class Program
@@ -1729,6 +1730,7 @@ public class Program
         RegisterHealthChecks(builder);
 
         ConfigureOpenTelemetryForHttp(builder);
+        ConfigureApplicationInsights(builder.Services, builder.Configuration, isStdioMode: false);
 
         using var bootstrapLoggerFactory = LoggingHelpers.CreateLoggerFactory(logLevel);
         var logger = bootstrapLoggerFactory.CreateLogger("PoshMcpHttpLogger");
@@ -2403,6 +2405,7 @@ public class Program
     {
         ConfigureJsonSerializerOptions(builder);
         ConfigureOpenTelemetry(builder, isStdioMode: true);
+        ConfigureApplicationInsights(builder.Services, builder.Configuration, isStdioMode: true);
         RegisterMcpServerServices(builder, tools, resourcesConfig, configFilePath, loggerFactory, promptHandler);
         RegisterCleanupServices(builder);
     }
@@ -2452,6 +2455,47 @@ public class Program
             options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
             options.WriteIndented = false;
         });
+    }
+
+    private static void ConfigureApplicationInsights(
+        IServiceCollection services,
+        IConfiguration configuration,
+        bool isStdioMode)
+    {
+        var options = configuration.GetSection(PoshMcp.Server.ApplicationInsightsOptions.SectionName).Get<PoshMcp.Server.ApplicationInsightsOptions>()
+                      ?? new PoshMcp.Server.ApplicationInsightsOptions();
+
+        if (!options.Enabled)
+            return;
+
+        var connectionString = options.ConnectionString;
+        if (string.IsNullOrWhiteSpace(connectionString))
+            connectionString = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING");
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            Console.Error.WriteLine("[WARN] Application Insights is enabled but no connection string was found. " +
+                                    "Set ApplicationInsights.ConnectionString in appsettings.json or the " +
+                                    "APPLICATIONINSIGHTS_CONNECTION_STRING environment variable.");
+            return;
+        }
+
+        var samplingPercentage = Math.Clamp(options.SamplingPercentage, 1, 100);
+        var transportMode = isStdioMode ? "stdio" : "http";
+
+        services.AddOpenTelemetry()
+            .UseAzureMonitor(azureMonitorOptions =>
+            {
+                azureMonitorOptions.ConnectionString = connectionString;
+                azureMonitorOptions.SamplingRatio = samplingPercentage / 100.0f;
+            })
+            .ConfigureResource(resource =>
+                resource.AddAttributes(new[]
+                {
+                    new KeyValuePair<string, object>("transport.mode", (object)transportMode)
+                }));
+
+        Console.Error.WriteLine($"[INFO] Application Insights enabled. Sampling: {samplingPercentage}%");
     }
 
     private static void RegisterMcpServerServices(

--- a/PoshMcp.Server/Program.cs
+++ b/PoshMcp.Server/Program.cs
@@ -19,6 +19,7 @@ using PoshMcp.Server.Metrics;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 using Azure.Monitor.OpenTelemetry.AspNetCore;
 using System;
 using System.Collections.Generic;
@@ -1903,6 +1904,10 @@ public class Program
         builder.Services.AddSingleton<McpMetrics>();
 
         builder.Services.AddOpenTelemetry()
+            .WithTracing(tracingBuilder =>
+            {
+                tracingBuilder.AddSource(PowerShellAssemblyGenerator.ToolActivitySource.Name);
+            })
             .WithMetrics(metricsBuilder =>
             {
                 metricsBuilder
@@ -2416,6 +2421,10 @@ public class Program
         builder.Services.AddSingleton<McpMetrics>();
 
         builder.Services.AddOpenTelemetry()
+            .WithTracing(tracingBuilder =>
+            {
+                tracingBuilder.AddSource(PowerShellAssemblyGenerator.ToolActivitySource.Name);
+            })
             .WithMetrics(metricsBuilder =>
             {
                 metricsBuilder.AddMeter(McpMetrics.MeterName);

--- a/PoshMcp.Server/appsettings.json
+++ b/PoshMcp.Server/appsettings.json
@@ -57,5 +57,10 @@
       "RequiredRoles": []
     },
     "Schemes": {}
+  },
+  "ApplicationInsights": {
+    "Enabled": false,
+    "ConnectionString": "",
+    "SamplingPercentage": 100
   }
 }


### PR DESCRIPTION
Closes #172

Implements ConfigureApplicationInsights() that conditionally wires up Azure Monitor OpenTelemetry when ApplicationInsights.Enabled is true. Sampling percentage is configurable (1-100, default 100), connection string falls back to APPLICATIONINSIGHTS_CONNECTION_STRING env var.

<!-- Reviewer: Farnsworth -->