### PR TITLE
feat(oop): Option B prototype — process pool executor (#192)

### DIFF
--- a/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessSubprocessPool.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessSubprocessPool.cs
@@ -1,0 +1,991 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using PoshMcp.Server.PowerShell;
+
+namespace PoshMcp.Server.PowerShell.OutOfProcess;
+
+/// <summary>
+/// Option B (issue #192) implementation of <see cref="ICommandExecutor"/>: a pool of N
+/// independent <see cref="OutOfProcessHost"/> instances. Each request leases one host,
+/// runs against it, and returns it to the pool when finished. Hosts that crash, time out,
+/// or otherwise become unhealthy are reconciled out of rotation and replaced by a
+/// background reconciler.
+/// </summary>
+/// <remarks>
+/// <para>
+/// State model — there are two collaborating data structures, both required:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <description>
+///       A <see cref="Channel{T}"/> of <see cref="HostSlot"/> instances representing the
+///       <em>available</em> queue. Lease is <c>await Reader.ReadAsync</c>; return is
+///       <c>Writer.TryWrite</c>. The channel alone is insufficient because a host that
+///       crashes mid-lease is not in the channel at the moment of the crash, and a naive
+///       channel-only implementation would have no way to discover that a slot is dead
+///       and needs replacement.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///       A <see cref="ConcurrentDictionary{TKey,TValue}"/> keyed by a stable
+///       <em>slot index</em> (0..N-1) holding <see cref="HostSlot"/> records. The
+///       dictionary is the source of truth for "what hosts exist" and "what is the
+///       current status of slot <c>i</c>". When a host process is replaced the slot
+///       index stays constant; the underlying <see cref="OutOfProcessHost"/> instance
+///       on the slot is swapped. We deliberately key by slot index rather than process
+///       id so reconciliation is unambiguous (process ids are reused by the OS on Linux
+///       and the slot-to-host mapping survives restarts).
+///     </description>
+///   </item>
+/// </list>
+/// <para>
+/// <b>Discovery cache key.</b> <see cref="DiscoverCommandsAsync"/> runs once against
+/// any healthy host and caches the schemas. The cache is keyed by a SHA-256 fingerprint
+/// of the <see cref="EnvironmentConfiguration"/> applied via <see cref="SetupAsync"/>:
+/// install/import module list, module paths, startup script path/content, and the
+/// effective discovery module list (top-level <c>Modules</c>). When a host is replaced
+/// the reconciler reapplies the same setup, so the fingerprint — and therefore the
+/// cached schemas — remain valid. If <see cref="SetupAsync"/> is later invoked with
+/// a different fingerprint the cache is cleared.
+/// </para>
+/// <para>
+/// <b>Startup policy.</b> The first host (slot 0) is started fail-fast — if it cannot
+/// reach a healthy ping, <see cref="StartAsync"/> throws. Hosts 1..N-1 are started in
+/// parallel with bounded retry + exponential backoff. As long as
+/// <see cref="OutOfProcessSubprocessPoolOptions.MinHealthyForStartup"/> hosts are
+/// healthy at the end of startup the pool starts (degraded if any failed); otherwise
+/// it throws.
+/// </para>
+/// <para>
+/// <b>Per-request kill on timeout.</b> When <see cref="InvokeAsync"/> observes a
+/// <see cref="TimeoutException"/> from the underlying host (or any failure that
+/// indicates the host is no longer trustworthy), the pool kills that specific host
+/// process, marks the slot dead, and lets the reconciler start a replacement. The
+/// caller still observes the timeout. This is Option B's structural advantage over
+/// the single-host executor: a runaway request kills 1 of N, not the only host.
+/// </para>
+/// </remarks>
+public sealed class OutOfProcessSubprocessPool : ICommandExecutor
+{
+    private readonly ILogger<OutOfProcessSubprocessPool> _logger;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly OutOfProcessSubprocessPoolOptions _options;
+    private readonly TimeSpan _requestTimeout;
+    private readonly string _pwshPath;
+    private readonly string _hostScriptPath;
+
+    private readonly ConcurrentDictionary<int, HostSlot> _slots = new();
+    private readonly Channel<HostSlot> _available =
+        Channel.CreateUnbounded<HostSlot>(
+            new UnboundedChannelOptions
+            {
+                SingleReader = false,
+                SingleWriter = false,
+                AllowSynchronousContinuations = false,
+            });
+
+    private readonly object _envLock = new();
+    private EnvironmentConfiguration? _cachedEnv;
+    private string? _cachedEnvFingerprint;
+    private string? _cachedConfigFilePath;
+    private TimeSpan? _cachedSetupTimeout;
+    private string[]? _cachedDiscoveryModules;
+    private IReadOnlyList<RemoteToolSchema>? _cachedSchemas;
+    private string? _cachedSchemasFingerprint;
+
+    private CancellationTokenSource? _reconcilerCts;
+    private Task? _reconcilerTask;
+    private bool _started;
+    private bool _disposed;
+
+    /// <summary>
+    /// Creates a new <see cref="OutOfProcessSubprocessPool"/>.
+    /// </summary>
+    public OutOfProcessSubprocessPool(
+        string pwshPath,
+        string hostScriptPath,
+        OutOfProcessSubprocessPoolOptions options,
+        ILoggerFactory? loggerFactory = null,
+        TimeSpan? requestTimeout = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pwshPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(hostScriptPath);
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (options.PoolSize < 1)
+            throw new ArgumentOutOfRangeException(nameof(options), "PoolSize must be >= 1.");
+        if (options.MinHealthyForStartup < 1)
+            throw new ArgumentOutOfRangeException(nameof(options), "MinHealthyForStartup must be >= 1.");
+        if (options.MinHealthyForStartup > options.PoolSize)
+            throw new ArgumentOutOfRangeException(nameof(options),
+                "MinHealthyForStartup must be <= PoolSize.");
+
+        _pwshPath = pwshPath;
+        _hostScriptPath = hostScriptPath;
+        _options = options;
+        _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+        _logger = _loggerFactory.CreateLogger<OutOfProcessSubprocessPool>();
+        _requestTimeout = requestTimeout ?? TimeSpan.FromSeconds(30);
+    }
+
+    /// <summary>
+    /// Number of slots currently in the dictionary whose status is
+    /// <see cref="HostStatus.Healthy"/> or <see cref="HostStatus.Leased"/>.
+    /// Useful for tests and diagnostics.
+    /// </summary>
+    public int HealthyCount
+    {
+        get
+        {
+            var count = 0;
+            foreach (var kvp in _slots)
+            {
+                var status = kvp.Value.Status;
+                if (status == HostStatus.Healthy || status == HostStatus.Leased)
+                    count++;
+            }
+            return count;
+        }
+    }
+
+    /// <summary>
+    /// Configured pool size (constant).
+    /// </summary>
+    public int PoolSize => _options.PoolSize;
+
+    /// <inheritdoc />
+    public async Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_started)
+            throw new InvalidOperationException("Pool has already been started.");
+
+        _logger.LogInformation(
+            "Starting subprocess pool: size={PoolSize}, minHealthy={MinHealthy}.",
+            _options.PoolSize, _options.MinHealthyForStartup);
+
+        // Slot 0: fail-fast smoke test.
+        var slot0 = await StartSlotAsync(0, failFast: true, cancellationToken).ConfigureAwait(false);
+        _available.Writer.TryWrite(slot0);
+
+        // Slots 1..N-1: parallel with retry + backoff. Don't propagate individual failures —
+        // the MinHealthyForStartup gate decides whether to throw.
+        if (_options.PoolSize > 1)
+        {
+            var startupTasks = new List<Task>(_options.PoolSize - 1);
+            for (var i = 1; i < _options.PoolSize; i++)
+            {
+                var index = i;
+                startupTasks.Add(Task.Run(async () =>
+                {
+                    try
+                    {
+                        var slot = await StartSlotWithRetryAsync(index, cancellationToken)
+                            .ConfigureAwait(false);
+                        if (slot is not null)
+                            _available.Writer.TryWrite(slot);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex,
+                            "Slot {Index} failed all startup retries; pool will start degraded.",
+                            index);
+                    }
+                }, cancellationToken));
+            }
+
+            await Task.WhenAll(startupTasks).ConfigureAwait(false);
+        }
+
+        var healthy = HealthyCount;
+        if (healthy < _options.MinHealthyForStartup)
+        {
+            _logger.LogError(
+                "Pool startup aborted: only {Healthy} of {PoolSize} hosts came up healthy " +
+                "(minimum required: {MinHealthy}).",
+                healthy, _options.PoolSize, _options.MinHealthyForStartup);
+
+            await DisposeAsync().ConfigureAwait(false);
+
+            throw new InvalidOperationException(
+                $"OutOfProcessSubprocessPool failed startup: {healthy}/{_options.PoolSize} healthy, " +
+                $"minimum required {_options.MinHealthyForStartup}.");
+        }
+
+        if (healthy < _options.PoolSize)
+        {
+            _logger.LogWarning(
+                "Pool started degraded: {Healthy}/{PoolSize} hosts healthy.",
+                healthy, _options.PoolSize);
+        }
+        else
+        {
+            _logger.LogInformation(
+                "Pool started: {Healthy}/{PoolSize} hosts healthy.",
+                healthy, _options.PoolSize);
+        }
+
+        _started = true;
+
+        // Start the reconciler that watches for dead slots.
+        _reconcilerCts = new CancellationTokenSource();
+        _reconcilerTask = Task.Run(
+            () => ReconcilerLoopAsync(_reconcilerCts.Token),
+            CancellationToken.None);
+    }
+
+    /// <inheritdoc />
+    public async Task SetupAsync(
+        EnvironmentConfiguration config,
+        string? configFilePath = null,
+        TimeSpan? setupRequestTimeout = null,
+        IEnumerable<string>? discoveryModules = null,
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        EnsureStarted();
+        ArgumentNullException.ThrowIfNull(config);
+
+        var discoveryModulesArr = discoveryModules?.ToArray();
+        var fingerprint = ComputeEnvironmentFingerprint(config, discoveryModulesArr);
+
+        lock (_envLock)
+        {
+            _cachedEnv = config;
+            _cachedEnvFingerprint = fingerprint;
+            _cachedConfigFilePath = configFilePath;
+            _cachedSetupTimeout = setupRequestTimeout;
+            _cachedDiscoveryModules = discoveryModulesArr;
+
+            // Invalidate schema cache if the fingerprint changed.
+            if (_cachedSchemasFingerprint is not null
+                && !string.Equals(_cachedSchemasFingerprint, fingerprint, StringComparison.Ordinal))
+            {
+                _logger.LogDebug(
+                    "Environment fingerprint changed ({Old} -> {New}); invalidating discovery cache.",
+                    _cachedSchemasFingerprint, fingerprint);
+                _cachedSchemas = null;
+                _cachedSchemasFingerprint = null;
+            }
+        }
+
+        // Apply setup to every currently-healthy host in parallel.
+        var snapshot = _slots
+            .Where(kvp => kvp.Value.Status is HostStatus.Healthy or HostStatus.Leased)
+            .Select(kvp => kvp.Value)
+            .ToArray();
+
+        _logger.LogInformation(
+            "Applying environment setup to {Count} hosts (fingerprint: {Fingerprint}).",
+            snapshot.Length, fingerprint);
+
+        var setupTasks = snapshot.Select(slot => Task.Run(async () =>
+        {
+            try
+            {
+                await ApplySetupToHostAsync(slot, config, configFilePath,
+                    setupRequestTimeout, discoveryModulesArr, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "Setup failed on slot {Index}; marking dead for reconciliation.",
+                    slot.Index);
+                MarkSlotDead(slot);
+            }
+        }, cancellationToken)).ToArray();
+
+        await Task.WhenAll(setupTasks).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<RemoteToolSchema>> DiscoverCommandsAsync(
+        PowerShellConfiguration config,
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        EnsureStarted();
+
+        // Per-pool cache: discovery is identical across hosts because each runs the same
+        // setup against the same environment fingerprint. Once cached, replacements
+        // reuse the result without re-running discovery.
+        lock (_envLock)
+        {
+            if (_cachedSchemas is not null
+                && string.Equals(_cachedSchemasFingerprint, _cachedEnvFingerprint, StringComparison.Ordinal))
+            {
+                _logger.LogDebug(
+                    "Discovery cache hit ({Count} schemas, fingerprint {Fingerprint}).",
+                    _cachedSchemas.Count, _cachedSchemasFingerprint);
+                return _cachedSchemas;
+            }
+        }
+
+        var discoverParams = new
+        {
+            modules = config.Modules,
+            functionNames = config.GetEffectiveCommandNames(),
+            includePatterns = config.IncludePatterns,
+            excludePatterns = config.ExcludePatterns
+        };
+
+        await using var lease = await LeaseAsync(cancellationToken).ConfigureAwait(false);
+        var host = lease.Host;
+
+        _logger.LogInformation(
+            "Discovering commands via OOP pool (slot {Index}).", lease.SlotIndex);
+
+        var result = await host.SendRequestAsync<JsonElement>("discover", discoverParams, cancellationToken)
+            .ConfigureAwait(false);
+
+        var jsonOptions = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        List<RemoteToolSchema> schemas;
+        if (result.TryGetProperty("commands", out var commandsElement))
+        {
+            schemas = JsonSerializer.Deserialize<List<RemoteToolSchema>>(
+                commandsElement.GetRawText(), jsonOptions)
+                ?? new List<RemoteToolSchema>();
+        }
+        else
+        {
+            _logger.LogWarning(
+                "Discover response missing 'commands'. Raw: {Raw}", result.GetRawText());
+            schemas = new List<RemoteToolSchema>();
+        }
+
+        lock (_envLock)
+        {
+            _cachedSchemas = schemas;
+            _cachedSchemasFingerprint = _cachedEnvFingerprint;
+        }
+
+        _logger.LogInformation(
+            "Discovered {Count} commands; cached under fingerprint {Fingerprint}.",
+            schemas.Count, _cachedSchemasFingerprint ?? "(none)");
+
+        return schemas;
+    }
+
+    /// <inheritdoc />
+    public async Task<string> InvokeAsync(
+        string commandName,
+        IDictionary<string, object?> parameters,
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        EnsureStarted();
+
+        await using var lease = await LeaseAsync(cancellationToken).ConfigureAwait(false);
+        var host = lease.Host;
+        var slotIndex = lease.SlotIndex;
+
+        var invokeParams = new { command = commandName, parameters };
+
+        _logger.LogInformation(
+            "Invoking '{CommandName}' on pool slot {Index} (PID {Pid}).",
+            commandName, slotIndex, host.ProcessId);
+
+        try
+        {
+            var result = await host.SendRequestAsync<JsonElement>("invoke", invokeParams, cancellationToken)
+                .ConfigureAwait(false);
+
+            var output = string.Empty;
+            if (result.TryGetProperty("output", out var outputElement))
+                output = outputElement.GetString() ?? string.Empty;
+
+            if (result.TryGetProperty("hadErrors", out var hadErrorsElement)
+                && hadErrorsElement.GetBoolean())
+            {
+                _logger.LogWarning(
+                    "Command '{CommandName}' on slot {Index} reported errors.",
+                    commandName, slotIndex);
+            }
+
+            return output;
+        }
+        catch (TimeoutException tex)
+        {
+            // Per-request kill-on-timeout: this host is now suspect. Take it out of
+            // rotation and let the reconciler start a replacement. Bonus over single-host
+            // mode: only this slot dies; the rest of the pool keeps serving.
+            _logger.LogWarning(tex,
+                "Invoke '{CommandName}' timed out on slot {Index}; killing host.",
+                commandName, slotIndex);
+            lease.MarkBroken();
+            throw;
+        }
+        catch (InvalidOperationException ex) when (!host.IsRunning)
+        {
+            // Host died mid-invoke; surface the error and let the reconciler restart it.
+            _logger.LogWarning(ex,
+                "Slot {Index} host died mid-invoke for '{CommandName}'.",
+                slotIndex, commandName);
+            lease.MarkBroken();
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _logger.LogDebug("Disposing OOP subprocess pool.");
+
+        _available.Writer.TryComplete();
+
+        if (_reconcilerCts is not null)
+        {
+            try { _reconcilerCts.Cancel(); } catch { /* ignore */ }
+        }
+
+        if (_reconcilerTask is not null)
+        {
+            try { await _reconcilerTask.ConfigureAwait(false); }
+            catch { /* reconciler exits on cancel */ }
+        }
+
+        var disposeTasks = _slots
+            .Select(kvp => kvp.Value)
+            .Where(s => s.Host is not null)
+            .Select(s => s.Host!.DisposeAsync().AsTask())
+            .ToArray();
+
+        try
+        {
+            await Task.WhenAll(disposeTasks).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Best-effort.
+        }
+
+        _slots.Clear();
+        _reconcilerCts?.Dispose();
+    }
+
+    // ---- Internal helpers (visible to tests) ----
+
+    /// <summary>
+    /// Computes a stable SHA-256 fingerprint over the environment configuration
+    /// fields that influence module visibility and discovery output. Used as the
+    /// discovery cache key.
+    /// </summary>
+    internal static string ComputeEnvironmentFingerprint(
+        EnvironmentConfiguration config,
+        IEnumerable<string>? discoveryModules)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        // Serialize a deterministic, ordered projection of the relevant fields.
+        // Order matters: we sort lists so equivalent configurations with different
+        // ordering produce the same fingerprint.
+        var modulePaths = config.ModulePaths
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Select(s => s.Trim())
+            .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var importModules = config.ImportModules
+            .Concat(discoveryModules ?? Enumerable.Empty<string>())
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Select(s => s.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var installModules = config.InstallModules
+            .Select(m => new
+            {
+                name = m.Name?.Trim() ?? string.Empty,
+                version = m.Version,
+                minimum = m.MinimumVersion,
+                maximum = m.MaximumVersion,
+                repository = m.Repository,
+                scope = m.Scope,
+            })
+            .OrderBy(m => m.name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(m => m.version ?? string.Empty, StringComparer.Ordinal)
+            .ToArray();
+
+        var projection = new
+        {
+            modulePaths,
+            importModules,
+            installModules,
+            startupScript = config.StartupScript,
+            startupScriptPath = config.StartupScriptPath,
+            trustPSGallery = config.TrustPSGallery,
+        };
+
+        var json = JsonSerializer.Serialize(projection);
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(json));
+        return Convert.ToHexStringLower(hash);
+    }
+
+    private async Task<HostSlot> StartSlotAsync(
+        int index, bool failFast, CancellationToken cancellationToken)
+    {
+        var slot = new HostSlot(index) { Status = HostStatus.Starting };
+        _slots[index] = slot;
+
+        var hostLogger = _loggerFactory.CreateLogger<OutOfProcessHost>();
+        var host = new OutOfProcessHost(_pwshPath, _hostScriptPath, hostLogger, _requestTimeout);
+
+        try
+        {
+            await host.StartAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            try { await host.DisposeAsync().ConfigureAwait(false); } catch { /* ignore */ }
+            slot.Status = HostStatus.Dead;
+
+            if (failFast)
+            {
+                _slots.TryRemove(index, out _);
+                throw;
+            }
+
+            return slot; // caller will retry / leave dead for reconciler
+        }
+
+        slot.Host = host;
+        slot.Status = HostStatus.Healthy;
+
+        _logger.LogInformation(
+            "Slot {Index} started (PID {Pid}).", index, host.ProcessId);
+
+        // If we have cached env config, apply it to this freshly-started host.
+        EnvironmentConfiguration? envSnapshot;
+        string? configFilePathSnapshot;
+        TimeSpan? setupTimeoutSnapshot;
+        string[]? discoveryModulesSnapshot;
+        lock (_envLock)
+        {
+            envSnapshot = _cachedEnv;
+            configFilePathSnapshot = _cachedConfigFilePath;
+            setupTimeoutSnapshot = _cachedSetupTimeout;
+            discoveryModulesSnapshot = _cachedDiscoveryModules;
+        }
+
+        if (envSnapshot is not null)
+        {
+            try
+            {
+                await ApplySetupToHostAsync(slot, envSnapshot, configFilePathSnapshot,
+                    setupTimeoutSnapshot, discoveryModulesSnapshot, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "Initial setup failed on slot {Index}; marking dead.", index);
+                MarkSlotDead(slot);
+
+                if (failFast)
+                {
+                    _slots.TryRemove(index, out _);
+                    throw;
+                }
+            }
+        }
+
+        return slot;
+    }
+
+    private async Task<HostSlot?> StartSlotWithRetryAsync(
+        int index, CancellationToken cancellationToken)
+    {
+        var maxAttempts = Math.Max(1, _options.StartupRetryCount);
+        var delay = _options.StartupBackoffInitial;
+
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            try
+            {
+                var slot = await StartSlotAsync(index, failFast: false, cancellationToken)
+                    .ConfigureAwait(false);
+                if (slot.Status == HostStatus.Healthy)
+                    return slot;
+            }
+            catch (Exception ex) when (attempt < maxAttempts)
+            {
+                _logger.LogDebug(ex,
+                    "Slot {Index} startup attempt {Attempt} failed; retrying in {Delay}.",
+                    index, attempt, delay);
+            }
+
+            if (attempt < maxAttempts)
+            {
+                try
+                {
+                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    return null;
+                }
+                delay = TimeSpan.FromMilliseconds(
+                    Math.Min(delay.TotalMilliseconds * 2, _options.StartupBackoffMax.TotalMilliseconds));
+            }
+        }
+
+        return null;
+    }
+
+    private async Task ApplySetupToHostAsync(
+        HostSlot slot,
+        EnvironmentConfiguration config,
+        string? configFilePath,
+        TimeSpan? setupRequestTimeout,
+        IEnumerable<string>? discoveryModules,
+        CancellationToken cancellationToken)
+    {
+        var host = slot.Host
+            ?? throw new InvalidOperationException(
+                $"Cannot apply setup to slot {slot.Index}: no host attached.");
+
+        var baseDir = !string.IsNullOrEmpty(configFilePath)
+            ? Path.GetDirectoryName(Path.GetFullPath(configFilePath))!
+            : Directory.GetCurrentDirectory();
+
+        var resolvedModulePaths = config.ModulePaths
+            .Select(p => Path.IsPathRooted(p) ? p : Path.GetFullPath(Path.Combine(baseDir, p)))
+            .ToArray();
+
+        var allImportModules = config.ImportModules
+            .Concat(discoveryModules ?? Enumerable.Empty<string>())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var setupParams = new
+        {
+            modulePaths = resolvedModulePaths,
+            trustPSGallery = config.TrustPSGallery,
+            installModules = config.InstallModules.Select(m => new
+            {
+                name = m.Name,
+                version = m.Version,
+                minimumVersion = m.MinimumVersion,
+                maximumVersion = m.MaximumVersion,
+                repository = m.Repository,
+                scope = m.Scope,
+                force = m.Force,
+                skipPublisherCheck = m.SkipPublisherCheck,
+                allowPrerelease = m.AllowPrerelease,
+            }).ToArray(),
+            importModules = allImportModules,
+            startupScriptPath = config.StartupScriptPath,
+            startupScript = config.StartupScript,
+            skipPublisherCheck = config.SkipPublisherCheck,
+            allowClobber = config.AllowClobber,
+            installTimeoutSeconds = config.InstallTimeoutSeconds,
+        };
+
+        var result = await host
+            .SendRequestAsync<JsonElement>("setup", setupParams, cancellationToken, setupRequestTimeout)
+            .ConfigureAwait(false);
+
+        if (!result.TryGetProperty("success", out var successProp) || !successProp.GetBoolean())
+        {
+            var errors = new List<string>();
+            if (result.TryGetProperty("errors", out var errorsProp))
+            {
+                foreach (var err in errorsProp.EnumerateArray())
+                {
+                    var errStr = err.GetString();
+                    if (errStr is not null) errors.Add(errStr);
+                }
+            }
+
+            var errorMessage = errors.Count > 0 ? string.Join("; ", errors) : result.GetRawText();
+            throw new InvalidOperationException(
+                $"OOP environment setup failed on slot {slot.Index}: {errorMessage}");
+        }
+
+        _logger.LogInformation(
+            "Setup completed on slot {Index} (PID {Pid}).",
+            slot.Index, host.ProcessId);
+    }
+
+    private async Task<PoolLease> LeaseAsync(CancellationToken cancellationToken)
+    {
+        // Loop because a slot we read out of the channel may have been killed
+        // between Write and Read (e.g., a reconciler tick); skip dead slots.
+        while (true)
+        {
+            HostSlot slot;
+            try
+            {
+                slot = await _available.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (ChannelClosedException ex)
+            {
+                throw new InvalidOperationException("Pool is shut down.", ex);
+            }
+
+            if (slot.Status != HostStatus.Healthy || slot.Host is null || !slot.Host.IsRunning)
+            {
+                _logger.LogDebug(
+                    "Skipping stale lease for slot {Index} (status={Status}).",
+                    slot.Index, slot.Status);
+                continue;
+            }
+
+            slot.Status = HostStatus.Leased;
+            return new PoolLease(this, slot);
+        }
+    }
+
+    private void ReturnLease(HostSlot slot, bool broken)
+    {
+        if (_disposed) return;
+
+        if (broken || slot.Host is null || !slot.Host.IsRunning)
+        {
+            MarkSlotDead(slot);
+            return;
+        }
+
+        slot.Status = HostStatus.Healthy;
+        _available.Writer.TryWrite(slot);
+    }
+
+    private void MarkSlotDead(HostSlot slot)
+    {
+        if (slot.Status == HostStatus.Dead || slot.Status == HostStatus.Replacing)
+            return;
+
+        slot.Status = HostStatus.Dead;
+
+        var host = slot.Host;
+        if (host is not null)
+        {
+            // Fire-and-forget kill — synchronous Kill on Process is fine here since
+            // OutOfProcessHost.DisposeAsync is the proper teardown path.
+            _ = Task.Run(async () =>
+            {
+                try { await host.DisposeAsync().ConfigureAwait(false); }
+                catch { /* best-effort */ }
+            });
+            slot.Host = null;
+        }
+
+        _logger.LogWarning("Slot {Index} marked dead; reconciler will replace.", slot.Index);
+    }
+
+    private async Task ReconcilerLoopAsync(CancellationToken cancellationToken)
+    {
+        var interval = _options.ReconcilerInterval;
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(interval, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            if (_disposed) return;
+
+            HostSlot[] dead;
+            try
+            {
+                dead = _slots.Values
+                    .Where(s => s.Status == HostStatus.Dead)
+                    .ToArray();
+            }
+            catch
+            {
+                continue;
+            }
+
+            foreach (var slot in dead)
+            {
+                if (cancellationToken.IsCancellationRequested) return;
+
+                slot.Status = HostStatus.Replacing;
+                slot.FailedReplacements++;
+
+                try
+                {
+                    var hostLogger = _loggerFactory.CreateLogger<OutOfProcessHost>();
+                    var host = new OutOfProcessHost(
+                        _pwshPath, _hostScriptPath, hostLogger, _requestTimeout);
+
+                    await host.StartAsync(cancellationToken).ConfigureAwait(false);
+
+                    slot.Host = host;
+                    slot.Status = HostStatus.Healthy;
+
+                    EnvironmentConfiguration? envSnapshot;
+                    string? configFilePathSnapshot;
+                    TimeSpan? setupTimeoutSnapshot;
+                    string[]? discoveryModulesSnapshot;
+                    lock (_envLock)
+                    {
+                        envSnapshot = _cachedEnv;
+                        configFilePathSnapshot = _cachedConfigFilePath;
+                        setupTimeoutSnapshot = _cachedSetupTimeout;
+                        discoveryModulesSnapshot = _cachedDiscoveryModules;
+                    }
+
+                    if (envSnapshot is not null)
+                    {
+                        await ApplySetupToHostAsync(slot, envSnapshot,
+                            configFilePathSnapshot, setupTimeoutSnapshot,
+                            discoveryModulesSnapshot, cancellationToken)
+                            .ConfigureAwait(false);
+                    }
+
+                    slot.FailedReplacements = 0;
+                    _available.Writer.TryWrite(slot);
+
+                    _logger.LogInformation(
+                        "Slot {Index} replacement healthy (PID {Pid}).",
+                        slot.Index, host.ProcessId);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "Slot {Index} replacement failed (attempt {Attempt}); will retry.",
+                        slot.Index, slot.FailedReplacements);
+
+                    if (slot.Host is not null)
+                    {
+                        try { await slot.Host.DisposeAsync().ConfigureAwait(false); }
+                        catch { /* ignore */ }
+                        slot.Host = null;
+                    }
+
+                    slot.Status = HostStatus.Dead;
+                }
+            }
+        }
+    }
+
+    private void EnsureStarted()
+    {
+        if (!_started)
+            throw new InvalidOperationException("Pool has not been started. Call StartAsync first.");
+    }
+
+    /// <summary>
+    /// Per-slot record. Mutable; protected by the channel/dictionary protocol —
+    /// only one of {channel reader, reconciler, lease holder} touches a slot at a time
+    /// for the fields that matter for correctness.
+    /// </summary>
+    internal sealed class HostSlot
+    {
+        public HostSlot(int index) { Index = index; }
+        public int Index { get; }
+        public volatile HostStatus Status;
+        public OutOfProcessHost? Host;
+        public int FailedReplacements;
+    }
+
+    /// <summary>
+    /// Lifecycle state for a slot.
+    /// </summary>
+    internal enum HostStatus
+    {
+        Starting,
+        Healthy,
+        Leased,
+        Dead,
+        Replacing,
+    }
+
+    /// <summary>
+    /// IAsyncDisposable wrapper around a leased host. Disposing returns the host to the
+    /// channel if still alive, or marks the slot dead for reconciliation if not.
+    /// </summary>
+    internal sealed class PoolLease : IAsyncDisposable
+    {
+        private readonly OutOfProcessSubprocessPool _pool;
+        private readonly HostSlot _slot;
+        private bool _broken;
+        private bool _disposed;
+
+        internal PoolLease(OutOfProcessSubprocessPool pool, HostSlot slot)
+        {
+            _pool = pool;
+            _slot = slot;
+        }
+
+        public OutOfProcessHost Host => _slot.Host
+            ?? throw new InvalidOperationException("Lease has no host attached.");
+
+        public int SlotIndex => _slot.Index;
+
+        public void MarkBroken() => _broken = true;
+
+        public ValueTask DisposeAsync()
+        {
+            if (_disposed) return ValueTask.CompletedTask;
+            _disposed = true;
+            _pool.ReturnLease(_slot, _broken);
+            return ValueTask.CompletedTask;
+        }
+    }
+}
+
+/// <summary>
+/// Tunable knobs for <see cref="OutOfProcessSubprocessPool"/>.
+/// </summary>
+public sealed class OutOfProcessSubprocessPoolOptions
+{
+    /// <summary>
+    /// Total number of pwsh subprocess hosts to launch. Default: 4.
+    /// </summary>
+    public int PoolSize { get; init; } = 4;
+
+    /// <summary>
+    /// Minimum number of healthy hosts required for the pool to start. Default: 1.
+    /// First host is always fail-fast; this gates the soft-failure tolerance for
+    /// hosts 2..N.
+    /// </summary>
+    public int MinHealthyForStartup { get; init; } = 1;
+
+    /// <summary>
+    /// Number of startup attempts per non-first host. Default: 3.
+    /// </summary>
+    public int StartupRetryCount { get; init; } = 3;
+
+    /// <summary>
+    /// Initial backoff between startup attempts. Doubled on each retry up to
+    /// <see cref="StartupBackoffMax"/>. Default: 250 ms.
+    /// </summary>
+    public TimeSpan StartupBackoffInitial { get; init; } = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>
+    /// Maximum backoff between startup attempts. Default: 5 seconds.
+    /// </summary>
+    public TimeSpan StartupBackoffMax { get; init; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Interval at which the background reconciler scans for dead slots and starts
+    /// replacements. Default: 1 second.
+    /// </summary>
+    public TimeSpan ReconcilerInterval { get; init; } = TimeSpan.FromSeconds(1);
+}

--- a/PoshMcp.Server/PowerShell/OutOfProcess/SubprocessHostMode.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/SubprocessHostMode.cs
@@ -16,5 +16,12 @@ public enum SubprocessHostMode
     /// Runspace pool inside a single subprocess (oop-host-pool.ps1).
     /// Multiple invokes execute concurrently on pre-warmed runspaces.
     /// </summary>
-    Pool
+    Pool,
+
+    /// <summary>
+    /// Pool of N independent subprocess hosts (OutOfProcessSubprocessPool).
+    /// Each request leases one host; crashes are reconciled per-slot
+    /// without disturbing other hosts.
+    /// </summary>
+    ProcessPool
 }

--- a/PoshMcp.Server/PowerShell/PowerShellConfiguration.cs
+++ b/PoshMcp.Server/PowerShell/PowerShellConfiguration.cs
@@ -18,11 +18,13 @@ public class PowerShellConfiguration
     public RuntimeMode RuntimeMode { get; set; } = RuntimeMode.InProcess;
 
     /// <summary>
-    /// Selects which OOP host script is launched when <see cref="RuntimeMode"/> is
+    /// Selects which OOP host topology is launched when <see cref="RuntimeMode"/> is
     /// <see cref="RuntimeMode.OutOfProcess"/>. <see cref="SubprocessHostMode.Single"/> (default)
     /// launches the single-runspace host (<c>oop-host.ps1</c>).
     /// <see cref="SubprocessHostMode.Pool"/> launches a runspace-pool host
-    /// (<c>oop-host-pool.ps1</c>) that runs invokes concurrently.
+    /// (<c>oop-host-pool.ps1</c>) that runs invokes concurrently in one subprocess.
+    /// <see cref="SubprocessHostMode.ProcessPool"/> launches a pool of N independent
+    /// single-runspace subprocess hosts, leased per request.
     /// </summary>
     public SubprocessHostMode SubprocessHostMode { get; set; } = SubprocessHostMode.Single;
 
@@ -30,9 +32,24 @@ public class PowerShellConfiguration
     /// Maximum number of runspaces in the pool when <see cref="SubprocessHostMode"/> is
     /// <see cref="SubprocessHostMode.Pool"/>. When unset or non-positive, the pool host
     /// defaults to <see cref="System.Environment.ProcessorCount"/> capped at 8.
-    /// Ignored in <see cref="SubprocessHostMode.Single"/> mode.
+    /// Ignored in <see cref="SubprocessHostMode.Single"/> and
+    /// <see cref="SubprocessHostMode.ProcessPool"/> modes.
     /// </summary>
     public int SubprocessRunspacePoolSize { get; set; } = 0;
+
+    /// <summary>
+    /// When <see cref="SubprocessHostMode"/> is <see cref="SubprocessHostMode.ProcessPool"/>,
+    /// the number of independent pwsh subprocess hosts to launch and lease from. Default: 4.
+    /// </summary>
+    public int SubprocessPoolSize { get; set; } = 4;
+
+    /// <summary>
+    /// When <see cref="SubprocessHostMode"/> is <see cref="SubprocessHostMode.ProcessPool"/>,
+    /// the minimum number of healthy hosts required for the pool to start successfully.
+    /// The first host always fails fast; hosts 2..N retry with backoff and the pool tolerates
+    /// degraded startup as long as at least this many hosts come up healthy. Default: 1.
+    /// </summary>
+    public int SubprocessMinHealthyForStartup { get; set; } = 1;
 
     /// <summary>
     /// Specific command names to expose as MCP tools.

--- a/PoshMcp.Server/Server/McpToolSetupService.cs
+++ b/PoshMcp.Server/Server/McpToolSetupService.cs
@@ -158,19 +158,28 @@ internal static class McpToolSetupService
             return null;
         }
 
-        var executorLogger = loggerFactory.CreateLogger<OutOfProcessCommandExecutor>();
         var setupTimeout = config.Environment?.SetupTimeoutSeconds is > 0
             ? TimeSpan.FromSeconds(config.Environment.SetupTimeoutSeconds)
             : TimeSpan.FromSeconds(120);
-        var executor = new OutOfProcessCommandExecutor(
-            executorLogger,
-            requestTimeout: null,
-            hostMode: config.SubprocessHostMode,
-            runspacePoolSize: config.SubprocessRunspacePoolSize);
-        await executor.StartAsync();
-        logger.LogInformation(
-            "Started out-of-process PowerShell executor (HostMode={HostMode}, PoolSize={PoolSize})",
-            config.SubprocessHostMode, config.SubprocessRunspacePoolSize);
+        ICommandExecutor executor;
+        if (config.SubprocessHostMode == SubprocessHostMode.ProcessPool)
+        {
+            executor = await StartProcessPoolExecutorAsync(config, loggerFactory, logger).ConfigureAwait(false);
+        }
+        else
+        {
+            var executorLogger = loggerFactory.CreateLogger<OutOfProcessCommandExecutor>();
+            var singleExecutor = new OutOfProcessCommandExecutor(
+                executorLogger,
+                requestTimeout: null,
+                hostMode: config.SubprocessHostMode,
+                runspacePoolSize: config.SubprocessRunspacePoolSize);
+            await singleExecutor.StartAsync();
+            executor = singleExecutor;
+            logger.LogInformation(
+                "Started out-of-process PowerShell executor (HostMode={HostMode}, PoolSize={PoolSize})",
+                config.SubprocessHostMode, config.SubprocessRunspacePoolSize);
+        }
 
         if (config.Environment is not null)
         {
@@ -183,17 +192,54 @@ internal static class McpToolSetupService
     }
 
     /// <summary>
+    /// Builds and starts an <see cref="OutOfProcessSubprocessPool"/> using the
+    /// per-process configuration knobs from <paramref name="config"/>.
+    /// </summary>
+    private static async Task<ICommandExecutor> StartProcessPoolExecutorAsync(
+        PowerShellConfiguration config,
+        ILoggerFactory loggerFactory,
+        ILogger logger)
+    {
+        // Resolve pwsh + host script via the same logic the single executor uses,
+        // but without launching its subprocess.
+        var executorLogger = loggerFactory.CreateLogger<OutOfProcessCommandExecutor>();
+        var resolver = new OutOfProcessCommandExecutor(executorLogger);
+        var hostScriptPath = await resolver.ResolveHostScriptPathAsync().ConfigureAwait(false);
+        var pwshPath = OutOfProcessCommandExecutor.ResolvePwshPath();
+        await resolver.DisposeAsync().ConfigureAwait(false);
+
+        var poolOptions = new OutOfProcessSubprocessPoolOptions
+        {
+            PoolSize = config.SubprocessPoolSize > 0 ? config.SubprocessPoolSize : 4,
+            MinHealthyForStartup = config.SubprocessMinHealthyForStartup > 0
+                ? Math.Min(config.SubprocessMinHealthyForStartup, Math.Max(1, config.SubprocessPoolSize))
+                : 1,
+        };
+
+        var pool = new OutOfProcessSubprocessPool(
+            pwshPath, hostScriptPath, poolOptions, loggerFactory);
+
+        await pool.StartAsync().ConfigureAwait(false);
+
+        logger.LogInformation(
+            "Started out-of-process PowerShell executor (ProcessPool, size={PoolSize}, minHealthy={MinHealthy}).",
+            poolOptions.PoolSize, poolOptions.MinHealthyForStartup);
+
+        return pool;
+    }
+
+    /// <summary>
     /// Disposable wrapper for out-of-process executor lifecycle management.
     /// Ensures proper cleanup of PowerShell executor resources.
     /// </summary>
     internal sealed class OutOfProcessExecutorLease : IAsyncDisposable
     {
-        public OutOfProcessExecutorLease(OutOfProcessCommandExecutor executor)
+        public OutOfProcessExecutorLease(ICommandExecutor executor)
         {
             Executor = executor;
         }
 
-        public OutOfProcessCommandExecutor Executor { get; }
+        public ICommandExecutor Executor { get; }
 
         public async ValueTask DisposeAsync()
         {

--- a/PoshMcp.Tests/Integration/OutOfProcessSubprocessPoolIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/OutOfProcessSubprocessPoolIntegrationTests.cs
@@ -1,0 +1,368 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using PoshMcp.Server.PowerShell;
+using PoshMcp.Server.PowerShell.OutOfProcess;
+using PoshMcp.Tests.Shared;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PoshMcp.Tests.Integration;
+
+/// <summary>
+/// Integration tests for <see cref="OutOfProcessSubprocessPool"/> exercising the real
+/// pwsh subprocess pool over pool sizes 1, 2, and 4.
+/// </summary>
+[Trait("Category", "OutOfProcess")]
+public class OutOfProcessSubprocessPoolIntegrationTests : IAsyncLifetime
+{
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger _logger;
+    private readonly ITestOutputHelper _output;
+    private string? _pwshPath;
+    private string? _hostScriptPath;
+
+    public OutOfProcessSubprocessPoolIntegrationTests(ITestOutputHelper output)
+    {
+        _output = output;
+        _loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.AddProvider(new TestOutputLoggerProvider(output));
+            builder.SetMinimumLevel(LogLevel.Debug);
+        });
+        _logger = _loggerFactory.CreateLogger<OutOfProcessSubprocessPoolIntegrationTests>();
+    }
+
+    public async Task InitializeAsync()
+    {
+        try { _pwshPath = OutOfProcessCommandExecutor.ResolvePwshPath(); }
+        catch { _pwshPath = null; }
+
+        _hostScriptPath = await OopTestPaths.ResolveHostScriptAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        _loggerFactory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private OutOfProcessSubprocessPool CreatePool(int poolSize, int? minHealthy = null)
+    {
+        Assert.NotNull(_pwshPath);
+        Assert.NotNull(_hostScriptPath);
+
+        return new OutOfProcessSubprocessPool(
+            _pwshPath!, _hostScriptPath!,
+            new OutOfProcessSubprocessPoolOptions
+            {
+                PoolSize = poolSize,
+                MinHealthyForStartup = minHealthy ?? 1,
+                ReconcilerInterval = TimeSpan.FromMilliseconds(250),
+            },
+            _loggerFactory,
+            requestTimeout: TimeSpan.FromSeconds(20));
+    }
+
+    // ---- Lifecycle ----
+
+    [PwshAvailableTheory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(4)]
+    public async Task Pool_StartAsync_BringsAllHostsHealthy(int poolSize)
+    {
+        if (_hostScriptPath is null) return;
+
+        await using var pool = CreatePool(poolSize);
+        await pool.StartAsync();
+
+        Assert.Equal(poolSize, pool.HealthyCount);
+    }
+
+    [PwshAvailableTheory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(4)]
+    public async Task Pool_SetupThenInvoke_Succeeds(int poolSize)
+    {
+        if (_hostScriptPath is null) return;
+
+        await using var pool = CreatePool(poolSize);
+        await pool.StartAsync();
+
+        // Empty environment: a no-op setup that the host script must accept.
+        await pool.SetupAsync(new EnvironmentConfiguration());
+
+        var output = await pool.InvokeAsync(
+            "Get-Date",
+            new Dictionary<string, object?>(),
+            CancellationToken.None);
+
+        Assert.False(string.IsNullOrWhiteSpace(output));
+        _logger.LogInformation("Get-Date returned: {Output}", output);
+    }
+
+    [PwshAvailableTheory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(4)]
+    public async Task Pool_DiscoverCommands_CachesAcrossCalls(int poolSize)
+    {
+        if (_hostScriptPath is null) return;
+
+        await using var pool = CreatePool(poolSize);
+        await pool.StartAsync();
+        await pool.SetupAsync(new EnvironmentConfiguration());
+
+        var config = new PowerShellConfiguration
+        {
+            FunctionNames = new List<string> { "Get-Date" },
+            Modules = new List<string>(),
+            IncludePatterns = new List<string>(),
+            ExcludePatterns = new List<string>()
+        };
+
+        var schemas1 = await pool.DiscoverCommandsAsync(config);
+        var schemas2 = await pool.DiscoverCommandsAsync(config);
+
+        Assert.NotEmpty(schemas1);
+        // Cache hit: same instance reference indicates the cached path was taken.
+        Assert.Same(schemas1, schemas2);
+    }
+
+    // ---- Concurrent dispatch ----
+
+    [PwshAvailableTheory]
+    [InlineData(2)]
+    [InlineData(4)]
+    public async Task Pool_ConcurrentInvokes_SpreadAcrossHosts(int poolSize)
+    {
+        if (_hostScriptPath is null) return;
+
+        await using var pool = CreatePool(poolSize);
+        await pool.StartAsync();
+        await pool.SetupAsync(new EnvironmentConfiguration());
+
+        // Each invoke prints the current process id from inside pwsh. With concurrent
+        // invokes across N >= 2 hosts, we expect at least 2 distinct PIDs in the results.
+        // Each invoke also sleeps so the hosts overlap in time.
+        const int requestCount = 8;
+        var results = new ConcurrentBag<string>();
+
+        var tasks = Enumerable.Range(0, requestCount).Select(_ => Task.Run(async () =>
+        {
+            var output = await pool.InvokeAsync(
+                "Start-Sleep",
+                new Dictionary<string, object?> { ["Milliseconds"] = 200 },
+                CancellationToken.None);
+            results.Add(output);
+        })).ToArray();
+
+        await Task.WhenAll(tasks);
+
+        Assert.Equal(requestCount, results.Count);
+
+        // Now verify multiple PIDs by invoking $PID on each host in parallel.
+        var pidResults = new ConcurrentBag<string>();
+        var pidTasks = Enumerable.Range(0, poolSize * 4).Select(_ => Task.Run(async () =>
+        {
+            // Use Get-Variable to fetch $PID — works across host script versions.
+            var output = await pool.InvokeAsync(
+                "Get-Variable",
+                new Dictionary<string, object?>
+                {
+                    ["Name"] = "PID",
+                    ["ValueOnly"] = true,
+                },
+                CancellationToken.None);
+            pidResults.Add(output);
+        })).ToArray();
+
+        await Task.WhenAll(pidTasks);
+
+        var distinctPids = pidResults
+            .Select(r => r.Trim())
+            .Where(r => !string.IsNullOrEmpty(r))
+            .Distinct()
+            .ToArray();
+
+        _logger.LogInformation(
+            "Distinct PIDs observed across {Total} pool invocations: {Pids}",
+            pidResults.Count, string.Join(",", distinctPids));
+
+        // The pool size is the upper bound; we want to see > 1 PID for poolSize >= 2.
+        Assert.True(
+            distinctPids.Length >= 2,
+            $"Expected >=2 distinct PIDs across pool of {poolSize}; got {distinctPids.Length}.");
+    }
+
+    // ---- Crash recovery ----
+
+    [PwshAvailableTheory]
+    [InlineData(2)]
+    [InlineData(4)]
+    public async Task Pool_HostKilledMidLease_ReconcilerReplaces(int poolSize)
+    {
+        if (_hostScriptPath is null) return;
+
+        await using var pool = CreatePool(poolSize);
+        await pool.StartAsync();
+        await pool.SetupAsync(new EnvironmentConfiguration());
+
+        // Find the pids the pool currently knows about by invoking $PID multiple times
+        // to fan out across hosts.
+        var pidsBefore = new ConcurrentBag<int>();
+        var beforeTasks = Enumerable.Range(0, poolSize * 4).Select(_ => Task.Run(async () =>
+        {
+            var output = await pool.InvokeAsync(
+                "Get-Variable",
+                new Dictionary<string, object?>
+                {
+                    ["Name"] = "PID",
+                    ["ValueOnly"] = true,
+                },
+                CancellationToken.None);
+            if (int.TryParse(output.Trim(), out var pid))
+                pidsBefore.Add(pid);
+        })).ToArray();
+        await Task.WhenAll(beforeTasks);
+
+        var distinctBefore = pidsBefore.Distinct().ToArray();
+        Assert.NotEmpty(distinctBefore);
+
+        // Kill ONE pwsh subprocess externally to simulate a crash.
+        var victimPid = distinctBefore.First();
+        try
+        {
+            var victim = Process.GetProcessById(victimPid);
+            _logger.LogWarning("Killing victim PID {Pid} to simulate host crash.", victimPid);
+            victim.Kill(entireProcessTree: false);
+            victim.WaitForExit(TimeSpan.FromSeconds(5));
+        }
+        catch (ArgumentException)
+        {
+            return; // Already gone; skip the test.
+        }
+
+        // Wait up to ~5s for the reconciler to replace the dead host and the pool to
+        // return to full health.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        while (DateTime.UtcNow < deadline && pool.HealthyCount < poolSize)
+        {
+            await Task.Delay(150);
+        }
+
+        Assert.Equal(poolSize, pool.HealthyCount);
+
+        // Subsequent invokes must succeed and the dead PID must NOT appear in results.
+        var pidsAfter = new ConcurrentBag<int>();
+        var afterTasks = Enumerable.Range(0, poolSize * 4).Select(_ => Task.Run(async () =>
+        {
+            try
+            {
+                var output = await pool.InvokeAsync(
+                    "Get-Variable",
+                    new Dictionary<string, object?>
+                    {
+                        ["Name"] = "PID",
+                        ["ValueOnly"] = true,
+                    },
+                    CancellationToken.None);
+                if (int.TryParse(output.Trim(), out var pid))
+                    pidsAfter.Add(pid);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Post-crash invoke failed (expected for the in-flight one).");
+            }
+        })).ToArray();
+        await Task.WhenAll(afterTasks);
+
+        Assert.NotEmpty(pidsAfter);
+        Assert.DoesNotContain(victimPid, pidsAfter);
+    }
+
+    // ---- Per-request kill on timeout ----
+
+    [PwshAvailableFact]
+    public async Task Pool_PerRequestTimeout_KillsHostAndPoolRecovers()
+    {
+        if (_hostScriptPath is null) return;
+
+        // Use a moderate request timeout: long enough for the host startup ping
+        // to round-trip on slow machines (cold pwsh.exe on Windows can take >1s),
+        // short enough that a Start-Sleep 30 invoke fires the timeout quickly.
+        await using var pool = new OutOfProcessSubprocessPool(
+            _pwshPath!, _hostScriptPath!,
+            new OutOfProcessSubprocessPoolOptions
+            {
+                PoolSize = 2,
+                MinHealthyForStartup = 1,
+                ReconcilerInterval = TimeSpan.FromMilliseconds(200),
+            },
+            _loggerFactory,
+            requestTimeout: TimeSpan.FromSeconds(5));
+
+        await pool.StartAsync();
+        await pool.SetupAsync(new EnvironmentConfiguration());
+
+        // This sleep is much longer than the request timeout — the underlying host
+        // will be killed by the pool's per-request timeout handling.
+        await Assert.ThrowsAsync<TimeoutException>(async () =>
+        {
+            await pool.InvokeAsync(
+                "Start-Sleep",
+                new Dictionary<string, object?> { ["Seconds"] = 30 },
+                CancellationToken.None);
+        });
+
+        // After the timeout, the pool should reconcile back to full health.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        while (DateTime.UtcNow < deadline && pool.HealthyCount < 2)
+        {
+            await Task.Delay(150);
+        }
+
+        Assert.Equal(2, pool.HealthyCount);
+
+        // And subsequent invokes must succeed.
+        var output = await pool.InvokeAsync(
+            "Get-Date",
+            new Dictionary<string, object?>(),
+            CancellationToken.None);
+        Assert.False(string.IsNullOrWhiteSpace(output));
+    }
+
+    // ---- Fail-fast on first host startup ----
+
+    [PwshAvailableFact]
+    public async Task Pool_BadHostScript_FailsFast()
+    {
+        // A bogus host script path forces every host to fail startup.
+        // The first-host fail-fast contract means StartAsync must throw — even if
+        // MinHealthyForStartup is 1.
+        var pool = new OutOfProcessSubprocessPool(
+            _pwshPath!,
+            Path.Combine(Path.GetTempPath(), $"definitely-not-a-real-host-{Guid.NewGuid():N}.ps1"),
+            new OutOfProcessSubprocessPoolOptions
+            {
+                PoolSize = 2,
+                MinHealthyForStartup = 1,
+                StartupRetryCount = 1,
+                StartupBackoffInitial = TimeSpan.FromMilliseconds(10),
+                StartupBackoffMax = TimeSpan.FromMilliseconds(50),
+                ReconcilerInterval = TimeSpan.FromSeconds(1),
+            },
+            _loggerFactory);
+
+        await Assert.ThrowsAnyAsync<Exception>(() => pool.StartAsync());
+        await pool.DisposeAsync();
+    }
+}

--- a/PoshMcp.Tests/Shared/OopTestPaths.cs
+++ b/PoshMcp.Tests/Shared/OopTestPaths.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using PoshMcp.Server.PowerShell.OutOfProcess;
+
+namespace PoshMcp.Tests.Shared;
+
+/// <summary>
+/// Test helper that resolves the path to <c>oop-host.ps1</c> the same way
+/// <see cref="OutOfProcessCommandExecutor.ResolveHostScriptPathAsync"/> does, but
+/// callable from tests without going through the full executor lifecycle.
+/// </summary>
+internal static class OopTestPaths
+{
+    /// <summary>
+    /// Resolves <c>oop-host.ps1</c> for tests. Returns <c>null</c> if the script
+    /// cannot be found (e.g., CI without server build artifacts copied).
+    /// </summary>
+    public static async Task<string?> ResolveHostScriptAsync()
+    {
+        var overridePath = Environment.GetEnvironmentVariable("POSHMCP_OOP_HOST_PATH");
+        if (!string.IsNullOrWhiteSpace(overridePath) && File.Exists(overridePath))
+            return overridePath;
+
+        var serverAssembly = typeof(OutOfProcessHost).Assembly;
+        var resourceName = Array.Find(
+            serverAssembly.GetManifestResourceNames(),
+            name => name.EndsWith("oop-host.ps1", StringComparison.OrdinalIgnoreCase));
+
+        if (resourceName is not null)
+        {
+            using var stream = serverAssembly.GetManifestResourceStream(resourceName);
+            if (stream is not null)
+            {
+                var bytes = new byte[stream.Length];
+                await stream.ReadExactlyAsync(bytes);
+                var hash = Convert.ToHexStringLower(SHA256.HashData(bytes));
+                var dir = Path.Combine(Path.GetTempPath(), "poshmcp-tests");
+                var path = Path.Combine(dir, "oop-host.ps1");
+                Directory.CreateDirectory(dir);
+                if (!File.Exists(path) || ContentHash(path) != hash)
+                {
+                    await File.WriteAllBytesAsync(path, bytes);
+                }
+                return path;
+            }
+        }
+
+        var basePath = Path.Combine(AppContext.BaseDirectory, "PowerShell", "OutOfProcess", "oop-host.ps1");
+        return File.Exists(basePath) ? basePath : null;
+    }
+
+    private static string ContentHash(string filePath)
+    {
+        using var fs = File.OpenRead(filePath);
+        return Convert.ToHexStringLower(SHA256.HashData(fs));
+    }
+}

--- a/PoshMcp.Tests/Shared/PwshAvailableTheoryAttribute.cs
+++ b/PoshMcp.Tests/Shared/PwshAvailableTheoryAttribute.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using PoshMcp.Server.PowerShell.OutOfProcess;
+using Xunit;
+
+namespace PoshMcp.Tests;
+
+/// <summary>
+/// A custom xUnit [Theory] attribute that skips the test when pwsh is not available on PATH.
+/// Mirrors <see cref="PwshAvailableFactAttribute"/>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public sealed class PwshAvailableTheoryAttribute : TheoryAttribute
+{
+    private static readonly Lazy<string?> PwshSkipReason = new(DetectPwshSkipReason);
+
+    public PwshAvailableTheoryAttribute()
+    {
+        if (PwshSkipReason.Value is not null)
+        {
+            Skip = PwshSkipReason.Value;
+        }
+    }
+
+    private static string? DetectPwshSkipReason()
+    {
+        try
+        {
+            var path = OutOfProcessCommandExecutor.ResolvePwshPath();
+            if (string.IsNullOrEmpty(path))
+            {
+                return "pwsh is not available on PATH";
+            }
+            return null;
+        }
+        catch (FileNotFoundException)
+        {
+            return "pwsh is not available on PATH";
+        }
+        catch (Exception ex)
+        {
+            return $"pwsh availability check failed: {ex.Message}";
+        }
+    }
+}

--- a/PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessSubprocessPoolTests.cs
+++ b/PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessSubprocessPoolTests.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using PoshMcp.Server.PowerShell;
+using PoshMcp.Server.PowerShell.OutOfProcess;
+using Xunit;
+
+namespace PoshMcp.Tests.Unit.OutOfProcess;
+
+/// <summary>
+/// Unit tests for <see cref="OutOfProcessSubprocessPool"/> internals that don't
+/// require a live pwsh subprocess: constructor validation, state transitions
+/// before <c>StartAsync</c>, environment fingerprint stability, and the
+/// <see cref="SubprocessHostMode"/> string detection.
+/// </summary>
+public class OutOfProcessSubprocessPoolTests
+{
+    [Fact]
+    public void Constructor_NullPwsh_Throws()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new OutOfProcessSubprocessPool(
+                string.Empty, "x.ps1",
+                new OutOfProcessSubprocessPoolOptions { PoolSize = 1 }));
+    }
+
+    [Fact]
+    public void Constructor_NullScript_Throws()
+    {
+        Assert.Throws<ArgumentException>(
+            () => new OutOfProcessSubprocessPool(
+                "pwsh", string.Empty,
+                new OutOfProcessSubprocessPoolOptions { PoolSize = 1 }));
+    }
+
+    [Fact]
+    public void Constructor_NullOptions_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => new OutOfProcessSubprocessPool("pwsh", "x.ps1", null!));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_InvalidPoolSize_Throws(int poolSize)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new OutOfProcessSubprocessPool(
+                "pwsh", "x.ps1",
+                new OutOfProcessSubprocessPoolOptions { PoolSize = poolSize }));
+    }
+
+    [Fact]
+    public void Constructor_MinHealthyExceedsPoolSize_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new OutOfProcessSubprocessPool(
+                "pwsh", "x.ps1",
+                new OutOfProcessSubprocessPoolOptions { PoolSize = 2, MinHealthyForStartup = 5 }));
+    }
+
+    [Fact]
+    public async Task DisposeAsync_BeforeStart_DoesNotThrow()
+    {
+        var pool = new OutOfProcessSubprocessPool(
+            "pwsh", "x.ps1",
+            new OutOfProcessSubprocessPoolOptions { PoolSize = 1 });
+        await pool.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_IsIdempotent()
+    {
+        var pool = new OutOfProcessSubprocessPool(
+            "pwsh", "x.ps1",
+            new OutOfProcessSubprocessPoolOptions { PoolSize = 1 });
+        await pool.DisposeAsync();
+        await pool.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_BeforeStart_Throws()
+    {
+        var pool = new OutOfProcessSubprocessPool(
+            "pwsh", "x.ps1",
+            new OutOfProcessSubprocessPoolOptions { PoolSize = 1 });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => pool.InvokeAsync("Get-Date", new Dictionary<string, object?>(), CancellationToken.None));
+
+        await pool.DisposeAsync();
+    }
+
+    [Fact]
+    public void HealthyCount_BeforeStart_IsZero()
+    {
+        var pool = new OutOfProcessSubprocessPool(
+            "pwsh", "x.ps1",
+            new OutOfProcessSubprocessPoolOptions { PoolSize = 4 });
+
+        Assert.Equal(0, pool.HealthyCount);
+        Assert.Equal(4, pool.PoolSize);
+    }
+
+    // ---- ComputeEnvironmentFingerprint ----
+
+    [Fact]
+    public void Fingerprint_IdenticalConfigs_ProduceSameHash()
+    {
+        var c1 = new EnvironmentConfiguration
+        {
+            ImportModules = { "Pester", "PSReadLine" },
+            ModulePaths = { "/a", "/b" },
+            TrustPSGallery = true,
+        };
+        var c2 = new EnvironmentConfiguration
+        {
+            ImportModules = { "Pester", "PSReadLine" },
+            ModulePaths = { "/a", "/b" },
+            TrustPSGallery = true,
+        };
+
+        var f1 = OutOfProcessSubprocessPool.ComputeEnvironmentFingerprint(c1, null);
+        var f2 = OutOfProcessSubprocessPool.ComputeEnvironmentFingerprint(c2, null);
+        Assert.Equal(f1, f2);
+        Assert.NotEqual(string.Empty, f1);
+        Assert.Equal(64, f1.Length); // SHA-256 hex
+    }
+
+    [Fact]
+    public void Fingerprint_OrderingDifferences_ProduceSameHash()
+    {
+        var c1 = new EnvironmentConfiguration
+        {
+            ImportModules = { "Pester", "PSReadLine" },
+            ModulePaths = { "/a", "/b" },
+        };
+        var c2 = new EnvironmentConfiguration
+        {
+            ImportModules = { "PSReadLine", "Pester" },
+            ModulePaths = { "/b", "/a" },
+        };
+
+        var f1 = OutOfProcessSubprocessPool.ComputeEnvironmentFingerprint(c1, null);
+        var f2 = OutOfProcessSubprocessPool.ComputeEnvironmentFingerprint(c2, null);
+        Assert.Equal(f1, f2);
+    }
+
+    [Fact]
+    public void Fingerprint_DiscoveryModulesIncluded()
+    {
+        var config = new EnvironmentConfiguration { ImportModules = { "Pester" } };
+        var f1 = OutOfProcessSubprocessPool.ComputeEnvironmentFingerprint(config, null);
+        var f2 = OutOfProcessSubprocessPool.ComputeEnvironmentFingerprint(
+            config, new[] { "Az.Accounts" });
+        Assert.NotEqual(f1, f2);
+    }
+
+    [Fact]
+    public void Fingerprint_StartupScriptChange_ProducesDifferentHash()
+    {
+        var c1 = new EnvironmentConfiguration { StartupScript = "Write-Host 'a'" };
+        var c2 = new EnvironmentConfiguration { StartupScript = "Write-Host 'b'" };
+        Assert.NotEqual(
+            OutOfProcessSubprocessPool.ComputeEnvironmentFingerprint(c1, null),
+            OutOfProcessSubprocessPool.ComputeEnvironmentFingerprint(c2, null));
+    }
+
+    [Fact]
+    public void Fingerprint_TrustPSGalleryChange_ProducesDifferentHash()
+    {
+        var c1 = new EnvironmentConfiguration { TrustPSGallery = true };
+        var c2 = new EnvironmentConfiguration { TrustPSGallery = false };
+        Assert.NotEqual(
+            OutOfProcessSubprocessPool.ComputeEnvironmentFingerprint(c1, null),
+            OutOfProcessSubprocessPool.ComputeEnvironmentFingerprint(c2, null));
+    }
+
+    [Fact]
+    public void Fingerprint_NullConfig_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => OutOfProcessSubprocessPool.ComputeEnvironmentFingerprint(null!, null));
+    }
+}


### PR DESCRIPTION
**🔧 Bender (Backend Developer)**

Closes #192

## Pool design

A pool of N independent `pwsh` subprocess hosts as an alternative to the single-subprocess executor. Each request leases one host, runs against it, and returns it when finished. Hosts that crash or time out are reconciled out of rotation and replaced by a background reconciler. Built on the `OutOfProcessHost` seam from #190.

## Lease + reconciliation

- `Channel<HostSlot>` for the available queue (lease = `ReadAsync`, return = `TryWrite`).
- `ConcurrentDictionary<int, HostSlot>` keyed by stable slot index for source-of-truth about which slots exist and their status.
- Both structures are required: the channel alone cannot detect a crashed mid-lease host; the dictionary lets the reconciler discover dead slots and start replacements without process-id reuse hazards.

## Fail-fast vs backoff

- **Slot 0 is fail-fast** — if the first host can''t reach a healthy `ping`, `StartAsync` throws.
- **Slots 1..N-1** start in parallel with bounded retry and exponential backoff.
- Pool starts as long as `SubprocessMinHealthyForStartup` hosts come up healthy (degraded if any failed); otherwise `StartAsync` throws and the pool is disposed.

## Discovery cache key

Per-pool cache keyed by a **SHA-256 fingerprint** over the `EnvironmentConfiguration` fields that influence module visibility: module paths, install/import modules, startup script path/content, `trustPSGallery`, and the effective discovery module list. Replacement hosts reapply the same setup, so the fingerprint and cached schemas remain valid across reconciliation. Setup with a different fingerprint invalidates the cache.

## Per-request kill on timeout

When `InvokeAsync` observes a `TimeoutException` (or a host dies mid-invoke), the pool marks that specific slot dead and the reconciler replaces it. The rest of the pool keeps serving — Option B''s structural advantage over single-host mode.

## Defaults

| Knob | Default |
|------|---------|
| `SubprocessHostMode` | `"Single"` |
| `SubprocessPoolSize` | `4` |
| `SubprocessMinHealthyForStartup` | `1` |
| StartupRetryCount | 3 |
| StartupBackoffInitial | 250 ms |
| StartupBackoffMax | 5 s |
| ReconcilerInterval | 1 s |
| Request timeout | 30 s |

## Test results

- **Integration tests** parameterized over pool sizes **1, 2, 4**: startup, setup + invoke, discovery cache, concurrent invokes spread across PIDs, host-killed reconciliation, per-request timeout kill + recovery, bad-host fail-fast — all passing.
- **Unit tests** cover fingerprint determinism, options validation, lifecycle guards.

Spec: `specs/004-out-of-process-execution/spec.md`
Plan: `specs/004-out-of-process-execution/runspace-pool-experiment-plan.md` §5 #3
