### PR TITLE
fix(oop): clear $Error before invoke in single-runspace host (#189)

### DIFF
--- a/PoshMcp.Server/PowerShell/OutOfProcess/oop-host.ps1
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/oop-host.ps1
@@ -556,6 +556,11 @@ function Invoke-InvokeHandler {
 
     Write-Diag "Invoking: $commandName with $($splatParams.Count) parameter(s)"
 
+    # Clear $Error before invoking so non-terminating errors from prior invokes
+    # in this single-runspace host don't leak into this invoke's hadErrors flag.
+    # See issue #189.
+    $Error.Clear()
+
     try {
         $result = & $commandName @splatParams
         $hadErrors = $false

--- a/PoshMcp.Tests/Integration/OutOfProcessIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/OutOfProcessIntegrationTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -481,14 +482,80 @@ public class OutOfProcessIntegrationTests : IAsyncLifetime
     /// </summary>
     private static Process? GetSubprocess(OutOfProcessCommandExecutor executor)
     {
-        var hostField = typeof(OutOfProcessCommandExecutor)
-            .GetField("_host", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        var host = hostField!.GetValue(executor);
+        var host = GetHost(executor);
         if (host is null) return null;
 
-        var processField = host.GetType()
+        var processField = typeof(OutOfProcessHost)
             .GetField("_process", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         return (Process?)processField!.GetValue(host);
+    }
+
+    /// <summary>
+    /// Reflects through the executor to grab the live OutOfProcessHost so tests
+    /// can issue raw JSON-RPC requests (SendRequestAsync) that surface the full
+    /// response envelope (e.g., the hadErrors flag).
+    /// </summary>
+    private static OutOfProcessHost? GetHost(OutOfProcessCommandExecutor executor)
+    {
+        var hostField = typeof(OutOfProcessCommandExecutor)
+            .GetField("_host", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        return (OutOfProcessHost?)hostField!.GetValue(executor);
+    }
+
+    // ---- Regression tests ----
+
+    /// <summary>
+    /// Regression for issue #189: in the single-runspace OOP host, $Error is process-global
+    /// and was not cleared between invokes. A failing invoke would leak its error count into
+    /// the next invoke's hadErrors flag, producing a false positive. The fix is a one-line
+    /// $Error.Clear() in Invoke-InvokeHandler before the user command runs.
+    ///
+    /// This test calls invoke twice via the host's SendRequestAsync (which exposes the raw
+    /// response): first an intentionally failing call (nonexistent path), then a clean call.
+    /// Pre-fix, the second call returns hadErrors=true. Post-fix, hadErrors=false.
+    /// </summary>
+    [PwshAvailableFact]
+    public async Task HadErrorsDoesNotLeakAcrossInvokes()
+    {
+        Assert.NotNull(_executor);
+        var host = GetHost(_executor!);
+        Assert.NotNull(host);
+
+        // First invoke: deliberately produce a non-terminating error.
+        // Get-ChildItem on a path that does not exist writes to $Error but does not throw.
+        var missingPath = Path.Combine(_testTempDir, "definitely-does-not-exist-" + Guid.NewGuid().ToString("N"));
+        var failingParams = new
+        {
+            command = "Get-ChildItem",
+            parameters = new Dictionary<string, object?>
+            {
+                ["Path"] = missingPath,
+                ["ErrorAction"] = "SilentlyContinue"
+            }
+        };
+
+        var first = await host!.SendRequestAsync<JsonElement>(
+            "invoke", failingParams, CancellationToken.None);
+
+        Assert.True(first.TryGetProperty("hadErrors", out var firstHadErrors),
+            "First response should include hadErrors property.");
+        Assert.True(firstHadErrors.GetBoolean(),
+            "First (failing) invoke should report hadErrors=true.");
+
+        // Second invoke: a clean command. Pre-fix, hadErrors leaks from the previous call.
+        var cleanParams = new
+        {
+            command = "Get-Date",
+            parameters = new Dictionary<string, object?>()
+        };
+
+        var second = await host.SendRequestAsync<JsonElement>(
+            "invoke", cleanParams, CancellationToken.None);
+
+        Assert.True(second.TryGetProperty("hadErrors", out var secondHadErrors),
+            "Second response should include hadErrors property.");
+        Assert.False(secondHadErrors.GetBoolean(),
+            "Second (clean) invoke must report hadErrors=false. Errors from the prior invoke must not leak into this one (#189).");
     }
 }
 


### PR DESCRIPTION
**🛠️ Hermes (PowerShell Expert)**

Closes #189

## Summary

In the single-runspace OOP PowerShell host, `$Error` is process-global. The host was not clearing it between invokes, so a failing call (e.g. `Get-ChildItem` against a missing path with `-ErrorAction SilentlyContinue`) left entries in `$Error` that the next, unrelated invoke counted toward its own `hadErrors` flag — producing false positives for clean commands.

## Fix

One-line change in `Invoke-InvokeHandler` (`oop-host.ps1`): call `$Error.Clear()` immediately before dispatching the user command, so each invoke starts with a clean error state.

```powershell
# Clear $Error before invoking so non-terminating errors from prior invokes
# in this single-runspace host don't leak into this invoke's hadErrors flag.
# See issue #189.
$Error.Clear()
```

## Regression test

Added `OutOfProcessIntegrationTests.HadErrorsDoesNotLeakAcrossInvokes`:

1. First invoke: `Get-ChildItem` against a guaranteed-missing path with `ErrorAction=SilentlyContinue` -> asserts `hadErrors == true`.
2. Second invoke: `Get-Date` (clean) -> asserts `hadErrors == false`.

Pre-fix this test fails on step 2. Post-fix it passes.

## Verification

- `dotnet build PoshMcp.sln -c Debug` — clean (0 errors, 2 pre-existing NU1510 warnings).
- `dotnet test --filter "FullyQualifiedName~OutOfProcess"` — 99 passed, 0 failed, 6 skipped (optional-module suites).
- `dotnet test --filter "FullyQualifiedName~HadErrorsDoesNotLeakAcrossInvokes"` — 1 passed.

## Files changed

- `PoshMcp.Server/PowerShell/OutOfProcess/oop-host.ps1` — added `$Error.Clear()` in `Invoke-InvokeHandler` before invoke.
- `PoshMcp.Tests/Integration/OutOfProcessIntegrationTests.cs` — added regression test.
