### PR TITLE
feat(oop): cancellation propagation (#188)

### DIFF
--- a/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessHost.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessHost.cs
@@ -238,14 +238,33 @@ public sealed class OutOfProcessHost : IAsyncDisposable
                 _sendLock.Release();
             }
 
-            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            using var timeoutCts = new CancellationTokenSource();
             var requestTimeout = requestTimeoutOverride ?? _requestTimeout;
             timeoutCts.CancelAfter(requestTimeout);
 
-            var registration = timeoutCts.Token.Register(() =>
+            // Per-request timeout: notify the host so its pipeline stops, then trip the TCS.
+            // The cancel frame is best-effort and runs on its own short-lived CTS.
+            var timeoutRegistration = timeoutCts.Token.Register(() =>
             {
+                if (!"cancel".Equals(method, StringComparison.Ordinal))
+                {
+                    _ = TrySendCancelFrameAsync(id);
+                }
                 tcs.TrySetException(new TimeoutException(
                     $"Request {id} (method={method}) timed out after {requestTimeout.TotalSeconds}s."));
+            });
+
+            // Caller cancellation: forward to the host as a cancel frame so the in-flight
+            // pipeline is signaled to stop. The awaiter completes promptly with OCE; the
+            // host's eventual cancelled-response is dropped silently because _pending no
+            // longer has the id (see ReadLoopAsync).
+            var cancelRegistration = cancellationToken.Register(() =>
+            {
+                if (!"cancel".Equals(method, StringComparison.Ordinal))
+                {
+                    _ = TrySendCancelFrameAsync(id);
+                }
+                tcs.TrySetCanceled(cancellationToken);
             });
 
             try
@@ -262,12 +281,63 @@ public sealed class OutOfProcessHost : IAsyncDisposable
             }
             finally
             {
-                await registration.DisposeAsync().ConfigureAwait(false);
+                await timeoutRegistration.DisposeAsync().ConfigureAwait(false);
+                await cancelRegistration.DisposeAsync().ConfigureAwait(false);
             }
         }
         finally
         {
             _pending.TryRemove(id, out _);
+        }
+    }
+
+    /// <summary>
+    /// Best-effort: send a fire-and-forget <c>cancel</c> frame to the host so it can
+    /// signal the in-flight pipeline for <paramref name="requestId"/> to stop.
+    /// The frame id uses a <c>cancel-</c> prefix and is intentionally not registered
+    /// in <see cref="_pending"/>; the host's ack is logged at Debug only.
+    /// </summary>
+    private async Task TrySendCancelFrameAsync(string requestId)
+    {
+        if (_disposed || _stdin is null) return;
+
+        var cancelFrameId = "cancel-" + Guid.NewGuid().ToString("N");
+        var frame = new
+        {
+            id = cancelFrameId,
+            method = "cancel",
+            @params = new { requestId }
+        };
+
+        string json;
+        try
+        {
+            json = JsonSerializer.Serialize(frame);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to serialize cancel frame for request {Id}.", requestId);
+            return;
+        }
+
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+            await _sendLock.WaitAsync(cts.Token).ConfigureAwait(false);
+            try
+            {
+                await _stdin.WriteLineAsync(json.AsMemory(), cts.Token).ConfigureAwait(false);
+                await _stdin.FlushAsync(cts.Token).ConfigureAwait(false);
+                _logger.LogDebug("Sent cancel frame for request {Id}.", requestId);
+            }
+            finally
+            {
+                try { _sendLock.Release(); } catch (ObjectDisposedException) { /* shutting down */ }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to send cancel frame for request {Id}.", requestId);
         }
     }
 
@@ -379,7 +449,20 @@ public sealed class OutOfProcessHost : IAsyncDisposable
 
                     if (!_pending.TryGetValue(id, out var tcs))
                     {
-                        _logger.LogWarning("OOP response for unknown request id '{Id}': {Line}", id, line);
+                        // Cancel-frame acks (id prefix "cancel-") are intentionally
+                        // not registered; a normal invoke response that lost its race
+                        // with caller cancellation is also expected. Both are noise.
+                        if (id.StartsWith("cancel-", StringComparison.Ordinal)
+                            || (root.TryGetProperty("result", out var resForUnknown)
+                                && resForUnknown.TryGetProperty("cancelled", out var cancelledFlag)
+                                && cancelledFlag.ValueKind == JsonValueKind.True))
+                        {
+                            _logger.LogDebug("OOP response for already-removed request id '{Id}'.", id);
+                        }
+                        else
+                        {
+                            _logger.LogWarning("OOP response for unknown request id '{Id}': {Line}", id, line);
+                        }
                         continue;
                     }
 

--- a/PoshMcp.Server/PowerShell/OutOfProcess/oop-host-pool.ps1
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/oop-host-pool.ps1
@@ -208,6 +208,7 @@ namespace PoshMcp.PoolHost
         public int QueueDepthOnArrival;
         public Stopwatch QueueSw;
         public string CommandName;
+        public bool Cancelled; // set by Cancel() before BeginStop fires
     }
 
     public sealed class PoolDispatcher : IDisposable
@@ -217,6 +218,7 @@ namespace PoshMcp.PoolHost
         private readonly Thread[] _workers;
         private readonly ManualResetEventSlim _idle = new ManualResetEventSlim(true);
         private readonly object _idleLock = new object();
+        private readonly ConcurrentDictionary<string, PoolWorkItem> _active = new ConcurrentDictionary<string, PoolWorkItem>();
         private int _activeCount;
         private int _pendingCount; // queued + active, used for IsIdle
 
@@ -260,8 +262,33 @@ namespace PoshMcp.PoolHost
                 _idle.Reset();
             }
 
+            _active[id] = item;
             _queue.Add(item);
             return depth;
+        }
+
+        /// <summary>
+        /// Signal a cancellation request to the in-flight invoke matching
+        /// <paramref name="requestId"/>. Returns true if the request was found
+        /// and BeginStop was called; false if no matching active item exists
+        /// (already completed, queued-only, or unknown id).
+        /// </summary>
+        public bool Cancel(string requestId)
+        {
+            if (string.IsNullOrEmpty(requestId)) return false;
+            PoolWorkItem item;
+            if (!_active.TryGetValue(requestId, out item)) return false;
+            try
+            {
+                item.Cancelled = true;
+                item.Ps.BeginStop(null, null);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine("[oop-host-pool:dispatcher] BeginStop failed for " + requestId + ": " + ex.Message);
+                return false;
+            }
         }
 
         /// <summary>Wait until the dispatcher is idle (queue empty + no active work).</summary>
@@ -292,6 +319,8 @@ namespace PoshMcp.PoolHost
                     finally
                     {
                         try { w.Ps.Dispose(); } catch { }
+                        PoolWorkItem _removed;
+                        _active.TryRemove(w.Id, out _removed);
                         Interlocked.Decrement(ref _activeCount);
                         lock (_idleLock)
                         {
@@ -314,29 +343,51 @@ namespace PoshMcp.PoolHost
         {
             Collection<PSObject> output = null;
             string invokeError = null;
+            bool wasStopped = false;
 
             try
             {
                 output = w.Ps.Invoke();
+            }
+            catch (System.Management.Automation.PipelineStoppedException)
+            {
+                wasStopped = true;
             }
             catch (Exception ex)
             {
                 invokeError = ex.Message;
             }
 
+            // BeginStop transitions the pipeline to Stopped without throwing
+            // PipelineStoppedException for some host configurations; double-check.
+            if (!wasStopped)
+            {
+                try
+                {
+                    var state = w.Ps.InvocationStateInfo;
+                    if (state != null && state.State == PSInvocationState.Stopped)
+                    {
+                        wasStopped = true;
+                    }
+                }
+                catch { /* best-effort */ }
+            }
+
+            bool cancelled = wasStopped || w.Cancelled;
+
             string[] errs = w.Ps.Streams.Error.Select(e => e.ToString()).ToArray();
             string[] warns = w.Ps.Streams.Warning.Select(x => x.Message).ToArray();
-            bool hadErrors = w.Ps.HadErrors || errs.Length > 0;
+            bool hadErrors = w.Ps.HadErrors || errs.Length > 0 || cancelled;
 
             // The user script returns a single string from ConvertTo-Json.
             // Embed it as a JSON-string value (escaped).
             string outputJson;
-            if (invokeError != null)
+            if (invokeError != null && !cancelled)
             {
                 WriteError(w.Id, invokeError);
                 return;
             }
-            if (output == null || output.Count == 0 || output[0] == null)
+            if (cancelled || output == null || output.Count == 0 || output[0] == null)
             {
                 outputJson = "null";
             }
@@ -352,6 +403,7 @@ namespace PoshMcp.PoolHost
             sb.Append("{\"id\":").Append(PoolStdout.EscapeString(w.Id)).Append(",\"result\":{");
             sb.Append("\"output\":").Append(PoolStdout.EscapeString(outputJson)).Append(',');
             sb.Append("\"hadErrors\":").Append(hadErrors ? "true" : "false").Append(',');
+            sb.Append("\"cancelled\":").Append(cancelled ? "true" : "false").Append(',');
             sb.Append("\"errors\":[");
             for (int i = 0; i < errs.Length; i++)
             {
@@ -506,6 +558,23 @@ function Invoke-ShutdownHandler {
     if ($null -ne $script:Dispatcher) { try { $script:Dispatcher.Dispose() } catch {} }
     Close-Pool
     exit 0
+}
+
+function Invoke-CancelHandler {
+    param(
+        [string]$Id,
+        [object]$Params
+    )
+    $requestId = ''
+    if ($null -ne $Params -and $null -ne $Params.requestId) {
+        $requestId = "$($Params.requestId)"
+    }
+    $found = $false
+    if (-not [string]::IsNullOrEmpty($requestId) -and $null -ne $script:Dispatcher) {
+        $found = $script:Dispatcher.Cancel($requestId)
+    }
+    Write-Diag "cancel: requestId=$requestId found=$found"
+    Write-NdjsonResponse -Id $Id -Result @{ cancelled = $found; requestId = $requestId }
 }
 
 # --- Setup handler (drains, mutates ISS, reopens pool) -------------------
@@ -936,6 +1005,7 @@ while ($true) {
             'shutdown' { Invoke-ShutdownHandler -Id $id }
             'discover' { Invoke-DiscoverHandler -Id $id -Params $params }
             'invoke'   { Invoke-InvokeHandler   -Id $id -Params $params }
+            'cancel'   { Invoke-CancelHandler   -Id $id -Params $params }
             default {
                 Write-NdjsonResponse -Id $id -ErrorObj @{ code = -1; message = "Unknown method: $method" }
             }

--- a/PoshMcp.Server/PowerShell/OutOfProcess/oop-host.ps1
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/oop-host.ps1
@@ -29,10 +29,268 @@ function Write-Diag {
     [Console]::Error.WriteLine("[oop-host] $Message")
 }
 
+# --- C# single-host dispatcher (for cancellation propagation, issue #188) ---
+# Compiled once per process. Owns a single worker thread that processes
+# invokes serially against a shared runspace; tracks active items by request
+# id so a 'cancel' message can call BeginStop() on the live pipeline. All
+# stdout writes are serialized through SingleStdout.Lock so the dispatcher
+# main loop and the worker thread can never interleave.
+
+if (-not ('PoshMcp.SingleHost.SingleDispatcher' -as [type])) {
+    Add-Type -TypeDefinition @'
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using System.Management.Automation;
+using System.Text;
+using System.Threading;
+
+namespace PoshMcp.SingleHost
+{
+    public static class SingleStdout
+    {
+        public static readonly object Lock = new object();
+
+        public static void Write(string json)
+        {
+            lock (Lock)
+            {
+                Console.Out.WriteLine(json);
+                Console.Out.Flush();
+            }
+        }
+
+        public static string EscapeString(string s)
+        {
+            if (s == null) return "null";
+            var sb = new StringBuilder(s.Length + 2);
+            sb.Append('"');
+            for (int i = 0; i < s.Length; i++)
+            {
+                char c = s[i];
+                switch (c)
+                {
+                    case '\\': sb.Append("\\\\"); break;
+                    case '"':  sb.Append("\\\""); break;
+                    case '\b': sb.Append("\\b"); break;
+                    case '\f': sb.Append("\\f"); break;
+                    case '\n': sb.Append("\\n"); break;
+                    case '\r': sb.Append("\\r"); break;
+                    case '\t': sb.Append("\\t"); break;
+                    default:
+                        if (c < 0x20)
+                            sb.Append("\\u").Append(((int)c).ToString("x4", CultureInfo.InvariantCulture));
+                        else
+                            sb.Append(c);
+                        break;
+                }
+            }
+            sb.Append('"');
+            return sb.ToString();
+        }
+    }
+
+    public sealed class SingleWorkItem
+    {
+        public string Id;
+        public PowerShell Ps;
+        public bool Cancelled;
+    }
+
+    public sealed class SingleDispatcher : IDisposable
+    {
+        private readonly BlockingCollection<SingleWorkItem> _queue = new BlockingCollection<SingleWorkItem>();
+        private readonly ConcurrentDictionary<string, SingleWorkItem> _active = new ConcurrentDictionary<string, SingleWorkItem>();
+        private readonly Thread _worker;
+
+        public SingleDispatcher()
+        {
+            _worker = new Thread(WorkerLoop);
+            _worker.IsBackground = true;
+            _worker.Name = "PoshMcpSingle-Worker";
+            _worker.Start();
+        }
+
+        public void Submit(string id, PowerShell ps)
+        {
+            var item = new SingleWorkItem { Id = id, Ps = ps };
+            _active[id] = item;
+            _queue.Add(item);
+        }
+
+        public bool Cancel(string requestId)
+        {
+            if (string.IsNullOrEmpty(requestId)) return false;
+            SingleWorkItem item;
+            if (!_active.TryGetValue(requestId, out item)) return false;
+            try
+            {
+                item.Cancelled = true;
+                item.Ps.BeginStop(null, null);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine("[oop-host:dispatcher] BeginStop failed for " + requestId + ": " + ex.Message);
+                return false;
+            }
+        }
+
+        private void WorkerLoop()
+        {
+            try
+            {
+                foreach (var w in _queue.GetConsumingEnumerable())
+                {
+                    try
+                    {
+                        ProcessOne(w);
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Error.WriteLine("[oop-host:dispatcher] worker exception: " + ex);
+                        try { WriteError(w.Id, ex.Message); } catch { }
+                    }
+                    finally
+                    {
+                        try { w.Ps.Dispose(); } catch { }
+                        SingleWorkItem _removed;
+                        _active.TryRemove(w.Id, out _removed);
+                    }
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // BlockingCollection completed during shutdown.
+            }
+        }
+
+        private void ProcessOne(SingleWorkItem w)
+        {
+            Collection<PSObject> output = null;
+            string invokeError = null;
+            bool wasStopped = false;
+
+            try
+            {
+                output = w.Ps.Invoke();
+            }
+            catch (System.Management.Automation.PipelineStoppedException)
+            {
+                wasStopped = true;
+            }
+            catch (Exception ex)
+            {
+                invokeError = ex.Message;
+            }
+
+            if (!wasStopped)
+            {
+                try
+                {
+                    var state = w.Ps.InvocationStateInfo;
+                    if (state != null && state.State == PSInvocationState.Stopped)
+                    {
+                        wasStopped = true;
+                    }
+                }
+                catch { /* best-effort */ }
+            }
+
+            bool cancelled = wasStopped || w.Cancelled;
+
+            string[] errs = w.Ps.Streams.Error.Select(e => e.ToString()).ToArray();
+            string[] warns = w.Ps.Streams.Warning.Select(x => x.Message).ToArray();
+            bool hadErrors = w.Ps.HadErrors || errs.Length > 0 || cancelled;
+
+            string outputJson;
+            if (invokeError != null && !cancelled)
+            {
+                WriteError(w.Id, invokeError);
+                return;
+            }
+            if (cancelled || output == null || output.Count == 0 || output[0] == null)
+            {
+                outputJson = "null";
+            }
+            else
+            {
+                var first = output[0];
+                outputJson = (first.BaseObject as string) ?? first.ToString() ?? "null";
+            }
+
+            var sb = new StringBuilder();
+            sb.Append("{\"id\":").Append(SingleStdout.EscapeString(w.Id)).Append(",\"result\":{");
+            sb.Append("\"output\":").Append(SingleStdout.EscapeString(outputJson)).Append(',');
+            sb.Append("\"hadErrors\":").Append(hadErrors ? "true" : "false").Append(',');
+            sb.Append("\"cancelled\":").Append(cancelled ? "true" : "false").Append(',');
+            sb.Append("\"errors\":[");
+            for (int i = 0; i < errs.Length; i++)
+            {
+                if (i > 0) sb.Append(',');
+                sb.Append(SingleStdout.EscapeString(errs[i] ?? string.Empty));
+            }
+            sb.Append("],\"warnings\":[");
+            for (int i = 0; i < warns.Length; i++)
+            {
+                if (i > 0) sb.Append(',');
+                sb.Append(SingleStdout.EscapeString(warns[i] ?? string.Empty));
+            }
+            sb.Append("]}}");
+
+            SingleStdout.Write(sb.ToString());
+        }
+
+        private static void WriteError(string id, string message)
+        {
+            var sb = new StringBuilder();
+            sb.Append("{\"id\":").Append(SingleStdout.EscapeString(id ?? string.Empty));
+            sb.Append(",\"error\":{\"code\":-1,\"message\":")
+              .Append(SingleStdout.EscapeString(message ?? string.Empty))
+              .Append("}}");
+            SingleStdout.Write(sb.ToString());
+        }
+
+        public void Dispose()
+        {
+            try { _queue.CompleteAdding(); } catch { }
+        }
+    }
+}
+'@
+}
+
+$script:Dispatcher = $null
+$script:SharedRunspace = $null
+
+function Ensure-SharedRunspace {
+    if ($null -eq $script:SharedRunspace) {
+        $iss = [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault2()
+        $script:SharedRunspace = [runspacefactory]::CreateRunspace($iss)
+        $script:SharedRunspace.Open()
+        Write-Diag 'Shared runspace opened.'
+    }
+}
+
+function Ensure-Dispatcher {
+    if ($null -eq $script:Dispatcher) {
+        Ensure-SharedRunspace
+        $script:Dispatcher = [PoshMcp.SingleHost.SingleDispatcher]::new()
+        Write-Diag 'Single-mode dispatcher started.'
+    }
+}
+
 function Write-NdjsonResponse {
     <#
     .SYNOPSIS
         Write a single ndjson response line to stdout.
+    .NOTES
+        Uses [PoshMcp.SingleHost.SingleStdout]::Write so the dispatcher main
+        loop and the worker thread (which writes invoke responses directly
+        from C#) cannot interleave on stdout.
     #>
     param(
         [Parameter(Mandatory)][string]$Id,
@@ -50,8 +308,13 @@ function Write-NdjsonResponse {
     }
 
     $json = $response | ConvertTo-Json -Depth 10 -Compress
-    [Console]::Out.WriteLine($json)
-    [Console]::Out.Flush()
+    if (('PoshMcp.SingleHost.SingleStdout' -as [type])) {
+        [PoshMcp.SingleHost.SingleStdout]::Write($json)
+    }
+    else {
+        [Console]::Out.WriteLine($json)
+        [Console]::Out.Flush()
+    }
 }
 
 function ConvertTo-SafeJson {
@@ -110,6 +373,11 @@ function Invoke-ShutdownHandler {
     param([string]$Id)
     Write-NdjsonResponse -Id $Id -Result @{ status = 'shutting_down' }
     Write-Diag 'Shutdown requested. Exiting.'
+    if ($null -ne $script:Dispatcher) { try { $script:Dispatcher.Dispose() } catch {} }
+    if ($null -ne $script:SharedRunspace) {
+        try { $script:SharedRunspace.Close() } catch {}
+        try { $script:SharedRunspace.Dispose() } catch {}
+    }
     exit 0
 }
 
@@ -537,7 +805,10 @@ function Invoke-DiscoverHandler {
 function Invoke-InvokeHandler {
     <#
     .SYNOPSIS
-        Execute a PowerShell command and return the result.
+        Execute a PowerShell command asynchronously via the SingleDispatcher
+        worker thread. The dispatcher main loop returns to read stdin
+        immediately so a follow-up 'cancel' message can be processed while
+        the user pipeline is in flight.
     #>
     param(
         [string]$Id,
@@ -553,10 +824,11 @@ function Invoke-InvokeHandler {
         return
     }
 
+    Ensure-Dispatcher
+
     # Build parameters hashtable for splatting
     $splatParams = @{}
     if ($null -ne $Params.parameters) {
-        # Convert the PSCustomObject from ConvertFrom-Json into a hashtable
         $Params.parameters.PSObject.Properties | ForEach-Object {
             $splatParams[$_.Name] = $_.Value
         }
@@ -582,7 +854,6 @@ function Invoke-InvokeHandler {
                     $splatParams[$switchName] = [switch]$true
                 }
                 else {
-                    # Remove false switch parameters so they aren't passed
                     $splatParams.Remove($switchName)
                 }
             }
@@ -590,44 +861,71 @@ function Invoke-InvokeHandler {
     }
     catch {
         Write-Diag "Warning: Could not resolve command info for '$commandName': $_"
-        # Proceed anyway — splatting may still work
     }
 
     Write-Diag "Invoking: $commandName with $($splatParams.Count) parameter(s)"
 
-    # Clear $Error before invoking so non-terminating errors from prior invokes
-    # in this single-runspace host don't leak into this invoke's hadErrors flag.
-    # See issue #189.
-    $Error.Clear()
-
-    try {
-        $result = & $commandName @splatParams
-        $hadErrors = $false
-
-        # Check if there were non-terminating errors
-        if ($Error.Count -gt 0) {
-            $hadErrors = $true
+    # User script executes inside the shared runspace. $Error is per-runspace
+    # (cleared so contamination from a prior invoke cannot leak; see #189).
+    # The pipeline pre-serializes the result to JSON so the worker thread can
+    # embed it without a second round-trip into PowerShell. ConvertTo-Json is
+    # wrapped to tolerate shadowed-property objects (see #203).
+    $userScript = {
+        param($Name, $Splat)
+        $Error.Clear()
+        # Wrap the call so terminating errors (e.g. CommandNotFoundException
+        # from the call operator) propagate out of [powershell]::Invoke() as
+        # exceptions rather than being collected into Streams.Error. The
+        # SingleDispatcher uses that exception to emit an error frame, which
+        # the .NET client surfaces as InvalidOperationException.
+        try { $r = & $Name @Splat } catch { throw }
+        if ($null -eq $r) { return 'null' }
+        try {
+            return ($r | ConvertTo-Json -Depth 4 -Compress -WarningAction SilentlyContinue)
         }
-
-        # Use ConvertTo-SafeJson to tolerate shadowed-property objects
-        # (e.g. Invoke-WebRequest results). See issue #203.
-        $jsonOutput = ConvertTo-SafeJson -InputObject $result -Depth 4
-        if ($null -eq $jsonOutput) {
-            $jsonOutput = 'null'
-        }
-
-        Write-NdjsonResponse -Id $Id -Result @{
-            output    = $jsonOutput
-            hadErrors = $hadErrors
-        }
-    }
-    catch {
-        Write-Diag "Error invoking '$commandName': $_"
-        Write-NdjsonResponse -Id $Id -ErrorObj @{
-            code    = -1
-            message = "$_"
+        catch [System.ArgumentException] {
+            try {
+                return ($r | Select-Object * | ConvertTo-Json -Depth 4 -Compress -WarningAction SilentlyContinue)
+            }
+            catch {
+                return (($r | Out-String).Trim() | ConvertTo-Json -Compress)
+            }
         }
     }
+
+    $ps = [powershell]::Create()
+    $ps.Runspace = $script:SharedRunspace
+    [void]$ps.AddScript($userScript)
+    [void]$ps.AddArgument($commandName)
+    [void]$ps.AddArgument($splatParams)
+
+    # Hand off to the worker thread; it writes the response when done.
+    $script:Dispatcher.Submit($Id, $ps)
+}
+
+function Invoke-CancelHandler {
+    <#
+    .SYNOPSIS
+        Cancel an in-flight invoke. Looks up the request id in the dispatcher's
+        active registry and calls BeginStop() on the live pipeline. Always
+        responds promptly with a small ack frame regardless of outcome.
+    #>
+    param(
+        [string]$Id,
+        [object]$Params
+    )
+
+    $requestId = ''
+    if ($null -ne $Params -and $null -ne $Params.requestId) {
+        $requestId = "$($Params.requestId)"
+    }
+
+    $found = $false
+    if (-not [string]::IsNullOrEmpty($requestId) -and $null -ne $script:Dispatcher) {
+        $found = $script:Dispatcher.Cancel($requestId)
+    }
+    Write-Diag "cancel: requestId=$requestId found=$found"
+    Write-NdjsonResponse -Id $Id -Result @{ cancelled = $found; requestId = $requestId }
 }
 
 # --- Main loop ---
@@ -690,6 +988,9 @@ while ($true) {
             }
             'invoke' {
                 Invoke-InvokeHandler -Id $id -Params $params
+            }
+            'cancel' {
+                Invoke-CancelHandler -Id $id -Params $params
             }
             default {
                 Write-NdjsonResponse -Id $id -ErrorObj @{

--- a/PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessCancellationTests.cs
+++ b/PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessCancellationTests.cs
@@ -1,0 +1,281 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using PoshMcp.Server.PowerShell.OutOfProcess;
+using Xunit;
+
+namespace PoshMcp.Tests.Unit.OutOfProcess;
+
+/// <summary>
+/// Cancellation propagation tests for issue #188. Cancelling the .NET-side
+/// <see cref="CancellationToken"/> must signal the in-flight pwsh pipeline to
+/// stop within a bounded time, leave the host healthy for follow-up requests,
+/// and (in Pool/ProcessPool) not block parallel work.
+/// </summary>
+public class OutOfProcessCancellationTests
+{
+    private static readonly TimeSpan ObservationTimeout = TimeSpan.FromSeconds(15);
+
+    [Fact]
+    public async Task Single_LongRunningInvoke_TokenCancelStopsPipeline()
+    {
+        if (!TryResolvePwsh(out var pwshPath)) return;
+
+        var scriptPath = await ResolveOopHostScriptForTestAsync("oop-host.ps1");
+        if (scriptPath is null) return;
+
+        await using var host = new OutOfProcessHost(
+            pwshPath, scriptPath,
+            NullLogger<OutOfProcessHost>.Instance,
+            TimeSpan.FromSeconds(60));
+
+        await host.StartAsync(CancellationToken.None);
+
+        using var cts = new CancellationTokenSource();
+
+        // Issue a 60s sleep and cancel after a short delay. Token cancel must
+        // unblock the awaiter in well under the sleep duration.
+        var invokeTask = host.SendRequestAsync<JsonElement>(
+            "invoke",
+            new
+            {
+                command = "Start-Sleep",
+                parameters = new Dictionary<string, object?> { ["Seconds"] = 60 }
+            },
+            cts.Token);
+
+        await Task.Delay(TimeSpan.FromMilliseconds(500));
+        var sw = Stopwatch.StartNew();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        {
+            await invokeTask.WaitAsync(ObservationTimeout);
+        });
+
+        sw.Stop();
+        Assert.True(sw.Elapsed < ObservationTimeout,
+            $"Cancellation took {sw.Elapsed.TotalSeconds:F1}s — exceeded {ObservationTimeout.TotalSeconds}s budget.");
+
+        // Follow-up ping must succeed promptly — the host is reusable.
+        using var pingCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var pingResult = await host.SendRequestAsync<JsonElement>(
+            "ping", null, pingCts.Token);
+        Assert.True(pingResult.TryGetProperty("status", out var status));
+        Assert.Equal("ok", status.GetString());
+    }
+
+    [Fact]
+    public async Task Pool_LongRunningInvoke_TokenCancelStopsPipelineNoHeadOfLine()
+    {
+        if (!TryResolvePwsh(out var pwshPath)) return;
+
+        var scriptPath = await ResolveOopHostScriptForTestAsync("oop-host-pool.ps1");
+        if (scriptPath is null) return;
+
+        await using var host = new OutOfProcessHost(
+            pwshPath, scriptPath,
+            NullLogger<OutOfProcessHost>.Instance,
+            TimeSpan.FromSeconds(60));
+
+        await host.StartAsync(CancellationToken.None);
+
+        // Apply a minimal setup so the pool sizes itself > 1.
+        using var setupCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await host.SendRequestAsync<JsonElement>(
+            "setup",
+            new
+            {
+                modulePaths = Array.Empty<string>(),
+                trustPSGallery = false,
+                installModules = Array.Empty<object>(),
+                importModules = Array.Empty<string>(),
+                runspacePoolSize = 4,
+            },
+            setupCts.Token);
+
+        using var sleepCts = new CancellationTokenSource();
+
+        // Slow invoke (sleeps 60s) on one runspace in the pool.
+        var slowInvoke = host.SendRequestAsync<JsonElement>(
+            "invoke",
+            new
+            {
+                command = "Start-Sleep",
+                parameters = new Dictionary<string, object?> { ["Seconds"] = 60 }
+            },
+            sleepCts.Token);
+
+        // Give it a moment to start.
+        await Task.Delay(TimeSpan.FromMilliseconds(500));
+
+        // Concurrent fast invoke MUST complete normally — proves no head-of-line.
+        using var fastCts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var fastTask = host.SendRequestAsync<JsonElement>(
+            "invoke",
+            new
+            {
+                command = "Get-Date",
+                parameters = new Dictionary<string, object?>()
+            },
+            fastCts.Token);
+
+        var fastResult = await fastTask;
+        Assert.True(fastResult.TryGetProperty("output", out _));
+
+        // Now cancel the slow one — should unblock promptly.
+        var sw = Stopwatch.StartNew();
+        sleepCts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        {
+            await slowInvoke.WaitAsync(ObservationTimeout);
+        });
+
+        sw.Stop();
+        Assert.True(sw.Elapsed < ObservationTimeout,
+            $"Pool cancellation took {sw.Elapsed.TotalSeconds:F1}s — exceeded {ObservationTimeout.TotalSeconds}s budget.");
+
+        // Pool still healthy for follow-up.
+        using var followUpCts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var followUp = await host.SendRequestAsync<JsonElement>(
+            "invoke",
+            new
+            {
+                command = "Get-Date",
+                parameters = new Dictionary<string, object?>()
+            },
+            followUpCts.Token);
+        Assert.True(followUp.TryGetProperty("output", out _));
+    }
+
+    [Fact]
+    public async Task ProcessPool_TokenCancel_StopsPipelineAndKeepsSlotsHealthy()
+    {
+        if (!TryResolvePwsh(out var pwshPath)) return;
+
+        var scriptPath = await ResolveOopHostScriptForTestAsync("oop-host.ps1");
+        if (scriptPath is null) return;
+
+        var poolOptions = new OutOfProcessSubprocessPoolOptions
+        {
+            PoolSize = 2,
+            MinHealthyForStartup = 1,
+            ReconcilerInterval = TimeSpan.FromMilliseconds(500),
+        };
+
+        await using var pool = new OutOfProcessSubprocessPool(
+            pwshPath, scriptPath, poolOptions,
+            loggerFactory: null,
+            requestTimeout: TimeSpan.FromSeconds(60));
+
+        await pool.StartAsync(CancellationToken.None);
+
+        // Two long invokes in parallel, both cancelled. Must observe OCE
+        // promptly on both. Slots should stay healthy (soft cancel — no kill
+        // required since Start-Sleep is interruptable).
+        using var cts1 = new CancellationTokenSource();
+        using var cts2 = new CancellationTokenSource();
+
+        var t1 = pool.InvokeAsync(
+            "Start-Sleep",
+            new Dictionary<string, object?> { ["Seconds"] = 60 },
+            cts1.Token);
+        var t2 = pool.InvokeAsync(
+            "Start-Sleep",
+            new Dictionary<string, object?> { ["Seconds"] = 60 },
+            cts2.Token);
+
+        await Task.Delay(TimeSpan.FromMilliseconds(750));
+        var sw = Stopwatch.StartNew();
+        cts1.Cancel();
+        cts2.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await t1.WaitAsync(ObservationTimeout));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await t2.WaitAsync(ObservationTimeout));
+
+        sw.Stop();
+        Assert.True(sw.Elapsed < ObservationTimeout,
+            $"ProcessPool cancellation took {sw.Elapsed.TotalSeconds:F1}s — exceeded budget.");
+
+        // Brief settle for the pipelines to fully unwind on the host side and
+        // for the slots to be returned to the pool. Then a follow-up invoke
+        // on the pool must succeed promptly — proves slots are reusable.
+        await Task.Delay(TimeSpan.FromSeconds(1));
+
+        using var followUpCts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var output = await pool.InvokeAsync(
+            "Get-Date",
+            new Dictionary<string, object?>(),
+            followUpCts.Token);
+        Assert.False(string.IsNullOrEmpty(output));
+        Assert.True(pool.HealthyCount >= 1,
+            $"Pool reported HealthyCount={pool.HealthyCount} after soft cancel; expected >= 1.");
+    }
+
+    private static bool TryResolvePwsh(out string pwshPath)
+    {
+        try
+        {
+            pwshPath = OutOfProcessCommandExecutor.ResolvePwshPath();
+            return true;
+        }
+        catch (FileNotFoundException)
+        {
+            pwshPath = string.Empty;
+            return false;
+        }
+    }
+
+    private static async Task<string?> ResolveOopHostScriptForTestAsync(string scriptName)
+    {
+        var overridePath = Environment.GetEnvironmentVariable("POSHMCP_OOP_HOST_PATH");
+        if (!string.IsNullOrWhiteSpace(overridePath) && File.Exists(overridePath))
+        {
+            return overridePath;
+        }
+
+        var serverAssembly = typeof(OutOfProcessHost).Assembly;
+        var resourceName = Array.Find(
+            serverAssembly.GetManifestResourceNames(),
+            name => name.EndsWith(scriptName, StringComparison.OrdinalIgnoreCase));
+
+        if (resourceName is not null)
+        {
+            using var stream = serverAssembly.GetManifestResourceStream(resourceName);
+            if (stream is not null)
+            {
+                var bytes = new byte[stream.Length];
+                await stream.ReadExactlyAsync(bytes);
+                var hash = Convert.ToHexStringLower(SHA256.HashData(bytes));
+                var dir = Path.Combine(Path.GetTempPath(), "poshmcp-tests");
+                var path = Path.Combine(dir, scriptName);
+                Directory.CreateDirectory(dir);
+                if (!File.Exists(path) || ContentHash(path) != hash)
+                {
+                    await File.WriteAllBytesAsync(path, bytes);
+                }
+                return path;
+            }
+        }
+
+        var basePath = Path.Combine(AppContext.BaseDirectory, "PowerShell", "OutOfProcess", scriptName);
+        return File.Exists(basePath) ? basePath : null;
+    }
+
+    private static string ContentHash(string filePath)
+    {
+        using var fs = File.OpenRead(filePath);
+        return Convert.ToHexStringLower(SHA256.HashData(fs));
+    }
+}

--- a/specs/004-out-of-process-execution/cancellation-design.md
+++ b/specs/004-out-of-process-execution/cancellation-design.md
@@ -1,0 +1,365 @@
+# Cancellation Propagation Design (issue #188)
+
+**Status:** Proposed
+**Owner:** Bender (Backend Developer)
+**Date:** 2026-05-06
+**Scope:** Out-of-process execution path only. In-process runspace cancellation is tracked separately and is NOT addressed here.
+**Related:** Spec 004 (Out-of-Process Execution), unblocks #196 (default-mode flip to `Pool`).
+
+---
+
+## 1. Problem statement
+
+`CancellationToken` plumbed through `OutOfProcessHost.SendRequestAsync` only governs the .NET-side wait. When the token fires:
+
+1. `_sendLock.WaitAsync(ct)` and the stdin write may abort (only relevant before the request is in flight).
+2. The linked `timeoutCts` may fail the local `TaskCompletionSource` with `TimeoutException` if the per-request timeout elapses.
+3. **The pwsh subprocess never learns about the cancellation.** It keeps running the pipeline to completion (or hangs).
+
+Net effect:
+
+- The `_pending` map entry is removed in `finally` only after `tcs.Task` observes a result. Caller cancellation does not currently set the TCS — the awaiter just stays parked. Since there is no `ct.Register` hook today, **caller cancellation has effectively no effect on a request that is already in flight** beyond what the per-request timeout produces.
+- The host's single-threaded stdin dispatcher (`oop-host.ps1`) cannot even *read* a follow-up cancel message while it is blocked inside `Invoke-InvokeHandler`. Head-of-line blocking is structural.
+- For `Pool` mode (`oop-host-pool.ps1`), invokes run on a runspace pool with N worker threads, so the dispatcher loop is not blocked — but there is no plumbing to map `requestId → PowerShell` and call `BeginStop()`.
+- For `ProcessPool` mode (`OutOfProcessSubprocessPool`), per-request kill-on-timeout already exists as a backstop, but it kills the host process even when a soft cancel would have sufficed.
+
+Until cancellation is plumbed through to the host pipeline, `Pool` cannot become the default mode (#196): a single runaway script wastes the only host until the per-request timeout kills it, blocking every subsequent invoke for that duration.
+
+---
+
+## 2. Mode-by-mode analysis
+
+### 2.1 `Single` (`oop-host.ps1`) — one host process, one runspace, one pipeline at a time
+
+- **Dispatcher loop** is single-threaded synchronous: `[Console]::ReadLine()` → `switch ($method)` → `Invoke-InvokeHandler` → blocking `& $cmdInfo @boundParams`.
+- The handler holds the dispatcher hostage for the full duration of the user pipeline. No other request — including a `cancel` for the in-flight invoke — can be read.
+- **Cancellation requires:**
+  1. Decoupling invoke execution from the dispatcher loop. The invoke must run on a background `[powershell]` instance via `BeginInvoke()`. The dispatcher continues reading stdin in parallel.
+  2. A registry of `requestId → [powershell]` (`ConcurrentDictionary[string,powershell]`) so a `cancel` request can find the live pipeline.
+  3. On `cancel`, call `$ps.BeginStop($null, $null)`. PowerShell will eventually unwind the pipeline; the existing completion callback writes the response (with the `cancelled` flag set) and frees the registry entry.
+
+### 2.2 `Pool` (`oop-host-pool.ps1`) — one host process, N runspaces, N concurrent pipelines
+
+- Invokes already run on the C# `PoolDispatcher`'s N worker threads. The PS dispatcher loop is free; it can read `cancel` immediately.
+- The `PoolDispatcher` already creates a `[powershell]` per `PoolWorkItem` and calls `ps.Invoke()` synchronously on the worker thread. To cancel, we need the worker to be interruptable from outside.
+- **Cancellation requires:**
+  1. Track active items by id: `ConcurrentDictionary<string, PoolWorkItem> _active` inside `PoolDispatcher`. Populate on `Submit`, remove in the worker `finally`.
+  2. Add `PoolDispatcher.Cancel(string requestId)` that looks up the item and calls `item.Ps.BeginStop(null, null)`. The worker's `ps.Invoke()` returns shortly thereafter; existing response-write path runs unchanged. The response includes a `cancelled` flag.
+  3. Add an `Invoke-CancelHandler` PS function that calls `$script:Dispatcher.Cancel($requestId)` and emits a small ack frame.
+- All response writes are already serialized through `PoolStdout.Lock`, so no new locking is needed.
+
+### 2.3 `ProcessPool` (`OutOfProcessSubprocessPool`) — N independent host processes, one pipeline each
+
+- The pool already kills a host on `TimeoutException` from `host.SendRequestAsync` (the per-request kill-on-timeout escape hatch from #200). That remains the backstop.
+- The **new behavior** is purely free of charge: by improving `OutOfProcessHost` to forward caller cancellation to the host as a `cancel` frame, the pool's `InvokeAsync` automatically gets soft-cancel propagation. Each leased host's script (which is `oop-host.ps1` in `ProcessPool` mode — the pool currently uses Single-mode hosts internally) handles the cancel via the new Single-mode path.
+- The kill-on-timeout fallback is preserved exactly as today. Sequence becomes:
+  1. Caller cancels token → `OutOfProcessHost` sends `cancel` frame → host script attempts `BeginStop()`.
+  2. .NET awaiter completes with `OperationCanceledException` immediately (we do not wait for the host to acknowledge — see §3).
+  3. If the host acks/responds normally, the slot stays healthy and is returned to the pool.
+  4. If the host wedges (cmdlet stuck in unmanaged code), the *next* invoke on this slot will time out and trigger the existing kill path.
+
+---
+
+## 3. Wire protocol additions
+
+A single new method, `cancel`, plus a single new optional field, `cancelled`, on existing response frames.
+
+### 3.1 `cancel` request (`.NET → host`)
+
+```json
+{"id":"<cancel-frame-id>","method":"cancel","params":{"requestId":"<original-invoke-id>"}}
+```
+
+- `cancel-frame-id` is a fresh GUID generated by `OutOfProcessHost`. It is **not** registered in `_pending` — we do not await the cancel ack.
+- The host **must** still respond to the cancel frame so its own dispatcher does not log "missing response". The ack is small:
+
+```json
+{"id":"<cancel-frame-id>","result":{"cancelled":true,"requestId":"<original-invoke-id>"}}
+```
+
+- `cancelled` in the ack is `true` if the host found the in-flight pipeline and signaled it; `false` if the request id was unknown (already completed, or wrong id). The .NET side ignores the ack body.
+
+### 3.2 Cancelled invoke response (`host → .NET`)
+
+When the original `invoke` unwinds because of a `BeginStop`, the host writes the *normal* response frame with an additional `cancelled` boolean:
+
+```json
+{"id":"<original-invoke-id>","result":{"output":"null","hadErrors":true,"cancelled":true,"errors":["The pipeline has been stopped."],"warnings":[]}}
+```
+
+The .NET side does not consume `cancelled` on the response — by then the awaiter has already observed `OperationCanceledException` and the `_pending` entry has been removed (the response is dropped with a debug log). The flag exists for log inspection and future analytics.
+
+### 3.3 Frame ordering
+
+- A `cancel` may arrive *after* the host has already finished the invoke and written its response. The host MUST ack with `cancelled:false` and otherwise no-op.
+- A `cancel` for an unknown request id MUST ack with `cancelled:false` and not error.
+- A `cancel` MUST NOT block the host dispatcher under any circumstances.
+
+---
+
+## 4. Implementation plan — .NET side
+
+### 4.1 `OutOfProcessHost.SendRequestAsync` (the central change)
+
+Add a cancellation-token registration that fires a cancel frame and trips the TCS with `OperationCanceledException`:
+
+```csharp
+var cancelRegistration = cancellationToken.Register(() =>
+{
+    // Best-effort: tell the host to stop. Do not await — caller wants to return now.
+    _ = TrySendCancelFrameAsync(id);
+    tcs.TrySetCanceled(cancellationToken);
+});
+```
+
+The existing `timeoutCts.Token.Register(...)` callback (per-request timeout) gets the same treatment: send cancel frame, then set `TimeoutException`. Both registrations dispose in `finally`.
+
+`TrySendCancelFrameAsync` is a small private helper:
+
+```csharp
+private async Task TrySendCancelFrameAsync(string requestId)
+{
+    if (_disposed || _stdin is null) return;
+    var cancelFrameId = "cancel-" + Guid.NewGuid().ToString("N");
+    var frame = new { id = cancelFrameId, method = "cancel", @params = new { requestId } };
+    var json = JsonSerializer.Serialize(frame);
+    try
+    {
+        // Use a short, independent CTS. We must not honor the just-cancelled token here.
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        await _sendLock.WaitAsync(cts.Token).ConfigureAwait(false);
+        try
+        {
+            await _stdin.WriteLineAsync(json.AsMemory(), cts.Token).ConfigureAwait(false);
+            await _stdin.FlushAsync(cts.Token).ConfigureAwait(false);
+        }
+        finally { _sendLock.Release(); }
+    }
+    catch (Exception ex)
+    {
+        _logger.LogDebug(ex, "Failed to send cancel frame for request {Id}.", requestId);
+    }
+}
+```
+
+Cancel frame ids are intentionally **not** registered in `_pending`. The host's ack will hit the existing "OOP response for unknown request id" warning path; downgrade that path to debug for ids prefixed with `cancel-` to keep logs clean.
+
+### 4.2 Read loop — drop responses for already-removed pending ids quietly
+
+When the host writes the eventual `cancelled:true` response for an invoke that the .NET side already abandoned (`_pending.TryRemove` in `finally`), the read loop currently logs `"OOP response for unknown request id"`. Downgrade to `Debug` when the response carries `"cancelled":true` to avoid log noise.
+
+### 4.3 `OutOfProcessSubprocessPool.InvokeAsync`
+
+No structural change. The existing `catch (TimeoutException)` and `catch (InvalidOperationException) when (!host.IsRunning)` paths remain. We add **one** additional catch for caller cancellation:
+
+```csharp
+catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+{
+    // Host has been signaled (cancel frame sent inside SendRequestAsync). Slot stays
+    // healthy unless the host fails to recover; if it wedges, the next invoke will
+    // time out and trigger the existing kill path. Do NOT mark the slot broken here.
+    _logger.LogDebug(
+        "Invoke '{CommandName}' on slot {Index} cancelled by caller.",
+        commandName, slotIndex);
+    throw;
+}
+```
+
+This catch is purely for clean diagnostics; without it the OCE bubbles up unannotated, which is correct but harder to debug.
+
+### 4.4 `OutOfProcessCommandExecutor.InvokeAsync` (Single mode)
+
+No code change required. The cancel-frame propagation is entirely inside `OutOfProcessHost`. The Single executor inherits it for free.
+
+---
+
+## 5. Implementation plan — PowerShell side
+
+### 5.1 `oop-host.ps1` (Single mode) — async invoke + active registry
+
+The single-threaded dispatcher loop is the structural blocker. Refactor `Invoke-InvokeHandler` to be non-blocking:
+
+```powershell
+# Module-level registry, populated on invoke, cleared on completion.
+$script:ActiveInvocations = [System.Collections.Concurrent.ConcurrentDictionary[string,powershell]]::new()
+$script:ActiveRunspace = [runspacefactory]::CreateRunspace()
+$script:ActiveRunspace.Open()
+
+function Invoke-InvokeHandler {
+    param([string]$Id, [object]$Params)
+
+    $commandName = $Params.command
+    if ([string]::IsNullOrWhiteSpace($commandName)) {
+        Write-NdjsonResponse -Id $Id -ErrorObj @{ code = -1; message = 'Missing required parameter: command' }
+        return
+    }
+
+    # ... build $splatParams, resolve switch parameters (existing logic) ...
+
+    $ps = [powershell]::Create()
+    $ps.Runspace = $script:ActiveRunspace
+    [void]$ps.AddScript({
+        param($Name, $Splat)
+        $Error.Clear()
+        $r = & $Name @Splat
+        if ($null -eq $r) { return ,@($null, $Error.Count -gt 0) }
+        $json = ConvertTo-SafeJson -InputObject $r -Depth 4
+        ,@($json, $Error.Count -gt 0)
+    })
+    [void]$ps.AddArgument($commandName)
+    [void]$ps.AddArgument($splatParams)
+
+    [void]$script:ActiveInvocations.TryAdd($Id, $ps)
+
+    $async = $ps.BeginInvoke()
+    $callbackState = @{ Id = $Id; Ps = $ps; Async = $async }
+
+    # Completion observer thread (or .NET timer) — see note below.
+    [void][System.Threading.ThreadPool]::QueueUserWorkItem({
+        param($state)
+        try {
+            $state.Async.AsyncWaitHandle.WaitOne()
+            $output = $state.Ps.EndInvoke($state.Async)
+            # ... build response (output JSON, hadErrors, cancelled, errors, warnings) ...
+            Write-NdjsonResponse -Id $state.Id -Result $resultObj
+        }
+        catch [System.Management.Automation.PipelineStoppedException] {
+            Write-NdjsonResponse -Id $state.Id -Result @{
+                output = 'null'; hadErrors = $true; cancelled = $true
+                errors = @('Pipeline stopped.'); warnings = @()
+            }
+        }
+        catch {
+            Write-NdjsonResponse -Id $state.Id -ErrorObj @{ code = -1; message = "$_" }
+        }
+        finally {
+            [void]$script:ActiveInvocations.TryRemove($state.Id, [ref]([powershell]::null))
+            try { $state.Ps.Dispose() } catch { }
+        }
+    }, $callbackState)
+}
+
+function Invoke-CancelHandler {
+    param([string]$Id, [object]$Params)
+    $requestId = "$($Params.requestId)"
+    $found = $false
+    if ($script:ActiveInvocations.ContainsKey($requestId)) {
+        $ps = $null
+        if ($script:ActiveInvocations.TryGetValue($requestId, [ref]$ps)) {
+            try { [void]$ps.BeginStop($null, $null); $found = $true }
+            catch { Write-Diag "BeginStop failed for $requestId : $_" }
+        }
+    }
+    Write-NdjsonResponse -Id $Id -Result @{ cancelled = $found; requestId = $requestId }
+}
+```
+
+**Note on the completion observer:** `BeginInvoke` accepts a `PSAsyncCallback` overload, but it executes back on the runspace thread which we want free for stop processing. A `ThreadPool.QueueUserWorkItem` that waits on `Async.AsyncWaitHandle` is a robust portable alternative; one OS thread per in-flight invoke in Single mode is acceptable (Single mode = max 1 in flight in normal operation; cancel allows brief overlap during stop unwind).
+
+`Write-NdjsonResponse` already serializes via `[Console]::Out.WriteLine` — wrap stdout writes in a `[object]` lock (`$script:StdoutLock`) to prevent interleaving when both the callback thread and the dispatcher thread (e.g., for cancel ack) write concurrently. Pool host already has `PoolStdout.Lock`; mirror the pattern.
+
+### 5.2 `oop-host-pool.ps1` (Pool mode) — track active dispatcher items
+
+Two surgical changes inside `PoolDispatcher`:
+
+1. **Track active items.** Add `private readonly ConcurrentDictionary<string, PoolWorkItem> _active = new();`. In `Submit`, do `_active.TryAdd(id, item)` *before* `_queue.Add(item)`. In `WorkerLoop`'s `finally`, do `_active.TryRemove(w.Id, out _)`.
+
+2. **Expose `Cancel`.**
+
+```csharp
+public bool Cancel(string requestId)
+{
+    if (_active.TryGetValue(requestId, out var item))
+    {
+        try { item.Ps.BeginStop(null, null); return true; }
+        catch { return false; }
+    }
+    return false;
+}
+```
+
+In `ProcessOne`, detect a cancelled invoke via `w.Ps.InvocationStateInfo.State == PSInvocationState.Stopped` and emit `cancelled:true` in the response object (the existing JSON builder gets one extra field). This is one-line additive.
+
+PS function:
+
+```powershell
+function Invoke-CancelHandler {
+    param([string]$Id, [object]$Params)
+    $requestId = "$($Params.requestId)"
+    $found = $false
+    if ($null -ne $script:Dispatcher) {
+        $found = $script:Dispatcher.Cancel($requestId)
+    }
+    Write-NdjsonResponse -Id $Id -Result @{ cancelled = $found; requestId = $requestId }
+}
+```
+
+Add `'cancel' { Invoke-CancelHandler -Id $id -Params $params }` to the main loop switch.
+
+### 5.3 `ProcessPool` host scripts
+
+Each `OutOfProcessHost` inside `OutOfProcessSubprocessPool` runs `oop-host.ps1` (Single mode). The Single-mode changes in §5.1 cover ProcessPool by default. No additional script work.
+
+---
+
+## 6. Test plan
+
+Three integration tests, one per mode. Pattern follows `OutOfProcessHostConcurrencyTests.cs`:
+
+### 6.1 `Single_LongRunningInvoke_TokenCancelStopsPipeline`
+
+1. Start `OutOfProcessHost` directly with `oop-host.ps1`.
+2. Issue `invoke` for `Start-Sleep -Seconds 60` with a `CancellationTokenSource`.
+3. Cancel the CTS after 200 ms.
+4. Assert the awaiter throws `OperationCanceledException` within 5 s (not 60 s).
+5. Issue a follow-up `ping` with a fresh token; assert it succeeds within 5 s — proves the host is still healthy.
+
+### 6.2 `Pool_LongRunningInvoke_TokenCancelStopsPipeline`
+
+1. Start `OutOfProcessHost` directly with `oop-host-pool.ps1` (or via `OutOfProcessCommandExecutor` with `SubprocessHostMode.Pool`).
+2. Issue *two* parallel invokes: one `Start-Sleep -Seconds 60`, one `Get-Date`.
+3. Cancel only the first invoke's CTS.
+4. Assert the first throws `OperationCanceledException` within 5 s.
+5. Assert the second completes successfully (proves no head-of-line blocking; proves the pool is still serving).
+
+### 6.3 `ProcessPool_LongRunningInvoke_TokenCancelStopsHost`
+
+1. Construct an `OutOfProcessSubprocessPool` with `PoolSize = 2`.
+2. Issue two parallel invokes (both `Start-Sleep -Seconds 60`).
+3. Cancel both CTSs.
+4. Assert both throw `OperationCanceledException` within 5 s.
+5. Assert `pool.HealthyCount == 2` after a short settle (slots stay healthy; soft-cancel did not require kill).
+
+For the wedged-pipeline path (cancel-times-out → kill), rely on the existing `Pool_PerRequestTimeout_KillsHostAndPoolRecovers` test which already covers the kill-and-recover behavior. This is intentional: §4.3 explicitly preserves that path; we are not regressing it.
+
+---
+
+## 7. Risks and open questions
+
+| Risk | Mitigation |
+|------|------------|
+| Pipeline is in unmanaged code (P/Invoke, native cmdlet) and ignores `BeginStop`. | The .NET awaiter still returns OCE promptly. The host pipeline keeps running until it exits naturally. For `ProcessPool`, the next invoke on this slot will trigger the existing kill-on-timeout path. For `Single`/`Pool`, the per-request timeout (still in place) kills the host as a backstop — degraded but bounded. Documented in XML doc on `cancellationToken` parameter. |
+| Race: `cancel` arrives between worker's `_active.TryRemove` and the response write. | Order matters. Worker writes response *before* `_active.TryRemove`. Late cancel finds nothing in `_active`, acks `cancelled:false`. Benign. |
+| Single-mode async refactor introduces concurrent stdout writes (callback thread + dispatcher writing cancel ack). | Wrap `Write-NdjsonResponse` writes in `[Console]::Out` with a process-wide lock. Mirror Pool's `PoolStdout.Lock` pattern. |
+| `OutOfProcessHost.SendRequestAsync` calling `_sendLock.WaitAsync` from the cancel-fire-and-forget path could deadlock if invoked synchronously from a continuation that holds the lock. | The cancel send runs via `Task.Run` (or fire-and-forget `_ = ...`), never on the cancel-token-callback thread synchronously. The 2-second CTS on the cancel send guarantees forward progress. |
+| Cancel ack for already-completed invoke writes a noisy "OOP response for unknown request id" log. | Cancel ack frame ids are prefixed `cancel-`; the read loop downgrades unknown-id warnings to debug for that prefix. |
+| In Single mode, the runspace is reused across invokes; a stopped pipeline may leave the runspace in a transient `Stopping` state when the next invoke arrives. | `[powershell]::Create().Runspace = $script:ActiveRunspace` does not require `Opened` state for the next pipeline as long as the previous `[powershell]` was disposed (which the completion callback does). If we observe issues in tests, switch to a per-invoke `[powershell]::Create()` without an explicit shared runspace (uses default), at the cost of cold runspace creation per invoke. |
+
+---
+
+## 8. Decision
+
+**Adopt the design described above.** Specifically:
+
+1. New wire method `cancel` with optional `cancelled` field on responses.
+2. `.NET`-side: `OutOfProcessHost.SendRequestAsync` registers a cancellation callback that fires a cancel frame and trips the TCS with `OperationCanceledException`. Per-request timeout path also fires the cancel frame.
+3. `Single` mode: refactor invoke handler to async `BeginInvoke` + active-invocation registry, with stdout serialized under a process-wide lock.
+4. `Pool` mode: extend `PoolDispatcher` with an active-item registry and a `Cancel(requestId)` method that calls `BeginStop`.
+5. `ProcessPool` mode: inherits cancel propagation from `OutOfProcessHost`; existing kill-on-timeout backstop preserved verbatim.
+6. Tests: one per mode covering soft-cancel-then-recover.
+
+**Why this design over alternatives:**
+
+- *Side-channel control protocol (named pipe, signal):* rejected. Adds an OS-specific surface (named pipes differ between Windows and Linux; signals don't exist on Windows in a useful form), and the existing stdin channel is not actually blocked in `Pool` mode and can be unblocked in `Single` mode by simply running invokes asynchronously. The async refactor is cheaper than introducing a second IPC channel.
+- *Always-kill-host on cancel:* rejected. Loses module/runspace state on every cancel, defeating the purpose of `Pool` mode. The kill path remains as a backstop, not the primary mechanism.
+- *Cooperative-only (no kill):* rejected. Wedged pipelines (unmanaged code) need a backstop. The existing per-request kill in `ProcessPool` already provides it; the new design preserves it.


### PR DESCRIPTION
Closes #188

Propagates `CancellationToken` cancellation through `OutOfProcessHost.SendRequestAsync` to the pwsh subprocess via a new `cancel` wire frame, so the in-flight pipeline is signaled to stop with `PowerShell.BeginStop()` instead of running to completion.

Full design: [`specs/004-out-of-process-execution/cancellation-design.md`](https://github.com/usepowershell/PoshMcp/blob/squad/188-cancellation-propagation/specs/004-out-of-process-execution/cancellation-design.md) (already on this branch, commit `9a5cf24`).

## Per-mode behavior

| Mode | What cancellation does |
|------|------------------------|
| `Single` (`oop-host.ps1`) | Refactored handler runs invokes on a background dispatcher thread against a shared runspace; `cancel` calls `BeginStop` on the matching `[powershell]` instance. Awaiter throws `OperationCanceledException` promptly; host stays healthy for follow-ups. |
| `Pool` (`oop-host-pool.ps1`) | `PoolDispatcher` tracks active items by request id; `Cancel(requestId)` calls `BeginStop` on the worker's `[powershell]`. No head-of-line blocking — concurrent invokes on other runspaces continue. |
| `ProcessPool` (`OutOfProcessSubprocessPool`) | Inherits soft-cancel for free via `OutOfProcessHost`. Existing per-request kill-on-timeout backstop preserved verbatim — wedged pipelines (unmanaged code) still get killed. |

## Test results

- 3 new cancellation tests (one per mode) in `PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessCancellationTests.cs`:
  - `Single_LongRunningInvoke_TokenCancelStopsPipeline`
  - `Pool_LongRunningInvoke_TokenCancelStopsPipelineNoHeadOfLine`
  - `ProcessPool_TokenCancel_StopsPipelineAndKeepsSlotsHealthy`
- Full OOP test suite (`--filter "FullyQualifiedName~OutOfProcess"`): **148 passed, 0 failed, 6 skipped** (skips are Az module integration tests gated on environment).

## Wire protocol additions

- New `cancel` request frame: `{"id":"cancel-<guid>","method":"cancel","params":{"requestId":"<original-id>"}}`
- New optional `cancelled` boolean on invoke response frames.
- Cancel frame ids use `cancel-` prefix so unknown-id ack logs are downgraded to Debug.

## Sequencing

Unblocks #196 (Farnsworth — adopt-default flip to `Pool`).