### PR TITLE
feat(benchmarks): wire harness to executors (#194)

### DIFF
--- a/PoshMcp.Benchmarks/BenchmarkConfig.cs
+++ b/PoshMcp.Benchmarks/BenchmarkConfig.cs
@@ -1,6 +1,8 @@
+using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Reports;
 
 namespace PoshMcp.Benchmarks;
 
@@ -26,5 +28,18 @@ public sealed class BenchmarkConfig : ManualConfig
         // BenchmarkDotNet so we don't have to enumerate them here. Scenarios
         // that need per-scenario tuning use attributes on the [Benchmark] methods.
         Add(DefaultConfig.Instance);
+
+        // Surface percentile columns called out in the AC for #194:
+        // "Markdown table includes columns: mode, scenario, payload size,
+        //  mean, p95, p99, crash-recovery time".
+        // BDN ships a static StatisticColumn.P95 but not P99 — see
+        // P99StatisticColumn for the custom column we add to fill the gap.
+        // For crash-recovery scenarios the Mean column IS the recovery time
+        // (each iteration kills + recovers); documented in
+        // PoshMcp.Benchmarks/README.md.
+        AddColumn(StatisticColumn.P95);
+        AddColumn(new P99StatisticColumn());
+
+        SummaryStyle = SummaryStyle.Default.WithRatioStyle(RatioStyle.Trend);
     }
 }

--- a/PoshMcp.Benchmarks/ExecutorFactory.cs
+++ b/PoshMcp.Benchmarks/ExecutorFactory.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using PoshMcp.Server.PowerShell.OutOfProcess;
+
+namespace PoshMcp.Benchmarks;
+
+/// <summary>
+/// Builds an <see cref="ICommandExecutor"/> for each <see cref="HostMode"/>
+/// using the same wiring path the production server uses
+/// (<c>McpToolSetupService.StartOutOfProcessExecutorIfNeededAsync</c>),
+/// without pulling in the hosting / configuration / logging stack.
+///
+/// <para>
+/// Skip the executor's <c>SetupAsync</c> step on purpose: benchmarks measure
+/// the executor itself, not environment customization (module install /
+/// import / startup script). Built-in cmdlets like <c>Get-Date</c>,
+/// <c>Get-Random</c>, and <c>Write-Output</c> are callable via
+/// <see cref="ICommandExecutor.InvokeAsync"/> without prior discovery.
+/// </para>
+/// </summary>
+internal static class ExecutorFactory
+{
+    /// <summary>
+    /// Default size for the <see cref="HostMode.ProcessPool"/> pool.
+    /// Matches <c>PowerShellConfiguration.SubprocessPoolSize</c>'s default.
+    /// </summary>
+    public const int DefaultProcessPoolSize = 4;
+
+    /// <summary>
+    /// Default size for the <see cref="HostMode.Pool"/> runspace pool.
+    /// 0 lets the host pick min(ProcessorCount, 8).
+    /// </summary>
+    public const int DefaultRunspacePoolSize = 0;
+
+    /// <summary>
+    /// Constructs and starts an executor for the given <paramref name="mode"/>.
+    /// Caller is responsible for <see cref="ICommandExecutor.DisposeAsync"/>.
+    /// </summary>
+    public static async Task<BenchExecutor> CreateAsync(
+        HostMode mode,
+        TimeSpan? requestTimeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        var timeout = requestTimeout ?? TimeSpan.FromSeconds(30);
+
+        switch (mode)
+        {
+            case HostMode.Single:
+            {
+                var exec = new OutOfProcessCommandExecutor(
+                    NullLoggerFactory.Instance,
+                    requestTimeout: timeout,
+                    hostMode: SubprocessHostMode.Single,
+                    runspacePoolSize: 0);
+                await exec.StartAsync(cancellationToken).ConfigureAwait(false);
+                return new SingleOrPoolBenchExecutor(exec);
+            }
+
+            case HostMode.Pool:
+            {
+                var exec = new OutOfProcessCommandExecutor(
+                    NullLoggerFactory.Instance,
+                    requestTimeout: timeout,
+                    hostMode: SubprocessHostMode.Pool,
+                    runspacePoolSize: DefaultRunspacePoolSize);
+                await exec.StartAsync(cancellationToken).ConfigureAwait(false);
+                return new SingleOrPoolBenchExecutor(exec);
+            }
+
+            case HostMode.ProcessPool:
+            {
+                // Resolve pwsh + the single-runspace host script (ProcessPool
+                // hosts run oop-host.ps1, not the pool variant — each subprocess
+                // owns one runspace).
+                var resolver = new OutOfProcessCommandExecutor(
+                    NullLoggerFactory.Instance,
+                    hostMode: SubprocessHostMode.Single);
+                var hostScript = await resolver.ResolveHostScriptPathAsync().ConfigureAwait(false);
+                var pwshPath = OutOfProcessCommandExecutor.ResolvePwshPath();
+                await resolver.DisposeAsync().ConfigureAwait(false);
+
+                var pool = new OutOfProcessSubprocessPool(
+                    pwshPath,
+                    hostScript,
+                    new OutOfProcessSubprocessPoolOptions
+                    {
+                        PoolSize = DefaultProcessPoolSize,
+                        MinHealthyForStartup = 1,
+                    },
+                    NullLoggerFactory.Instance,
+                    requestTimeout: timeout);
+
+                await pool.StartAsync(cancellationToken).ConfigureAwait(false);
+                return new ProcessPoolBenchExecutor(pool);
+            }
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unknown HostMode.");
+        }
+    }
+}
+
+/// <summary>
+/// Wraps an <see cref="ICommandExecutor"/> with crash-injection helpers the
+/// benchmark scenarios need but that aren't part of the production interface.
+/// </summary>
+internal abstract class BenchExecutor : IAsyncDisposable
+{
+    public abstract ICommandExecutor Executor { get; }
+
+    /// <summary>
+    /// Forcibly kills one underlying pwsh subprocess to simulate a crash.
+    /// Returns the killed PID, or null if no live host could be found.
+    /// </summary>
+    /// <remarks>
+    /// For <see cref="HostMode.Single"/> and <see cref="HostMode.Pool"/> this
+    /// kills the only subprocess — the executor will not auto-recover; the
+    /// caller is expected to dispose and recreate.
+    /// For <see cref="HostMode.ProcessPool"/> this kills one of N hosts; the
+    /// pool's reconciler replaces it on its next sweep, and other hosts serve
+    /// requests in the meantime.
+    /// </remarks>
+    public abstract int? KillOneHost();
+
+    public abstract ValueTask DisposeAsync();
+}
+
+internal sealed class SingleOrPoolBenchExecutor : BenchExecutor
+{
+    private OutOfProcessCommandExecutor _exec;
+    public override ICommandExecutor Executor => _exec;
+
+    public SingleOrPoolBenchExecutor(OutOfProcessCommandExecutor exec)
+    {
+        _exec = exec;
+    }
+
+    public override int? KillOneHost()
+    {
+        // Reflect into _host._process — both fields are private; we live in
+        // the same friend assembly so we could surface them, but reflection
+        // keeps the bench-only crash hook out of the production type.
+        var hostField = typeof(OutOfProcessCommandExecutor)
+            .GetField("_host", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var host = (OutOfProcessHost?)hostField?.GetValue(_exec);
+        if (host is null) return null;
+
+        var procField = typeof(OutOfProcessHost)
+            .GetField("_process", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var proc = (Process?)procField?.GetValue(host);
+        if (proc is null) return null;
+
+        try
+        {
+            var pid = proc.Id;
+            proc.Kill(entireProcessTree: true);
+            return pid;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        await _exec.DisposeAsync().ConfigureAwait(false);
+    }
+}
+
+internal sealed class ProcessPoolBenchExecutor : BenchExecutor
+{
+    private readonly OutOfProcessSubprocessPool _pool;
+    public override ICommandExecutor Executor => _pool;
+
+    public ProcessPoolBenchExecutor(OutOfProcessSubprocessPool pool)
+    {
+        _pool = pool;
+    }
+
+    public override int? KillOneHost()
+    {
+        // _slots is a ConcurrentDictionary<int, HostSlot> on the pool; HostSlot
+        // exposes Host (an OutOfProcessHost). Walk via reflection — HostSlot
+        // and the field are internal, but reflecting into private state keeps
+        // the benchmark contract loose against future refactors.
+        var slotsField = typeof(OutOfProcessSubprocessPool)
+            .GetField("_slots", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var slots = slotsField?.GetValue(_pool) as System.Collections.IEnumerable;
+        if (slots is null) return null;
+
+        foreach (var kvp in slots)
+        {
+            var slot = kvp.GetType().GetProperty("Value")?.GetValue(kvp);
+            if (slot is null) continue;
+
+            var hostProp = slot.GetType().GetField("Host");
+            var host = hostProp?.GetValue(slot) as OutOfProcessHost;
+            if (host is null || !host.IsRunning) continue;
+
+            var procField = typeof(OutOfProcessHost)
+                .GetField("_process", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var proc = procField?.GetValue(host) as Process;
+            if (proc is null) continue;
+
+            try
+            {
+                var pid = proc.Id;
+                proc.Kill(entireProcessTree: true);
+                return pid;
+            }
+            catch
+            {
+                // Try the next slot.
+            }
+        }
+        return null;
+    }
+
+    public override async ValueTask DisposeAsync()
+    {
+        await _pool.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/PoshMcp.Benchmarks/ExecutorFactory.cs
+++ b/PoshMcp.Benchmarks/ExecutorFactory.cs
@@ -51,53 +51,53 @@ internal static class ExecutorFactory
         switch (mode)
         {
             case HostMode.Single:
-            {
-                var exec = new OutOfProcessCommandExecutor(
-                    NullLoggerFactory.Instance,
-                    requestTimeout: timeout,
-                    hostMode: SubprocessHostMode.Single,
-                    runspacePoolSize: 0);
-                await exec.StartAsync(cancellationToken).ConfigureAwait(false);
-                return new SingleOrPoolBenchExecutor(exec);
-            }
+                {
+                    var exec = new OutOfProcessCommandExecutor(
+                        NullLoggerFactory.Instance,
+                        requestTimeout: timeout,
+                        hostMode: SubprocessHostMode.Single,
+                        runspacePoolSize: 0);
+                    await exec.StartAsync(cancellationToken).ConfigureAwait(false);
+                    return new SingleOrPoolBenchExecutor(exec);
+                }
 
             case HostMode.Pool:
-            {
-                var exec = new OutOfProcessCommandExecutor(
-                    NullLoggerFactory.Instance,
-                    requestTimeout: timeout,
-                    hostMode: SubprocessHostMode.Pool,
-                    runspacePoolSize: DefaultRunspacePoolSize);
-                await exec.StartAsync(cancellationToken).ConfigureAwait(false);
-                return new SingleOrPoolBenchExecutor(exec);
-            }
+                {
+                    var exec = new OutOfProcessCommandExecutor(
+                        NullLoggerFactory.Instance,
+                        requestTimeout: timeout,
+                        hostMode: SubprocessHostMode.Pool,
+                        runspacePoolSize: DefaultRunspacePoolSize);
+                    await exec.StartAsync(cancellationToken).ConfigureAwait(false);
+                    return new SingleOrPoolBenchExecutor(exec);
+                }
 
             case HostMode.ProcessPool:
-            {
-                // Resolve pwsh + the single-runspace host script (ProcessPool
-                // hosts run oop-host.ps1, not the pool variant — each subprocess
-                // owns one runspace).
-                var resolver = new OutOfProcessCommandExecutor(
-                    NullLoggerFactory.Instance,
-                    hostMode: SubprocessHostMode.Single);
-                var hostScript = await resolver.ResolveHostScriptPathAsync().ConfigureAwait(false);
-                var pwshPath = OutOfProcessCommandExecutor.ResolvePwshPath();
-                await resolver.DisposeAsync().ConfigureAwait(false);
+                {
+                    // Resolve pwsh + the single-runspace host script (ProcessPool
+                    // hosts run oop-host.ps1, not the pool variant — each subprocess
+                    // owns one runspace).
+                    var resolver = new OutOfProcessCommandExecutor(
+                        NullLoggerFactory.Instance,
+                        hostMode: SubprocessHostMode.Single);
+                    var hostScript = await resolver.ResolveHostScriptPathAsync().ConfigureAwait(false);
+                    var pwshPath = OutOfProcessCommandExecutor.ResolvePwshPath();
+                    await resolver.DisposeAsync().ConfigureAwait(false);
 
-                var pool = new OutOfProcessSubprocessPool(
-                    pwshPath,
-                    hostScript,
-                    new OutOfProcessSubprocessPoolOptions
-                    {
-                        PoolSize = DefaultProcessPoolSize,
-                        MinHealthyForStartup = 1,
-                    },
-                    NullLoggerFactory.Instance,
-                    requestTimeout: timeout);
+                    var pool = new OutOfProcessSubprocessPool(
+                        pwshPath,
+                        hostScript,
+                        new OutOfProcessSubprocessPoolOptions
+                        {
+                            PoolSize = DefaultProcessPoolSize,
+                            MinHealthyForStartup = 1,
+                        },
+                        NullLoggerFactory.Instance,
+                        requestTimeout: timeout);
 
-                await pool.StartAsync(cancellationToken).ConfigureAwait(false);
-                return new ProcessPoolBenchExecutor(pool);
-            }
+                    await pool.StartAsync(cancellationToken).ConfigureAwait(false);
+                    return new ProcessPoolBenchExecutor(pool);
+                }
 
             default:
                 throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unknown HostMode.");

--- a/PoshMcp.Benchmarks/P99StatisticColumn.cs
+++ b/PoshMcp.Benchmarks/P99StatisticColumn.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+
+namespace PoshMcp.Benchmarks;
+
+/// <summary>
+/// Custom <see cref="IColumn"/> reporting the 99th percentile of a benchmark's
+/// per-invocation latency. BenchmarkDotNet 0.14 ships <see cref="StatisticColumn.P95"/>
+/// but does not expose a built-in P99 column; the AC for issue #194 calls for
+/// both, so this fills the gap by walking the same <c>Statistics</c> bag the
+/// built-in percentile columns use.
+/// </summary>
+internal sealed class P99StatisticColumn : IColumn
+{
+    public string Id => nameof(P99StatisticColumn);
+    public string ColumnName => "P99";
+    public string Legend => "Percentile 99 of per-operation latency.";
+    public bool AlwaysShow => true;
+    public ColumnCategory Category => ColumnCategory.Statistics;
+    public int PriorityInCategory => 0;
+    public bool IsNumeric => true;
+    public UnitType UnitType => UnitType.Time;
+
+    public bool IsAvailable(Summary summary) => true;
+    public bool IsDefault(Summary summary, BenchmarkCase benchmarkCase) => false;
+
+    public string GetValue(Summary summary, BenchmarkCase benchmarkCase)
+        => GetValue(summary, benchmarkCase, SummaryStyle.Default);
+
+    public string GetValue(Summary summary, BenchmarkCase benchmarkCase, SummaryStyle style)
+    {
+        var report = summary[benchmarkCase];
+        var stats = report?.ResultStatistics;
+        if (stats is null || stats.OriginalValues is null || stats.OriginalValues.Count == 0)
+        {
+            return "NA";
+        }
+
+        // Sort once, then linear-interpolated rank (R-7) for P99.
+        var sorted = stats.OriginalValues.OrderBy(v => v).ToArray();
+        var rank = 0.99 * (sorted.Length - 1);
+        var lo = (int)Math.Floor(rank);
+        var hi = (int)Math.Ceiling(rank);
+        var weight = rank - lo;
+        var p99Ns = sorted[lo] * (1 - weight) + sorted[hi] * weight;
+
+        // Render in ms with 3 decimals — matches the magnitude of the other
+        // time columns for the OOP benchmarks (per-invoke latencies typically
+        // range from sub-ms warm invokes to multi-second cold starts).
+        var p99Ms = p99Ns / 1_000_000.0;
+        return p99Ms.ToString("N3", style.CultureInfo ?? CultureInfo.InvariantCulture) + " ms";
+    }
+}

--- a/PoshMcp.Benchmarks/README.md
+++ b/PoshMcp.Benchmarks/README.md
@@ -1,0 +1,105 @@
+# PoshMcp.Benchmarks
+
+BenchmarkDotNet harness comparing the three out-of-process executor configurations
+called out in `specs/004-out-of-process-execution/runspace-pool-experiment-plan.md`:
+
+| `HostMode` | Subprocesses | Runspaces / process | Notes |
+|------------|--------------|---------------------|-------|
+| `Single`   | 1            | 1                   | Baseline — existing single-host, single-runspace executor. |
+| `Pool`     | 1            | N (Option A)        | One subprocess, runspace pool of N. |
+| `ProcessPool` | N         | 1 each (Option B)   | Pool of N subprocesses, single runspace each. |
+
+`HostMode` is a `[Params]` axis on every scenario, so a single `dotnet run` produces
+one row per (mode × scenario × payload-size) combination in one results table.
+
+## Scenarios
+
+| Scenario class                               | What it measures |
+|----------------------------------------------|------------------|
+| `ColdStartBenchmark`                         | ctor → start → first invoke → dispose, per iteration. |
+| `WarmInvokeThroughputBenchmark`              | N concurrent `Invoke-WebRequest` calls against an in-proc HTTP server. |
+| `PayloadSizeSerializationBenchmark`          | Round-trip a string of size `PayloadBytes` (1 KB / 16 KB / 256 KB / 1 MB). |
+| `ProcessCrashRecoveryBenchmark`              | Kill one underlying `pwsh` host, then time the next successful invoke. |
+| `RunspaceCorruptionRecoveryBenchmark`        | Slow invoke in flight → time a fast probe (head-of-line-blocking gate). |
+
+## Running
+
+All commands assume the repo root.
+
+### Run everything (all scenarios, all modes)
+
+```powershell
+dotnet run --project PoshMcp.Benchmarks --configuration Release -- --filter *
+```
+
+### Filter by scenario
+
+```powershell
+dotnet run --project PoshMcp.Benchmarks --configuration Release -- --filter '*WarmInvoke*'
+dotnet run --project PoshMcp.Benchmarks --configuration Release -- --filter '*ColdStart*'
+dotnet run --project PoshMcp.Benchmarks --configuration Release -- --filter '*PayloadSize*'
+dotnet run --project PoshMcp.Benchmarks --configuration Release -- --filter '*ProcessCrash*'
+dotnet run --project PoshMcp.Benchmarks --configuration Release -- --filter '*RunspaceCorruption*'
+```
+
+### Filter by mode (BDN matches `[Params]` values in the case ID)
+
+```powershell
+dotnet run --project PoshMcp.Benchmarks --configuration Release -- --filter '*Mode=ProcessPool*'
+```
+
+### Quick smoke test (near-zero iterations, just verifies wiring)
+
+```powershell
+dotnet run --project PoshMcp.Benchmarks --configuration Release -- --filter '*WarmInvoke*' --job dry
+```
+
+### List discovered cases without running
+
+```powershell
+dotnet run --project PoshMcp.Benchmarks --configuration Release -- --list flat
+```
+
+## Output
+
+BenchmarkDotNet writes results to `BenchmarkDotNet.Artifacts/` next to the run
+working directory (typically `PoshMcp.Benchmarks/BenchmarkDotNet.Artifacts/`).
+The Markdown table named `*-report-github.md` is the artifact #195 consumes.
+
+The Markdown report includes these columns relevant to the AC for #194:
+
+| Column           | Source |
+|------------------|--------|
+| `Mode`           | `HostMode` `[Params]` axis on every scenario. |
+| (scenario)       | One BDN case row per `[Benchmark]` method. |
+| `PayloadBytes`   | `[Params]` axis on `PayloadSizeSerializationBenchmark`. |
+| `Mean`           | BDN built-in. |
+| `P95`            | `StatisticColumn.P95` (BDN built-in). |
+| `P99`            | `P99StatisticColumn` (custom — see `P99StatisticColumn.cs`). |
+| Crash-recovery   | `Mean` column on `ProcessCrashRecoveryBenchmark` rows IS the per-mode recovery time (each iteration kills one host and then awaits the next invoke). |
+
+## Telemetry
+
+Application Insights / OpenTelemetry export (spec-008) is disabled inside the
+benchmark process by `Program.cs` setting `ApplicationInsights__Enabled=false`
+and clearing `APPLICATIONINSIGHTS_CONNECTION_STRING` before BDN starts. The
+defaults in `PoshMcp.Server` are already off, but the env-var override defends
+against an inherited connection string in the host shell.
+
+## Runtime caveats
+
+- A full run across all five scenarios × three modes × payload-size axis takes
+  on the order of **30–60 minutes** on a modern dev box; allow longer when
+  including the 1 MB payload row.
+- The crash-recovery scenario kills `pwsh` subprocesses by PID via reflection
+  into private fields of `OutOfProcessCommandExecutor` / `OutOfProcessSubprocessPool`.
+  This is intentional — the bench-only crash hook lives in `ExecutorFactory.cs`
+  to keep production types clean.
+- For `Single` and `Pool` modes the crash-recovery benchmark must dispose and
+  recreate the executor (only one subprocess existed). The `Mean` column for
+  those rows therefore reports cold-start cost, which is the correct answer
+  to "time until next successful request" for those configurations.
+- Scenarios skip the executor's `SetupAsync` step — built-in cmdlets like
+  `Get-Date`, `Get-Random`, `Write-Output`, `Invoke-WebRequest`, and
+  `Start-Sleep` are callable directly. The harness measures executor cost,
+  not module install / import.

--- a/PoshMcp.Benchmarks/Scenarios/ColdStartBenchmark.cs
+++ b/PoshMcp.Benchmarks/Scenarios/ColdStartBenchmark.cs
@@ -1,19 +1,24 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 
 namespace PoshMcp.Benchmarks.Scenarios;
 
 /// <summary>
 /// Cold-start scenario: wall-clock from executor construction → first
-/// successful invoke. Favors Option A (one process started once); is the
-/// primary cost Option B has to amortize.
+/// successful invoke → dispose. Favors Option A (one process started once);
+/// is the primary cost Option B has to amortize.
 ///
 /// Spec reference: experiment plan §4 "Cold-start cost" row.
 ///
-/// STUB — wiring to a real <see cref="PoshMcp.Server.PowerShell.OutOfProcess.ICommandExecutor"/>
-/// happens in issue #194. The body is shaped so BenchmarkDotNet can
-/// discover and enumerate the scenario today.
+/// Each iteration constructs a fresh executor, starts it, runs one
+/// <c>Get-Date</c> invoke, and disposes. <c>[InvocationCount(1)] +
+/// [UnrollFactor(1)]</c> ensures one cold-start per iteration so the Mean
+/// column reports per-cold-start cost (not amortized). <c>SetupAsync</c> is
+/// intentionally skipped — built-in cmdlets are callable without environment
+/// customization, and the bench measures executor cost (process launch +
+/// runspace open + first round-trip) rather than module install time.
 /// </summary>
-[MemoryDiagnoser]
 [MinIterationCount(3)]
 [MaxIterationCount(10)]
 public class ColdStartBenchmark
@@ -21,15 +26,13 @@ public class ColdStartBenchmark
     [Params(HostMode.Single, HostMode.Pool, HostMode.ProcessPool)]
     public HostMode Mode { get; set; }
 
-    [Benchmark(Baseline = true, Description = "Cold start: ctor → first invoke")]
-    public int ColdStart()
+    [Benchmark(Description = "Cold start: ctor → start → first invoke → dispose")]
+    [InvocationCount(1)]
+    public async Task ColdStart()
     {
-        // STUB: returns a placeholder value. #194 will replace this with:
-        //   var executor = ExecutorFactory.Create(Mode);
-        //   await executor.StartAsync();
-        //   await executor.SetupAsync(...);
-        //   var result = await executor.InvokeAsync("Get-Date", ...);
-        //   await executor.DisposeAsync();
-        return (int)Mode;
+        await using var bench = await ExecutorFactory.CreateAsync(Mode);
+        _ = await bench.Executor.InvokeAsync(
+            "Get-Date",
+            new Dictionary<string, object?>());
     }
 }

--- a/PoshMcp.Benchmarks/Scenarios/PayloadSizeSerializationBenchmark.cs
+++ b/PoshMcp.Benchmarks/Scenarios/PayloadSizeSerializationBenchmark.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 
 namespace PoshMcp.Benchmarks.Scenarios;
@@ -6,31 +8,67 @@ namespace PoshMcp.Benchmarks.Scenarios;
 /// Heavy serialization scenario, parameterized by payload size to expose
 /// Option B's IPC/serialization overhead and Option A's <c>ConvertTo-Json</c>
 /// contention. Threshold from experiment plan §4: ≥ 2× baseline on this
-/// class of workload.
+/// class of workload (under concurrency).
 ///
-/// Models the spec's <c>Get-Process | Select-Object -First {N}</c> shape.
-/// STUB — #194 wires to ICommandExecutor.
+/// <para>
+/// Implementation: invoke <c>Write-Output -InputObject &lt;string of size N&gt;</c>.
+/// The string crosses the wire twice — once C#→pwsh as the request payload,
+/// once pwsh→C# as the JSON-serialized result — so the metric reflects both
+/// directions of serialization at the named <see cref="PayloadBytes"/> size.
+/// </para>
+/// <para>
+/// Sizes are chosen to span small (1 KB) through medium (256 KB) to the
+/// "large result" boundary called out in spec-005 (1 MB).
+/// </para>
 /// </summary>
 [MemoryDiagnoser]
 [MinIterationCount(5)]
 [MaxIterationCount(15)]
 public class PayloadSizeSerializationBenchmark
 {
+    private BenchExecutor? _bench;
+    private string _payload = string.Empty;
+
     [Params(HostMode.Single, HostMode.Pool, HostMode.ProcessPool)]
     public HostMode Mode { get; set; }
 
-    /// <summary>Number of objects to serialize per invoke (10, 100, 1000).</summary>
-    [Params(10, 100, 1000)]
-    public int PayloadCount { get; set; }
+    /// <summary>
+    /// Payload size in bytes. 1 KB / 16 KB / 256 KB / 1 MB.
+    /// </summary>
+    [Params(1024, 16 * 1024, 256 * 1024, 1024 * 1024)]
+    public int PayloadBytes { get; set; }
 
-    [Benchmark(Baseline = true, Description = "Heavy serialization (Get-Process | Select -First N), 2× bar")]
-    public int Serialize()
+    [GlobalSetup]
+    public async Task Setup()
     {
-        // STUB: returns the expected payload size as a placeholder.
-        // #194 replaces with:
-        //   var json = await executor.InvokeAsync("Get-Process",
-        //       new() { ["First"] = PayloadCount });
-        //   return json.Length;
-        return PayloadCount;
+        // ASCII filler so JSON serialization cost scales with the size param,
+        // not with character escapes.
+        _payload = new string('X', PayloadBytes);
+
+        _bench = await ExecutorFactory.CreateAsync(
+            Mode,
+            // Larger payloads can take noticeably longer than 30 s on a cold
+            // ProcessPool; bump the per-request timeout to keep iterations
+            // from spuriously failing.
+            requestTimeout: System.TimeSpan.FromSeconds(60));
+
+        // Warm-up.
+        _ = await _bench.Executor.InvokeAsync(
+            "Get-Date", new Dictionary<string, object?>());
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        if (_bench is not null) await _bench.DisposeAsync();
+    }
+
+    [Benchmark(Description = "Round-trip a string of size PayloadBytes through Write-Output")]
+    public async Task<int> Serialize()
+    {
+        var json = await _bench!.Executor.InvokeAsync(
+            "Write-Output",
+            new Dictionary<string, object?> { ["InputObject"] = _payload });
+        return json.Length;
     }
 }

--- a/PoshMcp.Benchmarks/Scenarios/ProcessCrashRecoveryBenchmark.cs
+++ b/PoshMcp.Benchmarks/Scenarios/ProcessCrashRecoveryBenchmark.cs
@@ -1,35 +1,90 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 
 namespace PoshMcp.Benchmarks.Scenarios;
 
 /// <summary>
-/// Process-crash recovery: wall-clock from induced
-/// <c>[System.Environment]::Exit(1)</c> in one host to next successful
-/// invoke. This scenario gates Option B per experiment plan §4:
-/// "Option B passes isolation if process crash of one host produces no
-/// server-visible error on requests routed elsewhere within 100 ms of
-/// the crash."
+/// Process-crash recovery: wall-clock from killing one underlying pwsh
+/// subprocess to the next successful invoke. This scenario gates Option B
+/// per experiment plan §4: "Option B passes isolation if process crash of
+/// one host produces no server-visible error on requests routed elsewhere
+/// within 100 ms of the crash."
 ///
-/// STUB — meaningful comparison requires the Option B pool implementation
-/// from issue #192, wired in issue #194. For Option A and Single this
-/// scenario degenerates into "restart the only process," which is the
-/// same as the baseline.
+/// <para>
+/// Each iteration kills exactly one host and then runs an invoke; the Mean
+/// column IS the per-mode recovery time (and the column the AC's
+/// "crash-recovery time" refers to for this scenario).
+/// </para>
+/// <para>
+/// Per-mode behaviour:
+/// </para>
+/// <list type="bullet">
+///   <item><description>
+///     <see cref="HostMode.ProcessPool"/>: kills 1 of N hosts. The pool's
+///     channel reader skips the stale slot; another healthy host serves the
+///     probe. The reconciler replaces the dead slot in the background.
+///     This is the configuration the gate applies to (target &lt; 100 ms).
+///   </description></item>
+///   <item><description>
+///     <see cref="HostMode.Single"/> and <see cref="HostMode.Pool"/>: there
+///     is only one subprocess; killing it leaves the executor unrecoverable
+///     in-place. To still produce a number, the iteration disposes the dead
+///     executor and constructs a fresh one before the probe. The Mean for
+///     these rows therefore reports cold-start cost — which is the correct
+///     answer to "how long until the next request succeeds" for those modes.
+///   </description></item>
+/// </list>
 /// </summary>
 [MinIterationCount(3)]
 [MaxIterationCount(10)]
 public class ProcessCrashRecoveryBenchmark
 {
+    private BenchExecutor? _bench;
+
     [Params(HostMode.Single, HostMode.Pool, HostMode.ProcessPool)]
     public HostMode Mode { get; set; }
 
-    [Benchmark(Baseline = true, Description = "Process crash → next invoke (Option B isolation gate)")]
-    public int CrashRecovery()
+    [GlobalSetup]
+    public async Task Setup()
     {
-        // STUB: placeholder. #194 replaces with:
-        //   await executor.InvokeAsync("ForceCrash", ...);  // exits one host
-        //   var sw = Stopwatch.StartNew();
-        //   await executor.InvokeAsync("Get-Date", ...);    // any other host serves it
-        //   return (int)sw.ElapsedMilliseconds;             // gate: < 100ms for Option B
-        return 0;
+        _bench = await ExecutorFactory.CreateAsync(Mode);
+        _ = await _bench.Executor.InvokeAsync(
+            "Get-Date", new Dictionary<string, object?>());
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        if (_bench is not null) await _bench.DisposeAsync();
+    }
+
+    [Benchmark(Description = "Kill one host → next invoke succeeds")]
+    [InvocationCount(1)]
+    public async Task<int> CrashRecovery()
+    {
+        // Kill one underlying pwsh process.
+        _bench!.KillOneHost();
+
+        if (Mode == HostMode.ProcessPool)
+        {
+            // Pool routes around the dead slot — a single invoke should land
+            // on a different healthy host. The bench Mean therefore reflects
+            // the lease-loop's skip-stale cost + one round-trip.
+            var json = await _bench.Executor.InvokeAsync(
+                "Get-Date", new Dictionary<string, object?>());
+            return json.Length;
+        }
+
+        // Single / Pool: only one subprocess existed; it's dead. The executor
+        // does not auto-restart, so producing a number means tearing down and
+        // reconstructing. This degrades gracefully into the cold-start cost,
+        // which IS the answer to "time until next successful request" for
+        // these modes. Documented in PoshMcp.Benchmarks/README.md.
+        await _bench.DisposeAsync();
+        _bench = await ExecutorFactory.CreateAsync(Mode);
+        var freshJson = await _bench.Executor.InvokeAsync(
+            "Get-Date", new Dictionary<string, object?>());
+        return freshJson.Length;
     }
 }

--- a/PoshMcp.Benchmarks/Scenarios/RunspaceCorruptionRecoveryBenchmark.cs
+++ b/PoshMcp.Benchmarks/Scenarios/RunspaceCorruptionRecoveryBenchmark.cs
@@ -1,32 +1,87 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 
 namespace PoshMcp.Benchmarks.Scenarios;
 
 /// <summary>
-/// Runspace-corruption recovery: one invoke pollutes a type accelerator
-/// or mutates a shared static; a parallel invoke verifies it is
-/// unaffected. Per experiment plan §4 this is the real isolation gate
-/// for Option A — process-kill is not the right discriminator because
-/// in Option A it is the same gate as the baseline.
+/// Runspace-isolation / head-of-line-blocking probe. Per experiment plan §4
+/// this is the real isolation gate for Option A — process-kill is not the
+/// right discriminator because in Option A it is the same gate as the
+/// baseline. The metric is: while one runspace is "stuck" on a slow command,
+/// how long until a fast probe completes?
 ///
-/// STUB — #194 wires this through the runspace-pool host (Option A,
-/// issue #191).
+/// <para>
+/// Implementation: each iteration fires a long-running invoke
+/// (<c>Start-Sleep -Milliseconds 1000</c>) and does NOT await it, then
+/// immediately awaits a fast probe (<c>Get-Date</c>). The Mean column IS
+/// the recovery / probe-latency metric.
+/// </para>
+/// <para>
+/// Per-mode behaviour:
+/// </para>
+/// <list type="bullet">
+///   <item><description>
+///     <see cref="HostMode.Single"/>: a single runspace per host, requests
+///     are serialized. The probe queues behind the 1 s sleeper. Mean ≈ 1 s.
+///   </description></item>
+///   <item><description>
+///     <see cref="HostMode.Pool"/> (Option A): N runspaces inside one
+///     subprocess. The probe should land on a different runspace and
+///     complete quickly. This is the gate Option A passes if probe latency
+///     stays ≪ 1 s.
+///   </description></item>
+///   <item><description>
+///     <see cref="HostMode.ProcessPool"/> (Option B): N independent hosts.
+///     The probe lands on a different host and completes quickly. Should
+///     match or beat <see cref="HostMode.Pool"/>.
+///   </description></item>
+/// </list>
+/// <para>
+/// The blocking sleeper completes on its own well within the executor's
+/// 30 s default request timeout, so nothing leaks between iterations.
+/// </para>
 /// </summary>
 [MinIterationCount(3)]
 [MaxIterationCount(10)]
 public class RunspaceCorruptionRecoveryBenchmark
 {
+    private BenchExecutor? _bench;
+
     [Params(HostMode.Single, HostMode.Pool, HostMode.ProcessPool)]
     public HostMode Mode { get; set; }
 
-    [Benchmark(Baseline = true, Description = "Runspace corruption → parallel invoke unaffected (Option A isolation gate)")]
-    public int CorruptionRecovery()
+    [GlobalSetup]
+    public async Task Setup()
     {
-        // STUB: placeholder. #194 replaces with:
-        //   var corrupt = executor.InvokeAsync("Pollute-TypeAccelerator", ...);
-        //   var probe   = executor.InvokeAsync("Verify-Clean", ...);
-        //   await Task.WhenAll(corrupt, probe);
-        //   return probe.Result.Contains("clean") ? 1 : 0;
-        return 1;
+        _bench = await ExecutorFactory.CreateAsync(Mode);
+        _ = await _bench.Executor.InvokeAsync(
+            "Get-Date", new Dictionary<string, object?>());
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        if (_bench is not null) await _bench.DisposeAsync();
+    }
+
+    [Benchmark(Description = "Slow invoke in flight → fast probe latency (Option A isolation gate)")]
+    [InvocationCount(1)]
+    public async Task<int> ProbeUnderHeadOfLine()
+    {
+        // Fire the slow command and do NOT await — we want it in flight when
+        // the probe goes out.
+        var slow = _bench!.Executor.InvokeAsync(
+            "Start-Sleep",
+            new Dictionary<string, object?> { ["Milliseconds"] = 1000 });
+
+        // Probe — what we actually measure.
+        var probe = await _bench.Executor.InvokeAsync(
+            "Get-Date", new Dictionary<string, object?>());
+
+        // Drain the slow request so it doesn't bleed into the next iteration.
+        try { await slow; } catch { /* iteration boundary; best-effort */ }
+
+        return probe.Length;
     }
 }

--- a/PoshMcp.Benchmarks/Scenarios/WarmInvokeThroughputBenchmark.cs
+++ b/PoshMcp.Benchmarks/Scenarios/WarmInvokeThroughputBenchmark.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 
 namespace PoshMcp.Benchmarks.Scenarios;
@@ -7,8 +10,10 @@ namespace PoshMcp.Benchmarks.Scenarios;
 /// Threshold from experiment plan §4: I/O-bound network-shaped workload
 /// must reach ≥ 4× baseline at 10 concurrent clients on Options A and B.
 ///
-/// STUB — uses <see cref="HttpListenerTestServer"/> for the network shape.
-/// Real invocation through ICommandExecutor lands in issue #194.
+/// Each iteration fires N parallel <c>Invoke-WebRequest</c> calls against
+/// the in-process <see cref="HttpListenerTestServer"/>. Single-runspace
+/// executors serialize them; Pool / ProcessPool overlap them and should
+/// finish in roughly <c>per-request-latency</c> time.
 /// </summary>
 [MemoryDiagnoser]
 [MinIterationCount(5)]
@@ -16,38 +21,56 @@ namespace PoshMcp.Benchmarks.Scenarios;
 public class WarmInvokeThroughputBenchmark
 {
     private HttpListenerTestServer? _server;
+    private BenchExecutor? _bench;
 
     [Params(HostMode.Single, HostMode.Pool, HostMode.ProcessPool)]
     public HostMode Mode { get; set; }
 
     /// <summary>
-    /// Concurrent client count — the parallelism axis the experiment plan
-    /// calls out (10, 50, 100). Default to 10 for the threshold gate; #194
-    /// can extend the params list once real executors are wired.
+    /// Concurrent invoke count per iteration — the parallelism axis the
+    /// experiment plan calls out. 10 is the threshold gate; smaller values
+    /// keep total run time sane while still showing the parallelism win.
     /// </summary>
     [Params(10)]
     public int Concurrency { get; set; }
 
     [GlobalSetup]
-    public void Setup()
+    public async Task Setup()
     {
         _server = new HttpListenerTestServer
         {
-            ResponseDelay = TimeSpan.FromMilliseconds(500),
+            // Short delay so each request takes ~50 ms — enough to expose
+            // serialization in Single mode without making the bench drag.
+            ResponseDelay = System.TimeSpan.FromMilliseconds(50),
         };
         _server.Start();
+
+        _bench = await ExecutorFactory.CreateAsync(Mode);
+
+        // Warm-up invoke so the executor is past first-request cost.
+        _ = await _bench.Executor.InvokeAsync(
+            "Get-Date", new Dictionary<string, object?>());
     }
 
     [GlobalCleanup]
-    public void Cleanup() => _server?.Dispose();
-
-    [Benchmark(Baseline = true, Description = "Warm invoke @ N concurrency (network-shaped, 4× bar)")]
-    public int WarmInvoke()
+    public async Task Cleanup()
     {
-        // STUB: a noop returning the URL hash. #194 replaces with:
-        //   await Parallel.ForEachAsync(Enumerable.Range(0, Concurrency), async (_, _) => {
-        //       await executor.InvokeAsync("Invoke-WebRequest", new() { ["Uri"] = _server!.Url });
-        //   });
-        return _server?.Url.Length ?? 0;
+        if (_bench is not null) await _bench.DisposeAsync();
+        _server?.Dispose();
+    }
+
+    [Benchmark(Description = "Warm invoke @ N concurrency (network-shaped, 4× bar)")]
+    public async Task WarmInvoke()
+    {
+        var url = _server!.Url;
+        var tasks = Enumerable.Range(0, Concurrency).Select(_ =>
+            _bench!.Executor.InvokeAsync(
+                "Invoke-WebRequest",
+                new Dictionary<string, object?>
+                {
+                    ["Uri"] = url,
+                    ["UseBasicParsing"] = true,
+                })).ToArray();
+        await Task.WhenAll(tasks);
     }
 }

--- a/PoshMcp.Server/PoshMcp.csproj
+++ b/PoshMcp.Server/PoshMcp.csproj
@@ -26,6 +26,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>PoshMcp.Tests</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>PoshMcp.Benchmarks</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**🧪 Fry (Tester)**

Closes #194

## What got wired

- **ExecutorFactory** — builds ICommandExecutor per HostMode using the same construction path the production server uses (OutOfProcessCommandExecutor + OutOfProcessSubprocessPool), without the hosting/configuration/logging stack. Skips `SetupAsync` because built-in cmdlets are callable without environment customization — the harness measures executor cost, not module install.
- **HostMode [Params] axis** on every scenario (Single, Pool, ProcessPool) — one `dotnet run` produces one results table covering all three configurations.
- **All five scenarios** wired end-to-end: `ColdStartBenchmark`, `WarmInvokeThroughputBenchmark`, `PayloadSizeSerializationBenchmark`, `ProcessCrashRecoveryBenchmark`, `RunspaceCorruptionRecoveryBenchmark`.
- **Crash injection** lives in `ExecutorFactory` via reflection into private fields — keeps the bench-only hook out of production types. `InternalsVisibleTo` for `PoshMcp.Benchmarks` added to `PoshMcp.csproj` for the few internal types referenced through the public `ICommandExecutor` surface.
- **P99StatisticColumn** custom BDN column — the AC requires P99 and BenchmarkDotNet 0.14 only ships `StatisticColumn.P95`.
- **AI / spec-008 logging disabled** inside the bench process — `Program.cs` sets `ApplicationInsights__Enabled=false` and clears `APPLICATIONINSIGHTS_CONNECTION_STRING` before BDN starts.

## Output columns (per AC)

| Column         | Source |
|----------------|--------|
| Mode           | `HostMode` `[Params]` |
| Scenario       | one row per `[Benchmark]` method |
| Payload size   | `PayloadBytes` `[Params]` (256 KB / 1 MB rows on the size scenario) |
| Mean           | BDN built-in |
| P95            | `StatisticColumn.P95` |
| P99            | `P99StatisticColumn` (custom) |
| Crash-recovery | `Mean` column on `ProcessCrashRecoveryBenchmark` rows IS the per-mode recovery time |

## Invocation (full reproduction lives in PoshMcp.Benchmarks/README.md)

```powershell
# All scenarios, all modes
dotnet run --project PoshMcp.Benchmarks --configuration Release -- --filter *

# One scenario across all modes
dotnet run --project PoshMcp.Benchmarks --configuration Release -- --filter '*WarmInvoke*'

# Filter by mode
dotnet run --project PoshMcp.Benchmarks --configuration Release -- --filter '*Mode=ProcessPool*'

# Smoke test (near-zero iterations)
dotnet run --project PoshMcp.Benchmarks --configuration Release -- --filter '*ColdStart*' --job dry
```

Markdown output lands in `PoshMcp.Benchmarks/BenchmarkDotNet.Artifacts/` — the `*-report-github.md` file is what #195 will consume.

## Smoke-test results

- **Build (Release):** 0 errors, no new warnings (2 pre-existing `NU1510` from `System.Security.Cryptography.Xml` in `PoshMcp.csproj`).
- **`--list flat`:** all 5 scenarios discovered.
- **`ColdStartBenchmark --job dry`:** PASS for `Single` (5.5 s), `Pool` (5.9 s), `ProcessPool` (6.0 s) — confirms the harness drives all three executors end-to-end.
- **`WarmInvokeThroughputBenchmark --job dry`:** PASS for `Pool` (265–318 ms / 10 calls). `Single` and `ProcessPool` throw `OOP error: An item with the same key has already been added. Key: Content` from `OutOfProcessHost.SendRequestAsync` when 10 concurrent invokes share a single host. **This is a real production bug in `OutOfProcessHost` that the harness exposes — not a bench-wiring defect.** Filed as a follow-up; does not block #194 (the harness wiring is correct, and the failure mode is exactly what a benchmark is supposed to surface).
- **Full regression suite (Debug):** 629 passed, 0 failed, 7 skipped.

## Expected full-run duration

A complete run across all five scenarios × three modes × the payload-size axis is on the order of **30–60 minutes** on a modern dev box; allow longer when including the 1 MB payload row and accounting for repeated cold-start launches in `ProcessCrashRecoveryBenchmark`.
