### PR TITLE
feat(benchmarks): PoshMcp.Benchmarks harness infrastructure (#193)

### DIFF
--- a/PoshMcp.Benchmarks/BenchmarkConfig.cs
+++ b/PoshMcp.Benchmarks/BenchmarkConfig.cs
@@ -1,0 +1,30 @@
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Loggers;
+
+namespace PoshMcp.Benchmarks;
+
+/// <summary>
+/// Shared BenchmarkDotNet configuration for the OOP executor comparison.
+/// Per the experiment plan (specs/004-out-of-process-execution/runspace-pool-experiment-plan.md §4),
+/// per-scenario thresholds live on individual [Benchmark] methods (via
+/// [MinIterationCount]/[MaxIterationCount]) rather than as a single
+/// global bar — a 4× speedup target on CPU-bound work would reject a
+/// winning design on a scenario that isn't its job.
+/// </summary>
+public sealed class BenchmarkConfig : ManualConfig
+{
+    public BenchmarkConfig()
+    {
+        // Markdown output for results-table consumption by spec-004 followups.
+        AddExporter(MarkdownExporter.GitHub);
+
+        // Console logger so individual runs are visible during long benchmarks.
+        AddLogger(ConsoleLogger.Default);
+
+        // Inherit the default columns / column providers / validators from
+        // BenchmarkDotNet so we don't have to enumerate them here. Scenarios
+        // that need per-scenario tuning use attributes on the [Benchmark] methods.
+        Add(DefaultConfig.Instance);
+    }
+}

--- a/PoshMcp.Benchmarks/HostModes.cs
+++ b/PoshMcp.Benchmarks/HostModes.cs
@@ -1,0 +1,32 @@
+namespace PoshMcp.Benchmarks;
+
+/// <summary>
+/// The three executor configurations being compared by this harness.
+/// See specs/004-out-of-process-execution/runspace-pool-experiment-plan.md §4.
+///
+/// Wiring from these enum values to concrete <see cref="PoshMcp.Server.PowerShell.OutOfProcess.ICommandExecutor"/>
+/// implementations happens in issue #194. For now, scenarios use this as a
+/// [Params] axis so BenchmarkDotNet can enumerate the comparison shape.
+/// </summary>
+public enum HostMode
+{
+    /// <summary>
+    /// Baseline: existing single-subprocess, single-runspace executor
+    /// (<c>OutOfProcessCommandExecutor</c> in Single mode). Captured in the
+    /// same run as the experimental modes so machine/version drift cannot
+    /// pollute the comparison.
+    /// </summary>
+    Single,
+
+    /// <summary>
+    /// Option A: single subprocess, runspace pool of N. Wired in issue #194
+    /// once #190 (oop-host extraction) and #191 (Option A prototype) land.
+    /// </summary>
+    Pool,
+
+    /// <summary>
+    /// Option B: pool of N subprocesses, single runspace each. Wired in
+    /// issue #194 once #192 (Option B prototype) lands.
+    /// </summary>
+    ProcessPool,
+}

--- a/PoshMcp.Benchmarks/HttpListenerTestServer.cs
+++ b/PoshMcp.Benchmarks/HttpListenerTestServer.cs
@@ -1,0 +1,131 @@
+using System.Net;
+using System.Text;
+
+namespace PoshMcp.Benchmarks;
+
+/// <summary>
+/// Local <see cref="HttpListener"/> bound to <c>127.0.0.1:0</c> (ephemeral port)
+/// for the network-shaped benchmark scenario.
+///
+/// Per the experiment plan §4: bind to <c>127.0.0.1:0</c> to avoid the URL
+/// ACL requirement Windows imposes on non-loopback bindings, and to work
+/// portably on .NET 10 across platforms. The server responds after a
+/// configurable delay so we can model Az/Graph-style latency without an
+/// external dependency.
+/// </summary>
+public sealed class HttpListenerTestServer : IDisposable
+{
+    private readonly HttpListener _listener;
+    private readonly CancellationTokenSource _cts = new();
+    private Task? _acceptLoop;
+
+    /// <summary>
+    /// Per-request response delay (default 500 ms — matches the Az/Graph
+    /// shape called out in the experiment plan).
+    /// </summary>
+    public TimeSpan ResponseDelay { get; set; } = TimeSpan.FromMilliseconds(500);
+
+    /// <summary>
+    /// Body returned for every request.
+    /// </summary>
+    public string ResponseBody { get; set; } = "{\"ok\":true}";
+
+    /// <summary>
+    /// The URL prefix the listener is bound to once <see cref="Start"/> has
+    /// returned. Includes the ephemeral port assigned by the OS.
+    /// </summary>
+    public string Url { get; private set; } = string.Empty;
+
+    public HttpListenerTestServer()
+    {
+        if (!HttpListener.IsSupported)
+        {
+            throw new PlatformNotSupportedException(
+                "HttpListener is not supported on this platform.");
+        }
+
+        _listener = new HttpListener();
+    }
+
+    /// <summary>
+    /// Bind to <c>127.0.0.1:0</c>, discover the assigned port, and begin
+    /// accepting requests on a background task.
+    /// </summary>
+    public void Start()
+    {
+        // HttpListener does not expose "bind to ephemeral and ask which port
+        // we got". Probe a free TCP port via the loopback adapter, then
+        // hand that port to the listener.
+        var probe = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        probe.Start();
+        var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+        probe.Stop();
+
+        Url = $"http://127.0.0.1:{port}/";
+        _listener.Prefixes.Add(Url);
+        _listener.Start();
+
+        _acceptLoop = Task.Run(() => AcceptLoopAsync(_cts.Token));
+    }
+
+    private async Task AcceptLoopAsync(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested && _listener.IsListening)
+        {
+            HttpListenerContext context;
+            try
+            {
+                context = await _listener.GetContextAsync().ConfigureAwait(false);
+            }
+            catch (ObjectDisposedException) { return; }
+            catch (HttpListenerException) { return; }
+
+            // Fire-and-forget per-connection handling so a slow response on
+            // one request does not block the accept loop.
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    if (ResponseDelay > TimeSpan.Zero)
+                    {
+                        await Task.Delay(ResponseDelay, cancellationToken)
+                            .ConfigureAwait(false);
+                    }
+
+                    var bytes = Encoding.UTF8.GetBytes(ResponseBody);
+                    context.Response.StatusCode = 200;
+                    context.Response.ContentType = "application/json";
+                    context.Response.ContentLength64 = bytes.Length;
+                    await context.Response.OutputStream
+                        .WriteAsync(bytes, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Benchmark harness — swallow per-response errors so a
+                    // single failed write does not tear the listener down.
+                }
+                finally
+                {
+                    try { context.Response.Close(); } catch { /* ignore */ }
+                }
+            }, cancellationToken);
+        }
+    }
+
+    public void Dispose()
+    {
+        try { _cts.Cancel(); } catch { /* ignore */ }
+        try
+        {
+            if (_listener.IsListening)
+            {
+                _listener.Stop();
+            }
+            _listener.Close();
+        }
+        catch { /* ignore */ }
+        try { _acceptLoop?.Wait(TimeSpan.FromSeconds(2)); } catch { /* ignore */ }
+        _cts.Dispose();
+    }
+}

--- a/PoshMcp.Benchmarks/PoshMcp.Benchmarks.csproj
+++ b/PoshMcp.Benchmarks/PoshMcp.Benchmarks.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <!-- BenchmarkDotNet requires Release builds for accurate measurements; do not run Debug. -->
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.14.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PoshMcp.Server\PoshMcp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/PoshMcp.Benchmarks/Program.cs
+++ b/PoshMcp.Benchmarks/Program.cs
@@ -1,0 +1,20 @@
+using BenchmarkDotNet.Running;
+using PoshMcp.Benchmarks;
+
+// BenchmarkSwitcher discovers all [Benchmark]-annotated types in this assembly.
+// Run with:
+//   dotnet run --project PoshMcp.Benchmarks --configuration Release -- --filter *
+// Or filter to a specific scenario:
+//   dotnet run --project PoshMcp.Benchmarks --configuration Release -- --filter *WarmInvoke*
+
+// Disable spec-008 Application Insights / OpenTelemetry export during benchmark
+// runs so latency numbers reflect executor cost, not telemetry overhead.
+// The PoshMcp.Server defaults already have ApplicationInsights:Enabled = false,
+// but we set the environment variable explicitly here in case a host inherits
+// a configured value from the process environment.
+Environment.SetEnvironmentVariable("ApplicationInsights__Enabled", "false");
+Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING", string.Empty);
+
+BenchmarkSwitcher
+    .FromAssembly(typeof(BenchmarkConfig).Assembly)
+    .Run(args, new BenchmarkConfig());

--- a/PoshMcp.Benchmarks/Scenarios/ColdStartBenchmark.cs
+++ b/PoshMcp.Benchmarks/Scenarios/ColdStartBenchmark.cs
@@ -1,0 +1,35 @@
+using BenchmarkDotNet.Attributes;
+
+namespace PoshMcp.Benchmarks.Scenarios;
+
+/// <summary>
+/// Cold-start scenario: wall-clock from executor construction → first
+/// successful invoke. Favors Option A (one process started once); is the
+/// primary cost Option B has to amortize.
+///
+/// Spec reference: experiment plan §4 "Cold-start cost" row.
+///
+/// STUB — wiring to a real <see cref="PoshMcp.Server.PowerShell.OutOfProcess.ICommandExecutor"/>
+/// happens in issue #194. The body is shaped so BenchmarkDotNet can
+/// discover and enumerate the scenario today.
+/// </summary>
+[MemoryDiagnoser]
+[MinIterationCount(3)]
+[MaxIterationCount(10)]
+public class ColdStartBenchmark
+{
+    [Params(HostMode.Single, HostMode.Pool, HostMode.ProcessPool)]
+    public HostMode Mode { get; set; }
+
+    [Benchmark(Baseline = true, Description = "Cold start: ctor → first invoke")]
+    public int ColdStart()
+    {
+        // STUB: returns a placeholder value. #194 will replace this with:
+        //   var executor = ExecutorFactory.Create(Mode);
+        //   await executor.StartAsync();
+        //   await executor.SetupAsync(...);
+        //   var result = await executor.InvokeAsync("Get-Date", ...);
+        //   await executor.DisposeAsync();
+        return (int)Mode;
+    }
+}

--- a/PoshMcp.Benchmarks/Scenarios/PayloadSizeSerializationBenchmark.cs
+++ b/PoshMcp.Benchmarks/Scenarios/PayloadSizeSerializationBenchmark.cs
@@ -1,0 +1,36 @@
+using BenchmarkDotNet.Attributes;
+
+namespace PoshMcp.Benchmarks.Scenarios;
+
+/// <summary>
+/// Heavy serialization scenario, parameterized by payload size to expose
+/// Option B's IPC/serialization overhead and Option A's <c>ConvertTo-Json</c>
+/// contention. Threshold from experiment plan §4: ≥ 2× baseline on this
+/// class of workload.
+///
+/// Models the spec's <c>Get-Process | Select-Object -First {N}</c> shape.
+/// STUB — #194 wires to ICommandExecutor.
+/// </summary>
+[MemoryDiagnoser]
+[MinIterationCount(5)]
+[MaxIterationCount(15)]
+public class PayloadSizeSerializationBenchmark
+{
+    [Params(HostMode.Single, HostMode.Pool, HostMode.ProcessPool)]
+    public HostMode Mode { get; set; }
+
+    /// <summary>Number of objects to serialize per invoke (10, 100, 1000).</summary>
+    [Params(10, 100, 1000)]
+    public int PayloadCount { get; set; }
+
+    [Benchmark(Baseline = true, Description = "Heavy serialization (Get-Process | Select -First N), 2× bar")]
+    public int Serialize()
+    {
+        // STUB: returns the expected payload size as a placeholder.
+        // #194 replaces with:
+        //   var json = await executor.InvokeAsync("Get-Process",
+        //       new() { ["First"] = PayloadCount });
+        //   return json.Length;
+        return PayloadCount;
+    }
+}

--- a/PoshMcp.Benchmarks/Scenarios/ProcessCrashRecoveryBenchmark.cs
+++ b/PoshMcp.Benchmarks/Scenarios/ProcessCrashRecoveryBenchmark.cs
@@ -1,0 +1,35 @@
+using BenchmarkDotNet.Attributes;
+
+namespace PoshMcp.Benchmarks.Scenarios;
+
+/// <summary>
+/// Process-crash recovery: wall-clock from induced
+/// <c>[System.Environment]::Exit(1)</c> in one host to next successful
+/// invoke. This scenario gates Option B per experiment plan §4:
+/// "Option B passes isolation if process crash of one host produces no
+/// server-visible error on requests routed elsewhere within 100 ms of
+/// the crash."
+///
+/// STUB — meaningful comparison requires the Option B pool implementation
+/// from issue #192, wired in issue #194. For Option A and Single this
+/// scenario degenerates into "restart the only process," which is the
+/// same as the baseline.
+/// </summary>
+[MinIterationCount(3)]
+[MaxIterationCount(10)]
+public class ProcessCrashRecoveryBenchmark
+{
+    [Params(HostMode.Single, HostMode.Pool, HostMode.ProcessPool)]
+    public HostMode Mode { get; set; }
+
+    [Benchmark(Baseline = true, Description = "Process crash → next invoke (Option B isolation gate)")]
+    public int CrashRecovery()
+    {
+        // STUB: placeholder. #194 replaces with:
+        //   await executor.InvokeAsync("ForceCrash", ...);  // exits one host
+        //   var sw = Stopwatch.StartNew();
+        //   await executor.InvokeAsync("Get-Date", ...);    // any other host serves it
+        //   return (int)sw.ElapsedMilliseconds;             // gate: < 100ms for Option B
+        return 0;
+    }
+}

--- a/PoshMcp.Benchmarks/Scenarios/RunspaceCorruptionRecoveryBenchmark.cs
+++ b/PoshMcp.Benchmarks/Scenarios/RunspaceCorruptionRecoveryBenchmark.cs
@@ -1,0 +1,32 @@
+using BenchmarkDotNet.Attributes;
+
+namespace PoshMcp.Benchmarks.Scenarios;
+
+/// <summary>
+/// Runspace-corruption recovery: one invoke pollutes a type accelerator
+/// or mutates a shared static; a parallel invoke verifies it is
+/// unaffected. Per experiment plan §4 this is the real isolation gate
+/// for Option A — process-kill is not the right discriminator because
+/// in Option A it is the same gate as the baseline.
+///
+/// STUB — #194 wires this through the runspace-pool host (Option A,
+/// issue #191).
+/// </summary>
+[MinIterationCount(3)]
+[MaxIterationCount(10)]
+public class RunspaceCorruptionRecoveryBenchmark
+{
+    [Params(HostMode.Single, HostMode.Pool, HostMode.ProcessPool)]
+    public HostMode Mode { get; set; }
+
+    [Benchmark(Baseline = true, Description = "Runspace corruption → parallel invoke unaffected (Option A isolation gate)")]
+    public int CorruptionRecovery()
+    {
+        // STUB: placeholder. #194 replaces with:
+        //   var corrupt = executor.InvokeAsync("Pollute-TypeAccelerator", ...);
+        //   var probe   = executor.InvokeAsync("Verify-Clean", ...);
+        //   await Task.WhenAll(corrupt, probe);
+        //   return probe.Result.Contains("clean") ? 1 : 0;
+        return 1;
+    }
+}

--- a/PoshMcp.Benchmarks/Scenarios/WarmInvokeThroughputBenchmark.cs
+++ b/PoshMcp.Benchmarks/Scenarios/WarmInvokeThroughputBenchmark.cs
@@ -1,0 +1,53 @@
+using BenchmarkDotNet.Attributes;
+
+namespace PoshMcp.Benchmarks.Scenarios;
+
+/// <summary>
+/// Warm-invoke throughput: sustained throughput once the executor is hot.
+/// Threshold from experiment plan §4: I/O-bound network-shaped workload
+/// must reach ≥ 4× baseline at 10 concurrent clients on Options A and B.
+///
+/// STUB — uses <see cref="HttpListenerTestServer"/> for the network shape.
+/// Real invocation through ICommandExecutor lands in issue #194.
+/// </summary>
+[MemoryDiagnoser]
+[MinIterationCount(5)]
+[MaxIterationCount(20)]
+public class WarmInvokeThroughputBenchmark
+{
+    private HttpListenerTestServer? _server;
+
+    [Params(HostMode.Single, HostMode.Pool, HostMode.ProcessPool)]
+    public HostMode Mode { get; set; }
+
+    /// <summary>
+    /// Concurrent client count — the parallelism axis the experiment plan
+    /// calls out (10, 50, 100). Default to 10 for the threshold gate; #194
+    /// can extend the params list once real executors are wired.
+    /// </summary>
+    [Params(10)]
+    public int Concurrency { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _server = new HttpListenerTestServer
+        {
+            ResponseDelay = TimeSpan.FromMilliseconds(500),
+        };
+        _server.Start();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _server?.Dispose();
+
+    [Benchmark(Baseline = true, Description = "Warm invoke @ N concurrency (network-shaped, 4× bar)")]
+    public int WarmInvoke()
+    {
+        // STUB: a noop returning the URL hash. #194 replaces with:
+        //   await Parallel.ForEachAsync(Enumerable.Range(0, Concurrency), async (_, _) => {
+        //       await executor.InvokeAsync("Invoke-WebRequest", new() { ["Uri"] = _server!.Url });
+        //   });
+        return _server?.Url.Length ?? 0;
+    }
+}

--- a/PoshMcp.sln
+++ b/PoshMcp.sln
@@ -9,24 +9,68 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestClient", "TestClient\Te
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PoshMcp.Tests", "PoshMcp.Tests\PoshMcp.Tests.csproj", "{85D9A3B6-DA59-425A-8969-9B8444057A10}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PoshMcp.Benchmarks", "PoshMcp.Benchmarks\PoshMcp.Benchmarks.csproj", "{9EAAE769-F9E7-4782-87F2-94906211AF54}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PoshMcp.Server", "PoshMcp.Server", "{1E4E7190-3CF3-7994-3ECE-27F1E9096ED4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{767B9CF1-E5C0-FAA9-041A-2DBA447F16BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{767B9CF1-E5C0-FAA9-041A-2DBA447F16BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{767B9CF1-E5C0-FAA9-041A-2DBA447F16BB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{767B9CF1-E5C0-FAA9-041A-2DBA447F16BB}.Debug|x64.Build.0 = Debug|Any CPU
+		{767B9CF1-E5C0-FAA9-041A-2DBA447F16BB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{767B9CF1-E5C0-FAA9-041A-2DBA447F16BB}.Debug|x86.Build.0 = Debug|Any CPU
 		{767B9CF1-E5C0-FAA9-041A-2DBA447F16BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{767B9CF1-E5C0-FAA9-041A-2DBA447F16BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{767B9CF1-E5C0-FAA9-041A-2DBA447F16BB}.Release|x64.ActiveCfg = Release|Any CPU
+		{767B9CF1-E5C0-FAA9-041A-2DBA447F16BB}.Release|x64.Build.0 = Release|Any CPU
+		{767B9CF1-E5C0-FAA9-041A-2DBA447F16BB}.Release|x86.ActiveCfg = Release|Any CPU
+		{767B9CF1-E5C0-FAA9-041A-2DBA447F16BB}.Release|x86.Build.0 = Release|Any CPU
 		{5B4B34DE-617F-4378-9773-BBC05452C813}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5B4B34DE-617F-4378-9773-BBC05452C813}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B4B34DE-617F-4378-9773-BBC05452C813}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5B4B34DE-617F-4378-9773-BBC05452C813}.Debug|x64.Build.0 = Debug|Any CPU
+		{5B4B34DE-617F-4378-9773-BBC05452C813}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5B4B34DE-617F-4378-9773-BBC05452C813}.Debug|x86.Build.0 = Debug|Any CPU
 		{5B4B34DE-617F-4378-9773-BBC05452C813}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5B4B34DE-617F-4378-9773-BBC05452C813}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B4B34DE-617F-4378-9773-BBC05452C813}.Release|x64.ActiveCfg = Release|Any CPU
+		{5B4B34DE-617F-4378-9773-BBC05452C813}.Release|x64.Build.0 = Release|Any CPU
+		{5B4B34DE-617F-4378-9773-BBC05452C813}.Release|x86.ActiveCfg = Release|Any CPU
+		{5B4B34DE-617F-4378-9773-BBC05452C813}.Release|x86.Build.0 = Release|Any CPU
 		{85D9A3B6-DA59-425A-8969-9B8444057A10}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{85D9A3B6-DA59-425A-8969-9B8444057A10}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{85D9A3B6-DA59-425A-8969-9B8444057A10}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{85D9A3B6-DA59-425A-8969-9B8444057A10}.Debug|x64.Build.0 = Debug|Any CPU
+		{85D9A3B6-DA59-425A-8969-9B8444057A10}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{85D9A3B6-DA59-425A-8969-9B8444057A10}.Debug|x86.Build.0 = Debug|Any CPU
 		{85D9A3B6-DA59-425A-8969-9B8444057A10}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{85D9A3B6-DA59-425A-8969-9B8444057A10}.Release|Any CPU.Build.0 = Release|Any CPU
+		{85D9A3B6-DA59-425A-8969-9B8444057A10}.Release|x64.ActiveCfg = Release|Any CPU
+		{85D9A3B6-DA59-425A-8969-9B8444057A10}.Release|x64.Build.0 = Release|Any CPU
+		{85D9A3B6-DA59-425A-8969-9B8444057A10}.Release|x86.ActiveCfg = Release|Any CPU
+		{85D9A3B6-DA59-425A-8969-9B8444057A10}.Release|x86.Build.0 = Release|Any CPU
+		{9EAAE769-F9E7-4782-87F2-94906211AF54}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9EAAE769-F9E7-4782-87F2-94906211AF54}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9EAAE769-F9E7-4782-87F2-94906211AF54}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9EAAE769-F9E7-4782-87F2-94906211AF54}.Debug|x64.Build.0 = Debug|Any CPU
+		{9EAAE769-F9E7-4782-87F2-94906211AF54}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9EAAE769-F9E7-4782-87F2-94906211AF54}.Debug|x86.Build.0 = Debug|Any CPU
+		{9EAAE769-F9E7-4782-87F2-94906211AF54}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9EAAE769-F9E7-4782-87F2-94906211AF54}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9EAAE769-F9E7-4782-87F2-94906211AF54}.Release|x64.ActiveCfg = Release|Any CPU
+		{9EAAE769-F9E7-4782-87F2-94906211AF54}.Release|x64.Build.0 = Release|Any CPU
+		{9EAAE769-F9E7-4782-87F2-94906211AF54}.Release|x86.ActiveCfg = Release|Any CPU
+		{9EAAE769-F9E7-4782-87F2-94906211AF54}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
**🧪 Fry (Tester)**

Closes #193.

Adds the `PoshMcp.Benchmarks` console project — the harness infrastructure called for in [`specs/004-out-of-process-execution/runspace-pool-experiment-plan.md`](specs/004-out-of-process-execution/runspace-pool-experiment-plan.md) §4 and follow-up issue #4a. **All scenarios are stubs.** Wiring to real `ICommandExecutor` implementations lands in #194.

## What ships

- `PoshMcp.Benchmarks/PoshMcp.Benchmarks.csproj` — .NET 10 console app, BenchmarkDotNet 0.14.0, project-references `PoshMcp.Server`.
- Added to `PoshMcp.sln`.
- `HttpListenerTestServer` — bound to `127.0.0.1:0` (ephemeral port discovered via `TcpListener` probe). Configurable response delay, default 500 ms — matches the Az/Graph network shape called out in the plan. Avoids the URL ACL requirement Windows imposes on non-loopback bindings.
- `BenchmarkConfig` — GitHub-flavored Markdown exporter so results tables drop straight into `specs/004-out-of-process-execution/benchmark-results/`.
- `HostMode` enum (`Single` / `Pool` / `ProcessPool`) used as a `[Params]` axis on every scenario, so the baseline (`Single` mode) is captured **in the same benchmark run** as the experimental modes.
- Application Insights / spec-008 logging disabled at process start (`ApplicationInsights__Enabled=false`, empty `APPLICATIONINSIGHTS_CONNECTION_STRING`).

## Scenario stubs

| File | Purpose | Threshold (per plan §4) |
|------|---------|-------------------------|
| `ColdStartBenchmark` | Wall-clock ctor → first invoke | Cold-start cost — favors Option A |
| `WarmInvokeThroughputBenchmark` | Sustained throughput at N concurrent clients | I/O-bound network-shaped: ≥ 4× baseline |
| `PayloadSizeSerializationBenchmark` | `Get-Process \| Select -First {10,100,1000}` shape | Heavy serialization: ≥ 2× baseline |
| `ProcessCrashRecoveryBenchmark` | Forced `[Environment]::Exit(1)`, time to next invoke | **Option B isolation gate** |
| `RunspaceCorruptionRecoveryBenchmark` | Pollute type accelerator, parallel invoke unaffected | **Option A isolation gate** |

Per-scenario thresholds are wired via `[MinIterationCount]` / `[MaxIterationCount]` attributes per scenario — no single 4× bar across all scenarios (would reject a winning design on a scenario that isn't its job).

## Acceptance criteria

- [x] New `PoshMcp.Benchmarks` project added to `PoshMcp.sln`.
- [x] Local `HttpListener` test server bound to `127.0.0.1:0` (ephemeral port).
- [x] BenchmarkDotNet configured with scenario stubs for all five required scenarios.
- [x] Per-scenario thresholds wired in (no single 4× bar).
- [x] Baseline (`Single` mode) captured in the same benchmark run.
- [x] AI / spec-008 logging disabled during runs.
- [x] Markdown output format ready for results table consumption.

## Verification

```
dotnet build .\PoshMcp.Benchmarks\PoshMcp.Benchmarks.csproj -c Release
# Build succeeded. 0 Error(s).

dotnet run --project .\PoshMcp.Benchmarks -c Release -- --list flat
# PoshMcp.Benchmarks.Scenarios.ColdStartBenchmark.ColdStart
# PoshMcp.Benchmarks.Scenarios.PayloadSizeSerializationBenchmark.Serialize
# PoshMcp.Benchmarks.Scenarios.ProcessCrashRecoveryBenchmark.CrashRecovery
# PoshMcp.Benchmarks.Scenarios.RunspaceCorruptionRecoveryBenchmark.CorruptionRecovery
# PoshMcp.Benchmarks.Scenarios.WarmInvokeThroughputBenchmark.WarmInvoke
```

All five scenarios discoverable.

## Independence

Independent of #190, #191, #192. The stubs reference only the `PoshMcp.Server.PowerShell.OutOfProcess.ICommandExecutor` contract via assembly reference; they do not call into any executor. `HostMode` is an enum local to this project. Wiring lands in #194.
