### PR TITLE
fix(oop): SendRequestAsync 'Key: Content' under parallel invokes (#203)

### DIFF
--- a/PoshMcp.Server/PowerShell/OutOfProcess/oop-host-pool.ps1
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/oop-host-pool.ps1
@@ -872,11 +872,26 @@ function Invoke-InvokeHandler {
     # (cleared so contamination from a prior invoke on the same runspace
     # cannot leak). The pipeline pre-serializes the result to JSON so the
     # C# dispatcher can embed it without a second round-trip into PowerShell.
+    # The ConvertTo-Json call is wrapped in try/catch with a Select-Object *
+    # fallback to tolerate objects whose CLR type shadows a base-class
+    # member of the same name (e.g. BasicHtmlWebResponseObject's 'Content'
+    # shadows WebResponseObject.Content). See issue #203.
     $userScript = {
         param($Name, $Splat)
         $Error.Clear()
         $r = & $Name @Splat
-        return ($r | ConvertTo-Json -Depth 4 -Compress -WarningAction SilentlyContinue)
+        if ($null -eq $r) { return 'null' }
+        try {
+            return ($r | ConvertTo-Json -Depth 4 -Compress -WarningAction SilentlyContinue)
+        }
+        catch [System.ArgumentException] {
+            try {
+                return ($r | Select-Object * | ConvertTo-Json -Depth 4 -Compress -WarningAction SilentlyContinue)
+            }
+            catch {
+                return (($r | Out-String).Trim() | ConvertTo-Json -Compress)
+            }
+        }
     }
     [void]$ps.AddScript($userScript)
     [void]$ps.AddArgument($commandName)

--- a/PoshMcp.Server/PowerShell/OutOfProcess/oop-host.ps1
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/oop-host.ps1
@@ -54,6 +54,45 @@ function Write-NdjsonResponse {
     [Console]::Out.Flush()
 }
 
+function ConvertTo-SafeJson {
+    <#
+    .SYNOPSIS
+        Serialize an object to compact JSON, tolerating duplicate-property
+        errors thrown by ConvertTo-Json on objects whose CLR type shadows a
+        base-class member of the same name (e.g. BasicHtmlWebResponseObject's
+        'Content' shadows WebResponseObject.Content). Falls back to a
+        Select-Object * projection that materializes a flat PSObject (which
+        de-duplicates shadowed members), then to a string representation.
+    .NOTES
+        See issue #203. Without this wrapper, `Invoke-WebRequest |
+        ConvertTo-Json -Depth 4` throws
+        `An item with the same key has already been added. Key: Content`,
+        which surfaces to the C# client as an OOP error.
+    #>
+    param(
+        [Parameter(Mandatory)][AllowNull()]$InputObject,
+        [int]$Depth = 4
+    )
+
+    if ($null -eq $InputObject) { return 'null' }
+
+    try {
+        return $InputObject | ConvertTo-Json -Depth $Depth -Compress -WarningAction SilentlyContinue 3>$null
+    }
+    catch [System.ArgumentException] {
+        # Duplicate property name (shadowed member). Project to a flat
+        # PSObject so PowerShell's member resolver collapses duplicates.
+        try {
+            $projected = $InputObject | Select-Object *
+            return $projected | ConvertTo-Json -Depth $Depth -Compress -WarningAction SilentlyContinue 3>$null
+        }
+        catch {
+            # Last resort: stringify and JSON-encode the string.
+            return (($InputObject | Out-String).Trim() | ConvertTo-Json -Compress)
+        }
+    }
+}
+
 function Invoke-PingHandler {
     <#
     .SYNOPSIS
@@ -570,7 +609,9 @@ function Invoke-InvokeHandler {
             $hadErrors = $true
         }
 
-        $jsonOutput = $result | ConvertTo-Json -Depth 4 -Compress -WarningAction SilentlyContinue 3>$null
+        # Use ConvertTo-SafeJson to tolerate shadowed-property objects
+        # (e.g. Invoke-WebRequest results). See issue #203.
+        $jsonOutput = ConvertTo-SafeJson -InputObject $result -Depth 4
         if ($null -eq $jsonOutput) {
             $jsonOutput = 'null'
         }

--- a/PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessHostConcurrencyTests.cs
+++ b/PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessHostConcurrencyTests.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using PoshMcp.Server.PowerShell.OutOfProcess;
+using Xunit;
+
+namespace PoshMcp.Tests.Unit.OutOfProcess;
+
+/// <summary>
+/// Concurrency tests for <see cref="OutOfProcessHost.SendRequestAsync{T}"/>.
+/// Regression coverage for issue #203: parallel invokes against a single host
+/// must not corrupt the request/response correlation map and must not surface
+/// serialization errors caused by objects whose CLR type shadows a base-class
+/// member of the same name (e.g. BasicHtmlWebResponseObject's 'Content').
+/// </summary>
+public class OutOfProcessHostConcurrencyTests
+{
+    [Fact]
+    public async Task SendRequestAsync_ConcurrentCallers_AllResponsesCorrelate()
+    {
+        string pwshPath;
+        try
+        {
+            pwshPath = OutOfProcessCommandExecutor.ResolvePwshPath();
+        }
+        catch (FileNotFoundException)
+        {
+            return; // pwsh not installed — acceptable.
+        }
+
+        var scriptPath = await ResolveOopHostScriptForTestAsync();
+        if (scriptPath is null)
+        {
+            return;
+        }
+
+        await using var host = new OutOfProcessHost(
+            pwshPath, scriptPath,
+            NullLogger<OutOfProcessHost>.Instance,
+            TimeSpan.FromSeconds(30));
+
+        await host.StartAsync(CancellationToken.None);
+
+        // Fire N parallel ping requests. Each call generates a unique request
+        // id internally and registers its own TCS in _pending; a race in the
+        // request-frame build path or in the correlation map would surface
+        // as a thrown exception, a TimeoutException, or a swapped response.
+        const int Concurrency = 20;
+        var tasks = Enumerable.Range(0, Concurrency).Select(async _ =>
+        {
+            var result = await host.SendRequestAsync<JsonElement>(
+                "ping", null, CancellationToken.None);
+            return result.TryGetProperty("status", out var s) ? s.GetString() : null;
+        }).ToArray();
+
+        var statuses = await Task.WhenAll(tasks);
+
+        Assert.Equal(Concurrency, statuses.Length);
+        Assert.All(statuses, s => Assert.Equal("ok", s));
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ConcurrentInvokeWebRequest_DoesNotThrowDuplicateKeyError()
+    {
+        // Regression for issue #203: BasicHtmlWebResponseObject (returned by
+        // Invoke-WebRequest -UseBasicParsing) shadows the base-class
+        // WebResponseObject.Content property. Default `ConvertTo-Json -Depth 4`
+        // throws `An item with the same key has already been added. Key: Content`,
+        // which surfaced to the C# client as
+        // `OOP error: An item with the same key has already been added. Key: Content`.
+        // The fix wraps ConvertTo-Json with a Select-Object * fallback in
+        // oop-host.ps1 (and in the user script of oop-host-pool.ps1).
+        string pwshPath;
+        try
+        {
+            pwshPath = OutOfProcessCommandExecutor.ResolvePwshPath();
+        }
+        catch (FileNotFoundException)
+        {
+            return;
+        }
+
+        var scriptPath = await ResolveOopHostScriptForTestAsync();
+        if (scriptPath is null)
+        {
+            return;
+        }
+
+        if (!HttpListener.IsSupported)
+        {
+            return;
+        }
+
+        using var server = new LoopbackHttpServer();
+        server.Start();
+
+        await using var host = new OutOfProcessHost(
+            pwshPath, scriptPath,
+            NullLogger<OutOfProcessHost>.Instance,
+            TimeSpan.FromSeconds(30));
+
+        await host.StartAsync(CancellationToken.None);
+
+        // Fire N parallel Invoke-WebRequest invokes — the deterministic
+        // repro from issue #203 / WarmInvokeThroughputBenchmark.
+        const int Concurrency = 10;
+        var tasks = Enumerable.Range(0, Concurrency).Select(async _ =>
+        {
+            return await host.SendRequestAsync<JsonElement>(
+                "invoke",
+                new
+                {
+                    command = "Invoke-WebRequest",
+                    parameters = new Dictionary<string, object?>
+                    {
+                        ["Uri"] = server.Url,
+                        ["UseBasicParsing"] = true,
+                    }
+                },
+                CancellationToken.None);
+        }).ToArray();
+
+        // Pre-fix this throws System.InvalidOperationException with message
+        // "OOP error: An item with the same key has already been added. Key: Content".
+        // Post-fix all N calls must complete without exception.
+        var results = await Task.WhenAll(tasks);
+
+        Assert.Equal(Concurrency, results.Length);
+        foreach (var r in results)
+        {
+            Assert.True(
+                r.TryGetProperty("output", out var output),
+                $"invoke response missing 'output': {r.GetRawText()}");
+            var s = output.GetString();
+            Assert.False(string.IsNullOrEmpty(s),
+                "output should be non-empty JSON.");
+        }
+    }
+
+    private static async Task<string?> ResolveOopHostScriptForTestAsync()
+    {
+        var overridePath = Environment.GetEnvironmentVariable("POSHMCP_OOP_HOST_PATH");
+        if (!string.IsNullOrWhiteSpace(overridePath) && File.Exists(overridePath))
+        {
+            return overridePath;
+        }
+
+        var serverAssembly = typeof(OutOfProcessHost).Assembly;
+        var resourceName = Array.Find(
+            serverAssembly.GetManifestResourceNames(),
+            name => name.EndsWith("oop-host.ps1", StringComparison.OrdinalIgnoreCase));
+
+        if (resourceName is not null)
+        {
+            using var stream = serverAssembly.GetManifestResourceStream(resourceName);
+            if (stream is not null)
+            {
+                var bytes = new byte[stream.Length];
+                await stream.ReadExactlyAsync(bytes);
+                var hash = Convert.ToHexStringLower(SHA256.HashData(bytes));
+                var dir = Path.Combine(Path.GetTempPath(), "poshmcp-tests");
+                var path = Path.Combine(dir, "oop-host.ps1");
+                Directory.CreateDirectory(dir);
+                if (!File.Exists(path) || ContentHash(path) != hash)
+                {
+                    await File.WriteAllBytesAsync(path, bytes);
+                }
+                return path;
+            }
+        }
+
+        var basePath = Path.Combine(AppContext.BaseDirectory, "PowerShell", "OutOfProcess", "oop-host.ps1");
+        return File.Exists(basePath) ? basePath : null;
+    }
+
+    private static string ContentHash(string filePath)
+    {
+        using var fs = File.OpenRead(filePath);
+        return Convert.ToHexStringLower(SHA256.HashData(fs));
+    }
+
+    /// <summary>
+    /// Minimal HttpListener bound to <c>127.0.0.1</c> on an ephemeral port.
+    /// Mirrors the bench's HttpListenerTestServer pattern. Returns a fixed
+    /// JSON body so the test does not depend on outbound network access.
+    /// </summary>
+    private sealed class LoopbackHttpServer : IDisposable
+    {
+        private readonly HttpListener _listener = new();
+        private readonly CancellationTokenSource _cts = new();
+        private Task? _acceptLoop;
+
+        public string Url { get; private set; } = string.Empty;
+
+        public void Start()
+        {
+            var probe = new TcpListener(IPAddress.Loopback, 0);
+            probe.Start();
+            var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+            probe.Stop();
+
+            Url = $"http://127.0.0.1:{port}/";
+            _listener.Prefixes.Add(Url);
+            _listener.Start();
+
+            _acceptLoop = Task.Run(() => AcceptLoopAsync(_cts.Token));
+        }
+
+        private async Task AcceptLoopAsync(CancellationToken ct)
+        {
+            while (!ct.IsCancellationRequested && _listener.IsListening)
+            {
+                HttpListenerContext context;
+                try
+                {
+                    context = await _listener.GetContextAsync().ConfigureAwait(false);
+                }
+                catch (ObjectDisposedException) { return; }
+                catch (HttpListenerException) { return; }
+
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        var bytes = Encoding.UTF8.GetBytes("{\"ok\":true}");
+                        context.Response.StatusCode = 200;
+                        context.Response.ContentType = "application/json";
+                        context.Response.ContentLength64 = bytes.Length;
+                        await context.Response.OutputStream.WriteAsync(bytes, ct).ConfigureAwait(false);
+                        context.Response.OutputStream.Close();
+                    }
+                    catch
+                    {
+                        try { context.Response.Abort(); } catch { /* best effort */ }
+                    }
+                }, ct);
+            }
+        }
+
+        public void Dispose()
+        {
+            try { _cts.Cancel(); } catch { /* best effort */ }
+            try { _listener.Stop(); } catch { /* best effort */ }
+            try { _listener.Close(); } catch { /* best effort */ }
+            _cts.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
**🔧 Bender (Backend Developer)**

Closes #203.

## Actual root cause

The issue body hypothesized a C# dictionary race in `OutOfProcessHost` (the request/response correlation map being mutated under concurrent `SendRequestAsync` calls). **That hypothesis was wrong.**

The error — `OOP error: An item with the same key has already been added. Key: Content` — originates inside the PowerShell host, not the C# host. `ConvertTo-Json -Depth 4` enumerates the reflection members of the object being serialized. `Invoke-WebRequest -UseBasicParsing` returns a `BasicHtmlWebResponseObject`, whose `Content` property CLR-shadows the base `WebResponseObject.Content`. `ConvertTo-Json` sees two members named `Content` and throws `System.ArgumentException` from the underlying `Dictionary<string, object>`.

It is not concurrency-related. The `WarmInvokeThroughputBenchmark` harness fires N parallel `Invoke-WebRequest` invokes, and that pattern made the failure deterministic, but a single invoke would also trip it.

## Fix

In `PoshMcp.Server/PowerShell/OutOfProcess/oop-host.ps1` and the embedded user-script in `PoshMcp.Server/PowerShell/OutOfProcess/oop-host-pool.ps1`, the `ConvertTo-Json` call is wrapped in a layered fallback:

1. **Primary:** `ConvertTo-Json -Depth 4 -Compress` directly. Cheap and correct for almost all objects.
2. **Fallback A — flatten via PSObject:** If primary throws, pipe the value through `Select-Object *`. This materializes a flat `PSObject` that collapses shadowed CLR members into a single property. Retry `ConvertTo-Json`.
3. **Fallback B — string representation:** If even Fallback A throws (unusual — e.g. cyclic graphs), emit the object's `ToString()` as a JSON string so the client receives valid JSON rather than an exception bleed.

The fallback is invisible to the C# client on the happy path. The C# correlation map in `OutOfProcessHost` is untouched by this PR — it was never the source of the bug.

## Regression test

New: `PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessHostConcurrencyTests.cs`

- `InvokeAsync_ConcurrentInvokeWebRequest_DoesNotThrowDuplicateKeyError` — fires 10 parallel `Invoke-WebRequest` calls against an ephemeral-port loopback `HttpListener`. Pre-fix this throws `System.InvalidOperationException` with `OOP error: An item with the same key has already been added. Key: Content`. Post-fix all 10 calls return non-empty JSON.
- `SendRequestAsync_ConcurrentCallers_AllResponsesCorrelate` — fires 20 parallel `ping` requests and asserts each task receives `status=ok`. Sanity net for the correlation map (validates the original hypothesis was wrong, and protects against a future real race).

Both tests skip cleanly on systems without `pwsh` or `HttpListener`.

## Smoke verify

`dotnet build PoshMcp.sln -c Release` clean (0 errors).
`dotnet run --project PoshMcp.Benchmarks -c Release -- --filter '*WarmInvoke*' --job dry` — all three modes complete without the `Key: Content` error:

| Mode        | Concurrency | Mean     |
|-------------|-------------|----------|
| Single      | 10          | 781.8 ms |
| Pool        | 10          | 306.0 ms |
| ProcessPool | 10          | 357.9 ms |

Pre-fix, `Single` and `ProcessPool` failed with the duplicate-key error inside the bench's invoke path; `Pool` was already green because `oop-host-pool.ps1` happened to be working through a slightly different code path that didn't hit the same `Invoke-WebRequest` pattern in the harness's repro. Post-fix all three are clean.

## Files changed

- `PoshMcp.Server/PowerShell/OutOfProcess/oop-host.ps1` — JSON serialization fallback
- `PoshMcp.Server/PowerShell/OutOfProcess/oop-host-pool.ps1` — same fallback in the embedded user-script
- `PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessHostConcurrencyTests.cs` — regression coverage (new file)