### PR TITLE
feat(oop): default to Pool host mode (#196)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -31,7 +31,7 @@ This project bridges traditional scripting with modern AI interfaces, extending 
 
 ### Execution engine
 - Isolated PowerShell runspace per session for resource isolation
-- Runtime mode support: in-process (default) and out-of-process PowerShell execution
+- Runtime mode support: in-process (default) and out-of-process PowerShell execution. Out-of-process mode launches a runspace-pool host (`SubprocessHostMode: Pool`) by default; `ProcessPool` and `Single` remain available as opt-in topologies. Default rationale and benchmark data are recorded in [`specs/004-out-of-process-execution/benchmark-findings.md`](specs/004-out-of-process-execution/benchmark-findings.md).
 - Input/output translation for AI consumption
 - Azure Managed Identity support when deployed as a container in Azure (no code changes required)
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -90,6 +90,7 @@ poshmcp build --modules "Az.Accounts Az.KeyVault" --tag myorg/poshmcp:prod
 - `POSHMCP_TRANSPORT` --- `http` or `stdio` (default: `http`)
 - `POSHMCP_LOG_LEVEL` --- `trace|debug|info|warn|error`
 - `POSHMCP_LOG_FILE` --- Path to log file (stdio mode only). In containers, use a volume-mounted path (e.g., `/data/poshmcp.log`) for persistence
+- `POSHMCP_RUNTIME_MODE` --- `InProcess` (default) or `OutOfProcess`. Selects the PowerShell execution model. Use `OutOfProcess` for module-isolation scenarios; configure the host topology via the `PowerShellConfiguration:SubprocessHostMode` setting in appsettings.json (default `Pool`). See [README.md](README.md#out-of-process-powershell-runtime-advanced).
 
 Run `poshmcp doctor --help` for all diagnostic options.
 

--- a/PoshMcp.Server/Diagnostics/DoctorReport.cs
+++ b/PoshMcp.Server/Diagnostics/DoctorReport.cs
@@ -54,6 +54,15 @@ public sealed record DoctorReport
     public List<string> Warnings { get; init; } = [];
 
     /// <summary>
+    /// Out-of-process execution diagnostics. Only meaningful when
+    /// <see cref="RuntimeSettingsSection.RuntimeMode"/> resolves to
+    /// <c>OutOfProcess</c>; otherwise <see cref="OutOfProcessSection.Applicable"/>
+    /// is <c>false</c> and the remaining fields hold defaults.
+    /// </summary>
+    [JsonPropertyName("outOfProcess")]
+    public OutOfProcessSection OutOfProcess { get; init; } = new();
+
+    /// <summary>
     /// Computes the overall health status from the diagnostic data.
     /// Returns <c>"errors"</c>, <c>"warnings"</c>, or <c>"healthy"</c>.
     /// </summary>
@@ -498,4 +507,73 @@ public sealed record IdentitySection
 
     [JsonPropertyName("roles")]
     public List<string> Roles { get; init; } = [];
+}
+
+/// <summary>
+/// Diagnostics for the out-of-process PowerShell execution layer, populated
+/// when the resolved <c>RuntimeMode</c> is <c>OutOfProcess</c>.
+/// </summary>
+public sealed record OutOfProcessSection
+{
+    /// <summary>
+    /// True when the active runtime mode is <c>OutOfProcess</c> and the rest
+    /// of the section is meaningful. False otherwise (defaults will be present
+    /// but should not be displayed to the operator).
+    /// </summary>
+    [JsonPropertyName("applicable")]
+    public bool Applicable { get; init; }
+
+    /// <summary>Resolved subprocess host mode (<c>Single</c>, <c>Pool</c>, or <c>ProcessPool</c>).</summary>
+    [JsonPropertyName("hostMode")]
+    public string HostMode { get; init; } = string.Empty;
+
+    /// <summary>How <see cref="HostMode"/> was resolved (<c>config (explicit)</c> or <c>config (default)</c>).</summary>
+    [JsonPropertyName("hostModeSource")]
+    public string HostModeSource { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Configured runspace pool size for <c>Pool</c> mode (0 means
+    /// auto-size to <c>min(ProcessorCount, 8)</c> at the host).
+    /// </summary>
+    [JsonPropertyName("runspacePoolSize")]
+    public int RunspacePoolSize { get; init; }
+
+    /// <summary>
+    /// Effective runspace pool size including any clamping (e.g. negative or
+    /// out-of-range inputs are normalized to 1; 0 is treated as auto).
+    /// </summary>
+    [JsonPropertyName("effectiveRunspacePoolSize")]
+    public string EffectiveRunspacePoolSize { get; init; } = string.Empty;
+
+    /// <summary>Configured process pool size for <c>ProcessPool</c> mode (number of subprocess hosts).</summary>
+    [JsonPropertyName("processPoolSize")]
+    public int ProcessPoolSize { get; init; }
+
+    /// <summary>Effective process pool size after clamping.</summary>
+    [JsonPropertyName("effectiveProcessPoolSize")]
+    public int EffectiveProcessPoolSize { get; init; }
+
+    /// <summary>Minimum healthy hosts required at startup for <c>ProcessPool</c> mode (configured value).</summary>
+    [JsonPropertyName("minHealthyForStartup")]
+    public int MinHealthyForStartup { get; init; }
+
+    /// <summary>Minimum healthy hosts after clamping (capped at the effective pool size).</summary>
+    [JsonPropertyName("effectiveMinHealthyForStartup")]
+    public int EffectiveMinHealthyForStartup { get; init; }
+
+    /// <summary>Per-request timeout enforced by the host for outbound invokes (defaults to 30s).</summary>
+    [JsonPropertyName("requestTimeoutSeconds")]
+    public double RequestTimeoutSeconds { get; init; }
+
+    /// <summary>Resolved on-disk path to the host script for the active mode.</summary>
+    [JsonPropertyName("hostScriptPath")]
+    public string? HostScriptPath { get; init; }
+
+    /// <summary>True when the host script for the active mode resolved successfully.</summary>
+    [JsonPropertyName("hostScriptResolved")]
+    public bool HostScriptResolved { get; init; }
+
+    /// <summary>If <see cref="HostScriptResolved"/> is false, a short error description.</summary>
+    [JsonPropertyName("hostScriptError")]
+    public string? HostScriptError { get; init; }
 }

--- a/PoshMcp.Server/Diagnostics/DoctorService.cs
+++ b/PoshMcp.Server/Diagnostics/DoctorService.cs
@@ -171,9 +171,9 @@ internal static class DoctorService
             authConfig: authConfig,
             currentIdentity: currentIdentity)
             with
-            {
-                OutOfProcess = BuildOutOfProcessSection(config, configurationPath, Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance),
-            };
+        {
+            OutOfProcess = BuildOutOfProcessSection(config, configurationPath, Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance),
+        };
     }
 
     /// <summary>

--- a/PoshMcp.Server/Diagnostics/DoctorService.cs
+++ b/PoshMcp.Server/Diagnostics/DoctorService.cs
@@ -11,6 +11,7 @@ using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using PoshMcp.Server.Authentication;
 using PoshMcp.Server.PowerShell;
+using PoshMcp.Server.PowerShell.OutOfProcess;
 
 namespace PoshMcp;
 
@@ -81,6 +82,11 @@ internal static class DoctorService
             configurationErrors: configurationErrors,
             environmentVariables: environmentVariables,
             authConfig: authConfig);
+
+        report = report with
+        {
+            OutOfProcess = BuildOutOfProcessSection(config, settings.FinalConfigPath, loggerFactory),
+        };
 
         if (format == "json")
         {
@@ -163,7 +169,11 @@ internal static class DoctorService
             configurationErrors: configurationErrors,
             environmentVariables: environmentVariables,
             authConfig: authConfig,
-            currentIdentity: currentIdentity);
+            currentIdentity: currentIdentity)
+            with
+            {
+                OutOfProcess = BuildOutOfProcessSection(config, configurationPath, Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance),
+            };
     }
 
     /// <summary>
@@ -184,6 +194,112 @@ internal static class DoctorService
             WriteIndented = writeIndented,
             DefaultIgnoreCondition = JsonIgnoreCondition.Never
         });
+    }
+
+    /// <summary>
+    /// Builds the out-of-process diagnostics section. Returns a non-applicable
+    /// section when <see cref="PowerShellConfiguration.RuntimeMode"/> is not
+    /// <see cref="RuntimeMode.OutOfProcess"/>; otherwise resolves the host
+    /// script path (without launching a subprocess) and reports the effective
+    /// pool sizing.
+    /// </summary>
+    internal static OutOfProcessSection BuildOutOfProcessSection(
+        PowerShellConfiguration config,
+        string? configurationPath,
+        ILoggerFactory loggerFactory)
+    {
+        if (config.RuntimeMode != RuntimeMode.OutOfProcess)
+        {
+            return new OutOfProcessSection { Applicable = false };
+        }
+
+        // Detect explicit-vs-default for HostMode by re-reading the raw config.
+        var hostModeSource = "config (default)";
+        if (!string.IsNullOrWhiteSpace(configurationPath))
+        {
+            try
+            {
+                var rootConfig = ConfigurationLoader.BuildRootConfiguration(configurationPath, reloadOnChange: false);
+                if (!string.IsNullOrWhiteSpace(rootConfig["PowerShellConfiguration:SubprocessHostMode"]))
+                {
+                    hostModeSource = "config (explicit)";
+                }
+            }
+            catch
+            {
+                // Best-effort detection only — fall back to "default".
+            }
+        }
+
+        // Effective sizing per host-mode.
+        var effectiveRunspacePoolSize = config.SubprocessHostMode switch
+        {
+            SubprocessHostMode.Pool when config.SubprocessRunspacePoolSize <= 0 => "auto (min(ProcessorCount, 8))",
+            SubprocessHostMode.Pool => config.SubprocessRunspacePoolSize.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            _ => "n/a",
+        };
+
+        var effectiveProcessPoolSize = config.SubprocessHostMode == SubprocessHostMode.ProcessPool
+            ? (config.SubprocessPoolSize > 0 ? config.SubprocessPoolSize : 4)
+            : 0;
+
+        var effectiveMinHealthy = config.SubprocessHostMode == SubprocessHostMode.ProcessPool
+            ? Math.Max(1, Math.Min(
+                config.SubprocessMinHealthyForStartup > 0 ? config.SubprocessMinHealthyForStartup : 1,
+                effectiveProcessPoolSize > 0 ? effectiveProcessPoolSize : 1))
+            : 0;
+
+        // Best-effort host script resolution. Mirrors the executor's resolution
+        // path without starting the subprocess. Failures are reported, not thrown.
+        string? hostScriptPath = null;
+        var hostScriptResolved = false;
+        string? hostScriptError = null;
+        try
+        {
+            var resolverLogger = loggerFactory.CreateLogger<OutOfProcessCommandExecutor>();
+            var resolver = new OutOfProcessCommandExecutor(
+                resolverLogger,
+                requestTimeout: null,
+                hostMode: config.SubprocessHostMode,
+                runspacePoolSize: config.SubprocessRunspacePoolSize);
+            try
+            {
+                hostScriptPath = resolver.ResolveHostScriptPathAsync().GetAwaiter().GetResult();
+                hostScriptResolved = !string.IsNullOrWhiteSpace(hostScriptPath) && File.Exists(hostScriptPath);
+                if (!hostScriptResolved)
+                {
+                    hostScriptError = "Resolved path does not exist on disk.";
+                }
+            }
+            finally
+            {
+                resolver.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
+        }
+        catch (Exception ex)
+        {
+            hostScriptError = ex.Message;
+        }
+
+        return new OutOfProcessSection
+        {
+            Applicable = true,
+            HostMode = config.SubprocessHostMode.ToString(),
+            HostModeSource = hostModeSource,
+            RunspacePoolSize = config.SubprocessRunspacePoolSize,
+            EffectiveRunspacePoolSize = effectiveRunspacePoolSize,
+            ProcessPoolSize = config.SubprocessPoolSize,
+            EffectiveProcessPoolSize = effectiveProcessPoolSize,
+            MinHealthyForStartup = config.SubprocessMinHealthyForStartup,
+            EffectiveMinHealthyForStartup = effectiveMinHealthy,
+            // Per-request timeout is not yet a config knob — OutOfProcessHost
+            // hard-codes the 30-second default. Surfacing it here makes the
+            // contract explicit for operators and signposts the eventual knob.
+            RequestTimeoutSeconds = 30.0,
+            HostScriptPath = hostScriptPath,
+            HostScriptResolved = hostScriptResolved,
+            HostScriptError = hostScriptError,
+        };
     }
 
     private static (List<string> Warnings, List<string> Errors) BuildConfigurationWarnings(PowerShellConfiguration config, string configPath)
@@ -224,6 +340,32 @@ internal static class DoctorService
             if (appInsightsOptions.SamplingPercentage < 1 || appInsightsOptions.SamplingPercentage > 100)
             {
                 warnings.Add($"ApplicationInsights SamplingPercentage is {appInsightsOptions.SamplingPercentage}, which is outside the valid range of 1-100. It will be clamped at runtime.");
+            }
+        }
+
+        // Out-of-process subprocess clamp warnings (only meaningful when OutOfProcess).
+        if (config.RuntimeMode == RuntimeMode.OutOfProcess)
+        {
+            if (config.SubprocessHostMode == SubprocessHostMode.Pool && config.SubprocessRunspacePoolSize < 0)
+            {
+                warnings.Add($"SubprocessRunspacePoolSize is {config.SubprocessRunspacePoolSize} (negative). The Pool host will treat this as 0 (auto-size to min(ProcessorCount, 8)).");
+            }
+
+            if (config.SubprocessHostMode == SubprocessHostMode.ProcessPool)
+            {
+                if (config.SubprocessPoolSize < 1)
+                {
+                    warnings.Add($"SubprocessPoolSize is {config.SubprocessPoolSize}. ProcessPool will fall back to the default size of 4.");
+                }
+
+                if (config.SubprocessMinHealthyForStartup < 1)
+                {
+                    warnings.Add($"SubprocessMinHealthyForStartup is {config.SubprocessMinHealthyForStartup}. ProcessPool will clamp this to 1.");
+                }
+                else if (config.SubprocessPoolSize > 0 && config.SubprocessMinHealthyForStartup > config.SubprocessPoolSize)
+                {
+                    warnings.Add($"SubprocessMinHealthyForStartup ({config.SubprocessMinHealthyForStartup}) exceeds SubprocessPoolSize ({config.SubprocessPoolSize}); it will be clamped to the pool size.");
+                }
             }
         }
 

--- a/PoshMcp.Server/Diagnostics/DoctorTextRenderer.cs
+++ b/PoshMcp.Server/Diagnostics/DoctorTextRenderer.cs
@@ -22,6 +22,9 @@ public static class DoctorTextRenderer
             FormatSection("Authentication",        RenderAuthentication(report.Authentication, report.Identity)),
         };
 
+        if (report.OutOfProcess.Applicable)
+            parts.Add(FormatSection("Out-of-Process Execution", RenderOutOfProcess(report.OutOfProcess)));
+
         var warningsBody = RenderWarnings(report.Warnings);
         if (!string.IsNullOrEmpty(warningsBody))
             parts.Add(FormatSection("Warnings", warningsBody));
@@ -213,6 +216,35 @@ public static class DoctorTextRenderer
                 if (identity.Roles.Count > 0)
                     lines.Add($"    roles        : {string.Join(", ", identity.Roles)}");
             }
+        }
+
+        return string.Join("\n", lines);
+    }
+
+    private static string RenderOutOfProcess(OutOfProcessSection section)
+    {
+        var lines = new List<string>
+        {
+            $"  host-mode    : {section.HostMode} ({section.HostModeSource})",
+        };
+
+        if (section.HostMode == nameof(PoshMcp.Server.PowerShell.OutOfProcess.SubprocessHostMode.Pool))
+        {
+            lines.Add($"  pool-size    : {section.RunspacePoolSize} → {section.EffectiveRunspacePoolSize}");
+        }
+        else if (section.HostMode == nameof(PoshMcp.Server.PowerShell.OutOfProcess.SubprocessHostMode.ProcessPool))
+        {
+            lines.Add($"  process-pool : {section.ProcessPoolSize} → {section.EffectiveProcessPoolSize}");
+            lines.Add($"  min-healthy  : {section.MinHealthyForStartup} → {section.EffectiveMinHealthyForStartup}");
+        }
+
+        lines.Add($"  request-timeout: {section.RequestTimeoutSeconds:0.#}s");
+
+        var scriptStatus = section.HostScriptResolved ? "✓" : "✗";
+        lines.Add($"  host-script  : [{scriptStatus}] {section.HostScriptPath ?? "(unresolved)"}");
+        if (!section.HostScriptResolved && !string.IsNullOrWhiteSpace(section.HostScriptError))
+        {
+            lines.Add($"      error    : {section.HostScriptError}");
         }
 
         return string.Join("\n", lines);

--- a/PoshMcp.Server/PowerShell/OutOfProcess/SubprocessHostMode.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/SubprocessHostMode.cs
@@ -4,16 +4,26 @@ namespace PoshMcp.Server.PowerShell.OutOfProcess;
 /// Selects which subprocess host script is launched when
 /// <see cref="RuntimeMode"/> is <see cref="RuntimeMode.OutOfProcess"/>.
 /// </summary>
+/// <remarks>
+/// The default at the configuration layer
+/// (<see cref="PoshMcp.Server.PowerShell.PowerShellConfiguration.SubprocessHostMode"/>)
+/// is <see cref="Pool"/>. Constructor defaults on the executor itself remain
+/// <see cref="Single"/> for backward compatibility with code that constructs
+/// <see cref="OutOfProcessCommandExecutor"/> directly without specifying a mode.
+/// </remarks>
 public enum SubprocessHostMode
 {
     /// <summary>
-    /// Single runspace per subprocess (oop-host.ps1, default).
-    /// All invokes are serialized inside the host.
+    /// Single runspace per subprocess (oop-host.ps1).
+    /// All invokes are serialized inside the host. Supported as an opt-in
+    /// fallback for bisecting regressions or for callers that want the legacy
+    /// serialized behavior.
     /// </summary>
     Single,
 
     /// <summary>
-    /// Runspace pool inside a single subprocess (oop-host-pool.ps1).
+    /// Runspace pool inside a single subprocess (oop-host-pool.ps1, recommended
+    /// default at the configuration layer).
     /// Multiple invokes execute concurrently on pre-warmed runspaces.
     /// </summary>
     Pool,
@@ -21,7 +31,8 @@ public enum SubprocessHostMode
     /// <summary>
     /// Pool of N independent subprocess hosts (OutOfProcessSubprocessPool).
     /// Each request leases one host; crashes are reconciled per-slot
-    /// without disturbing other hosts.
+    /// without disturbing other hosts. Use for trust-boundary or
+    /// tail-latency-sensitive workloads.
     /// </summary>
     ProcessPool
 }

--- a/PoshMcp.Server/PowerShell/PowerShellConfiguration.cs
+++ b/PoshMcp.Server/PowerShell/PowerShellConfiguration.cs
@@ -19,14 +19,18 @@ public class PowerShellConfiguration
 
     /// <summary>
     /// Selects which OOP host topology is launched when <see cref="RuntimeMode"/> is
-    /// <see cref="RuntimeMode.OutOfProcess"/>. <see cref="SubprocessHostMode.Single"/> (default)
-    /// launches the single-runspace host (<c>oop-host.ps1</c>).
-    /// <see cref="SubprocessHostMode.Pool"/> launches a runspace-pool host
-    /// (<c>oop-host-pool.ps1</c>) that runs invokes concurrently in one subprocess.
+    /// <see cref="RuntimeMode.OutOfProcess"/>. <see cref="SubprocessHostMode.Pool"/> (default)
+    /// launches a runspace-pool host (<c>oop-host-pool.ps1</c>) that runs invokes
+    /// concurrently in one subprocess and is the recommended setting for typical
+    /// concurrent MCP workloads (see <c>specs/004-out-of-process-execution/benchmark-findings.md</c>).
+    /// <see cref="SubprocessHostMode.Single"/> launches the legacy single-runspace
+    /// host (<c>oop-host.ps1</c>) and remains supported for callers that need the
+    /// historical serialized behavior or are bisecting a regression.
     /// <see cref="SubprocessHostMode.ProcessPool"/> launches a pool of N independent
-    /// single-runspace subprocess hosts, leased per request.
+    /// single-runspace subprocess hosts, leased per request, for trust-boundary or
+    /// tail-latency-sensitive workloads.
     /// </summary>
-    public SubprocessHostMode SubprocessHostMode { get; set; } = SubprocessHostMode.Single;
+    public SubprocessHostMode SubprocessHostMode { get; set; } = SubprocessHostMode.Pool;
 
     /// <summary>
     /// Maximum number of runspaces in the pool when <see cref="SubprocessHostMode"/> is

--- a/PoshMcp.Server/appsettings.json
+++ b/PoshMcp.Server/appsettings.json
@@ -26,7 +26,9 @@
     "Performance": {
       "EnableResultCaching": false,
       "UseDefaultDisplayProperties": true
-    }
+    },
+    "SubprocessHostMode": "Pool",
+    "SubprocessRunspacePoolSize": 0
   },
   "McpResources": {
     "Resources": [

--- a/PoshMcp.Server/default.appsettings.json
+++ b/PoshMcp.Server/default.appsettings.json
@@ -20,6 +20,8 @@
     "Performance": {
       "EnableResultCaching": true,
       "UseDefaultDisplayProperties": true
-    }
+    },
+    "SubprocessHostMode": "Pool",
+    "SubprocessRunspacePoolSize": 0
   }
 }

--- a/README.md
+++ b/README.md
@@ -361,16 +361,21 @@ dotnet run --project PoshMcp.Server
 # Set PowerShellConfiguration.RuntimeMode to "OutOfProcess"
 ```
 
-### Trade-offs
+### Host Modes
 
-| Aspect | In-Process (Default) | Out-of-Process |
-|--------|----------------------|-----------------|
-| Latency | ~5 ms | ~120 ms |
-| Memory | ~250 MB | ~330–370 MB |
-| Module isolation | Shared (one failure affects all) | Isolated |
-| Complexity | Simpler | More complex |
+When `RuntimeMode` is `OutOfProcess`, the `SubprocessHostMode` setting selects the host topology:
 
-**For complete documentation, see [docs/articles/transport-modes.md](docs/articles/transport-modes.md) and [specs/out-of-process-execution.md](specs/out-of-process-execution.md).**
+| `SubprocessHostMode` | Topology | When to use |
+|----------------------|----------|-------------|
+| `Pool` (**default**) | One subprocess, runspace pool inside it | Typical concurrent MCP workloads. Best warm-invoke throughput (~4.9× over `Single` at concurrency 10 in run-3 benchmarks). |
+| `ProcessPool` | N independent single-runspace subprocesses, leased per request | Tail-latency-sensitive or trust-boundary-sensitive workloads where one runaway invoke must not affect siblings. |
+| `Single` | One subprocess with one runspace, requests serialized | Backward-compatible legacy mode. Useful for bisecting regressions or when minimal cold-start is the only metric that matters. |
+
+`Pool` is the default since the run-3 benchmark study; see [`specs/004-out-of-process-execution/benchmark-findings.md`](specs/004-out-of-process-execution/benchmark-findings.md) for the full comparison and [`specs/004-out-of-process-execution/spec.md`](specs/004-out-of-process-execution/spec.md) for the configuration surface.
+
+Run `poshmcp doctor` in `OutOfProcess` mode to see the resolved host mode, effective pool size, host script path, and any clamp warnings.
+
+**For complete documentation, see [docs/articles/transport-modes.md](docs/articles/transport-modes.md) and [`specs/004-out-of-process-execution/spec.md`](specs/004-out-of-process-execution/spec.md).**
 
 ---
 

--- a/appsettings.json
+++ b/appsettings.json
@@ -60,6 +60,8 @@
       "EnableResultCaching": true,
       "UseDefaultDisplayProperties": true
     },
-    "RuntimeMode": "OutOfProcess"
+    "RuntimeMode": "OutOfProcess",
+    "SubprocessHostMode": "Pool",
+    "SubprocessRunspacePoolSize": 0
   }
 }

--- a/specs/004-out-of-process-execution/spec.md
+++ b/specs/004-out-of-process-execution/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `004-out-of-process-execution`
 **Created**: 2026-04-17
-**Status**: Draft
+**Status**: Implemented (default `SubprocessHostMode = Pool` as of 2026-05-06, issue #196)
 **Input**: Run PowerShell commands in a separate persistent `pwsh` subprocess so that heavy or conflicting modules (Az, Microsoft.Graph) cannot crash or deadlock the MCP server
 
 ## User Scenarios & Testing *(mandatory)*
@@ -177,3 +177,37 @@ The server's doctor/health tooling MUST verify the following when `RuntimeMode` 
 - Module installation in the subprocess (`Install-Module`) requires internet access or a configured repository; the server does not manage offline module caches
 - In out-of-process mode, interactive prompt support is out of scope (see spec 003); all commands must be non-interactive
 - The subprocess host script is shipped alongside the server binary and does not require a separate installation step
+
+---
+
+## Implementation Notes (added 2026-05-06)
+
+The original spec assumed a single subprocess with one runspace and serialized requests. The implementation has expanded that surface; the original requirements still hold for the `Single` host mode and the assumption above is **superseded** by the host-mode taxonomy below.
+
+### `SubprocessHostMode`
+
+When `RuntimeMode` is `OutOfProcess`, the `PowerShellConfiguration:SubprocessHostMode` setting selects the host topology:
+
+| `SubprocessHostMode` | Topology | Notes |
+|----------------------|----------|-------|
+| `Pool` (default) | One subprocess, runspace pool inside it (`oop-host-pool.ps1`) | Default since 2026-05-06 (#196). Best concurrent warm-invoke throughput; uses a custom `PSHost` to keep `[Console]::Out` ordering safe across runspaces. Pool size is `SubprocessRunspacePoolSize` (0 = auto-size to `min(ProcessorCount, 8)`). |
+| `ProcessPool` | N independent single-runspace subprocess hosts, leased per request | For tail-latency- or trust-boundary-sensitive workloads. Pool size is `SubprocessPoolSize` (default 4); `SubprocessMinHealthyForStartup` is the gate (clamped to `[1, SubprocessPoolSize]`). |
+| `Single` | One subprocess, one runspace, serialized requests (`oop-host.ps1`) | The original spec contract. Backward compatible; useful for bisecting and for callers who care only about cold-start. |
+
+The benchmark study driving the default flip is recorded in [`benchmark-findings.md`](benchmark-findings.md) (run-3 data). Doctor (`poshmcp doctor`) reports the resolved host mode, effective pool sizes, the host-script path, and clamp warnings.
+
+### Cancellation Contract
+
+- The MCP request-side `CancellationToken` is propagated through `OutOfProcessHost.InvokeAsync` to the subprocess channel, including when the call is awaiting a response.
+- For `Pool`: when a token is cancelled, the host issues a stop request to the matching runspace and the lease is returned. The pool's effective concurrency under stuck-but-cancelled invokes is `N - in_flight_uncancelled`, not `N - stuck`.
+- For `ProcessPool`: cancellation tears down the leased subprocess and the pool spins a replacement. The remaining hosts are unaffected.
+- For `Single`: the historical timeout-and-restart behavior remains. A cancelled invoke does not preserve the host.
+- Cancellation propagation is a hard prerequisite for the `Pool` default and was wired through PR #207 prior to the default flip.
+
+### Supersedence of Original Assumptions
+
+- "One subprocess instance is created per executor" — superseded by `ProcessPool`.
+- "Concurrency is handled by serializing requests" — superseded by both `Pool` (intra-process concurrency via runspace pool) and `ProcessPool` (inter-process concurrency via lease).
+- FR-051 ("MUST serialize out-of-process tool invocations to prevent concurrent in-flight requests from corrupting the subprocess communication channel") still applies, but the unit of serialization is now the **channel writer**, not the request stream. The subprocess protocol carries a request id so the host can multiplex responses back to the correct caller.
+
+The remaining requirements (FR-044 through FR-054), success criteria, and edge cases continue to hold for all three host modes.


### PR DESCRIPTION
Closes #196

Adopts `SubprocessHostMode = Pool` as the default for out-of-process PowerShell execution and surfaces the resolved out-of-process configuration through the doctor command.

## What changed

### 1. Default flip (commit `6e0c8b1`)
- `PowerShellConfiguration.SubprocessHostMode` default: `Single` → `Pool`.
- Top-level `appsettings.json`, `PoshMcp.Server/appsettings.json`, and `default.appsettings.json` set `SubprocessHostMode = Pool` explicitly so the choice is visible to operators.
- `OutOfProcessCommandExecutor` constructor defaults remain `Single` for direct-construction call sites (tests/benchmarks). The configuration layer is the binding surface.
- Rationale: run-3 of the OOP benchmarks ([`benchmark-findings.md`](specs/004-out-of-process-execution/benchmark-findings.md)) shows `Pool` wins WarmInvoke @ concurrency 10 by 4.86× mean / 4.79× P99 over `Single`, clearing spec 004's ≥4× I/O-shaped bar.
- Hard gates: PR #201 (Pool host with custom `PSHost`) and PR #207 (cancellation propagation) landed first.

### 2. Doctor reports OOP host config (commit `5a3f838`)
New `OutOfProcess` section emitted only when `RuntimeMode = OutOfProcess`. Reports:
- Resolved `HostMode` and its source (`config (explicit)` vs `config (default)`).
- Effective `Pool` runspace size including the auto-size hint (`min(ProcessorCount, 8)` when configured size is 0).
- Effective `ProcessPool` size and clamped `MinHealthyForStartup` (capped at pool size, floored at 1).
- Per-request timeout (currently the host-side 30s default; signposted for the future config knob).
- Best-effort host script path resolution (no subprocess launch) with status flag and short error string when resolution fails.

Configuration warning sweep extended to flag negative `SubprocessRunspacePoolSize`, sub-1 `SubprocessPoolSize`, and `MinHealthyForStartup` exceeding pool size.

### 3. Docs (commit `d91e0af`)
- `README.md`: replaced trade-off table with a host-mode table (Pool default, ProcessPool for tail/trust workloads, Single for legacy/bisecting); links to `benchmark-findings.md` and the spec.
- `DOCKER.md`: added `POSHMCP_RUNTIME_MODE` to the env-var reference; called out that host topology is set in appsettings via `SubprocessHostMode`.
- `DESIGN.md`: noted new default in the execution-engine bullet.
- `specs/004-out-of-process-execution/spec.md`: flipped Status from Draft to Implemented (2026-05-06). Added Implementation Notes section covering the `SubprocessHostMode` taxonomy, cancellation contract for each mode, and supersedence of the original "one subprocess, serialized requests" assumption. FR-051 restated as channel-writer serialization with multiplexed responses.

## Tests

`dotnet test PoshMcp.Tests/PoshMcp.Tests.csproj --no-build`: **634 passed, 0 failed, 7 skipped** (the 7 skips are pre-existing OOP module integration tests gated on optional Az modules; unrelated to this PR).

No tests required adjustment for the default flip.

## Notes

- Hermes is independently re-running the run-4 benchmarks against this default to reaffirm the recommendation; that work lands separately and does not gate this PR.
- This PR does not change `OutOfProcessCommandExecutor` constructor defaults, so existing direct-construction call sites (tests, benchmarks) continue to default to `Single` until they are explicitly migrated.