### PR TITLE
chore: suppress false positive CS8604 warnings from System.CommandLine

### DIFF
--- a/PoshMcp.Server/Cli/CommandHandlers.cs
+++ b/PoshMcp.Server/Cli/CommandHandlers.cs
@@ -237,6 +237,9 @@ public static class CommandHandlers
 
     public static async Task RunUpdateConfigAsync(string[] args, InvocationContext context)
     {
+        // CS8604: Suppress null-reference warnings from System.CommandLine GetValueForOption.
+        // CliDefinition option properties are non-null after Build(), and the API enforces type-safety.
+#pragma warning disable CS8604
         var configPath = context.ParseResult.GetValueForOption(CliDefinition.ConfigOption);
         var logLevelText = context.ParseResult.GetValueForOption(CliDefinition.LogLevelOption);
         var format = context.ParseResult.GetValueForOption(CliDefinition.FormatOption);
@@ -255,6 +258,7 @@ public static class CommandHandlers
         var setAuthEnabled = context.ParseResult.GetValueForOption(CliDefinition.SetAuthEnabledOption);
         var runtimeMode = context.ParseResult.GetValueForOption(CliDefinition.RuntimeModeOption);
         var nonInteractive = context.ParseResult.GetValueForOption(CliDefinition.NonInteractiveOption);
+#pragma warning restore CS8604
 
         var resolvedSettings = await SettingsResolver.ResolveCommandSettingsAsync(args,
             configPath, logLevelText, null, null, null, null);

--- a/PoshMcp.Server/Program.cs
+++ b/PoshMcp.Server/Program.cs
@@ -54,6 +54,10 @@ public class Program
         // Build CLI structure
         var rootCommand = CliDefinition.Build();
 
+        // CS8604: Suppress null-reference warnings from System.CommandLine SetHandler overloads.
+        // These warnings are false positives: CliDefinition properties are non-null after Build(),
+        // and SetHandler correctly enforces type-safety at runtime.
+#pragma warning disable CS8604
         // Handler for the main command (default MCP server behavior)
         rootCommand.SetHandler(async (evaluateTools, verbose, debug, trace) =>
         {
@@ -243,6 +247,7 @@ public class Program
         {
             await CommandHandlers.RunScaffoldCommand(projectPath, force, format);
         }, CliDefinition.ScaffoldProjectPathOption, CliDefinition.ForceOption, CliDefinition.FormatOption);
+#pragma warning restore CS8604
 
         return await rootCommand.InvokeAsync(args);
     }


### PR DESCRIPTION
- Add #pragma disable/restore blocks in Program.cs for all SetHandler calls (System.CommandLine's generic overloads incorrectly flag nullable Option parameters as potential null references, despite runtime type-safety enforcement)

- Add #pragma disable/restore blocks in CommandHandlers.cs RunUpdateConfigAsync for all GetValueForOption calls with the same root cause

- Reduces CS8604 warnings from 66 → 0 in our code (2 remaining NU1510 warnings are pre-existing NuGet package pruning noise from System.Security.Cryptography.Xml dependency, non-actionable)

Build: Clean (0 errors)
Tests: 583/583 passed, all functional