### PR TITLE
docs+samples: document Pool default and SubprocessHostMode taxonomy from spec 004

### DIFF
--- a/.squad/agents/leela/history.md
+++ b/.squad/agents/leela/history.md
@@ -101,3 +101,32 @@
 
 ---
 *Further trimmed to 100 lines on 2026-05-05 by Scribe (15KB gate). Full record in `history-archive.md`.*
+
+### 2026-05-07: OOP Docs + Samples Audit (PR #210)
+
+**Task:** Audit whether spec 004 OOP changes (default flip to Pool, SubprocessHostMode taxonomy, pool sizing knobs, cancellation contract) reached the configuration docs under `./docs` and the sample `appsettings.json` files.
+
+**Verdict:** Docs — gaps (substantive). Samples — partial.
+
+**What needed updating:**
+- `docs/articles/advanced.md` — Out-of-Process section was stale: only mentioned `POSHMCP_RUNTIME_MODE=out-of-process` (wrong casing), no `SubprocessHostMode`, no Pool default, no sizing knobs, no cancellation contract.
+- `docs/articles/configuration.md` — full `appsettings.json` reference omitted `RuntimeMode` and `SubprocessHostMode` entirely.
+- `docs/articles/azure-integration.md` — described `RuntimeMode` as "sync/async". It's `InProcess` / `OutOfProcess`.
+- `examples/appsettings.advanced.json` — no PowerShell runtime tuning, despite loading `Az.*` modules.
+- `examples/appsettings.tenant.json` — no PowerShell runtime tuning, despite the multi-tenant trust-boundary use case being exactly what `ProcessPool` exists for.
+
+**What I left alone:**
+- `examples/appsettings.basic.json` — purpose is simple/learning. Adding OOP config there changes the sample's purpose.
+- `PoshMcp.Server/default.appsettings.json`, `appsettings.modules.json`, `appsettings.azure.json`, `appsettings.environment-example.json` — loaded by dev server / tests in source builds. Out of audit scope; would silently change dev runtime.
+- `README.md` / `DOCKER.md` — already updated in #208.
+- `docs/release-notes/` — release notes for the default flip belong with the release that ships it.
+
+**Key insight — when to extend an existing doc vs add a new one:**
+The task brief offered the option of creating a new "Out-of-Process Execution Modes" article. I extended `advanced.md` instead because (a) the existing OOP section was the natural home for the topic, (b) `configuration.md` already had a full `appsettings.json` reference that needed the `RuntimeMode`/`SubprocessHostMode` row added regardless, and (c) cross-linking from the brief reference in configuration.md into the deep-dive in advanced.md gives readers two natural entry points without duplicating content. Net result: one rewritten section + one new section + one fix, no new TOC entry, no content split across two articles.
+
+**Key insight — sample-rationale belongs in the README, not as JSON comments:**
+`appsettings.json` doesn't support comments. To explain why advanced.json picks `Pool` and tenant.json picks `ProcessPool`, I added a "Runtime mode" note to each sample's section in `examples/README.md` rather than trying to encode rationale in key names or duplicate the schema docs. This keeps the samples copy-pasteable as-is.
+
+**Build sanity:** `dotnet build PoshMcp.sln -c Debug` — green; only pre-existing nullable warnings.
+
+**PR:** #210 (do not merge — pending Steven's review).

--- a/docs/articles/advanced.md
+++ b/docs/articles/advanced.md
@@ -104,7 +104,7 @@ export POSHMCP_RUNTIME_MODE=OutOfProcess
 poshmcp serve --transport http
 ```
 
-The environment variable takes precedence over the config file value. Valid values: `InProcess`, `OutOfProcess`. Unrecognized values fall back to `InProcess` with a logged error.
+The environment variable takes precedence over the config file value. Valid values: `InProcess`, `OutOfProcess` (kebab-case `in-process` / `out-of-process` is also accepted by the env var and CLI). Unrecognized values cause the server to fail startup with `InvalidOperationException` (`Unsupported runtime mode '<value>'. Supported runtime modes: in-process, out-of-process.`).
 
 ### Subprocess Host Modes
 
@@ -149,11 +149,11 @@ ProcessPool example for tenant isolation:
 
 ### Cancellation
 
-The MCP request `CancellationToken` propagates into the subprocess channel for all three host modes:
+The MCP request `CancellationToken` propagates into the subprocess channel for all three host modes via a `cancel` control frame sent by `OutOfProcessHost.SendRequestAsync`. The host attempts a cooperative `BeginStop` on the in-flight pipeline; the .NET awaiter completes with `OperationCanceledException` immediately without waiting for the host to acknowledge. Per-mode behavior:
 
-- `Pool`: cancellation issues a stop request to the matching runspace and returns the lease. Pool capacity under stuck-but-cancelled invokes is `N - in_flight_uncancelled`.
-- `ProcessPool`: cancellation tears down the leased subprocess; the pool spins a replacement. Other hosts are unaffected.
-- `Single`: cancellation kills the host; the historical timeout-and-restart behavior applies.
+- `Pool`: `PoolDispatcher` looks up the active `[powershell]` instance by request id and calls `BeginStop` on it. The runspace is returned to the pool when the pipeline unwinds, so pool capacity recovers without restart. Pool capacity under stuck-but-cancelled invokes is `N - in_flight_uncancelled`.
+- `ProcessPool`: each leased host runs the Single-mode script and inherits the same soft-cancel via the inherited `OutOfProcessHost` cancel frame. If the host honors `BeginStop`, the slot stays healthy and is returned to the pool; other hosts are unaffected. The existing per-request kill-on-timeout path in `OutOfProcessSubprocessPool` remains as a backstop for wedged hosts (e.g., a cmdlet stuck in unmanaged code) that do not honor `BeginStop` within the per-request timeout.
+- `Single`: `SingleDispatcher` runs the invoke on a background dispatcher thread and calls `BeginStop` on the matching `[powershell]` instance when the cancel frame arrives. The host stays healthy for follow-up requests; the per-request timeout serves as the backstop and recycles the host only if `BeginStop` does not unwind the pipeline in time.
 
 ### Diagnostics
 

--- a/docs/articles/advanced.md
+++ b/docs/articles/advanced.md
@@ -83,14 +83,81 @@ docker build \
 
 ## Out-of-Process PowerShell
 
-Run PowerShell in a separate process for better module isolation:
+Run PowerShell in a separate `pwsh` subprocess so that heavy or conflicting modules (Az, Microsoft.Graph) cannot crash or destabilize the MCP server. Requires PowerShell 7.x on `PATH`.
+
+### Enable Out-of-Process Mode
+
+Set `RuntimeMode` in `appsettings.json`:
+
+```json
+{
+  "PowerShellConfiguration": {
+    "RuntimeMode": "OutOfProcess"
+  }
+}
+```
+
+Or via environment variable:
 
 ```bash
-export POSHMCP_RUNTIME_MODE=out-of-process
+export POSHMCP_RUNTIME_MODE=OutOfProcess
 poshmcp serve --transport http
 ```
 
-Requires PowerShell 7.x for out-of-process mode.
+The environment variable takes precedence over the config file value. Valid values: `InProcess`, `OutOfProcess`. Unrecognized values fall back to `InProcess` with a logged error.
+
+### Subprocess Host Modes
+
+When `RuntimeMode` is `OutOfProcess`, `SubprocessHostMode` selects the subprocess topology:
+
+| `SubprocessHostMode` | Topology | When to use |
+|----------------------|----------|-------------|
+| `Pool` (default) | One subprocess, runspace pool inside it | Default since 2026-05-06. Best concurrent warm-invoke throughput; recommended for typical MCP workloads. |
+| `ProcessPool` | N independent single-runspace subprocess hosts, leased per request | Trust-boundary or tail-latency-sensitive workloads. Crashes are reconciled per slot without disturbing other hosts. |
+| `Single` | One subprocess, one runspace, serialized requests | Backward-compatible legacy mode. Useful for bisecting regressions or when only cold-start latency matters. |
+
+The default flip from `Single` to `Pool` was driven by benchmark study — `Pool` posted ~4.86× warm-invoke throughput at concurrency 10 versus `Single`. See [`specs/004-out-of-process-execution/benchmark-findings.md`](https://github.com/usepowershell/PoshMcp/blob/main/specs/004-out-of-process-execution/benchmark-findings.md) for full data.
+
+### Pool Sizing
+
+```json
+{
+  "PowerShellConfiguration": {
+    "RuntimeMode": "OutOfProcess",
+    "SubprocessHostMode": "Pool",
+    "SubprocessRunspacePoolSize": 0
+  }
+}
+```
+
+- `SubprocessRunspacePoolSize` (Pool mode): runspaces in the pool. `0` (default) auto-sizes to `min(ProcessorCount, 8)`. Ignored in `Single` and `ProcessPool` modes.
+- `SubprocessPoolSize` (ProcessPool mode): independent subprocess hosts to launch. Default `4`.
+- `SubprocessMinHealthyForStartup` (ProcessPool mode): minimum healthy hosts required for the pool to start. Clamped to `[1, SubprocessPoolSize]`. Default `1`.
+
+ProcessPool example for tenant isolation:
+
+```json
+{
+  "PowerShellConfiguration": {
+    "RuntimeMode": "OutOfProcess",
+    "SubprocessHostMode": "ProcessPool",
+    "SubprocessPoolSize": 4,
+    "SubprocessMinHealthyForStartup": 2
+  }
+}
+```
+
+### Cancellation
+
+The MCP request `CancellationToken` propagates into the subprocess channel for all three host modes:
+
+- `Pool`: cancellation issues a stop request to the matching runspace and returns the lease. Pool capacity under stuck-but-cancelled invokes is `N - in_flight_uncancelled`.
+- `ProcessPool`: cancellation tears down the leased subprocess; the pool spins a replacement. Other hosts are unaffected.
+- `Single`: cancellation kills the host; the historical timeout-and-restart behavior applies.
+
+### Diagnostics
+
+`poshmcp doctor` reports the resolved host mode, effective pool sizes, host-script path, and any clamp warnings under Runtime Settings.
 
 ## Dynamic Tool Reloading
 

--- a/docs/articles/azure-integration.md
+++ b/docs/articles/azure-integration.md
@@ -85,7 +85,7 @@ These settings from your server's `appsettings.json` are automatically converted
 
 - **PowerShellConfiguration.CommandNames** — Exposed PowerShell functions
 - **PowerShellConfiguration.Modules** — Preinstalled modules
-- **PowerShellConfiguration.RuntimeMode** — Execution mode (sync/async)
+- **PowerShellConfiguration.RuntimeMode** — Execution mode (`InProcess` or `OutOfProcess`; `OutOfProcess` runs commands in a `pwsh` subprocess for module isolation)
 - **Logging settings** — Log levels and sinks
 - **Authentication settings** — Identity provider configuration
 - **Health check configuration** — Diagnostics and monitoring

--- a/docs/articles/configuration.md
+++ b/docs/articles/configuration.md
@@ -120,10 +120,30 @@ Full configuration structure:
       "EnableResultCaching": false,
       "UseDefaultDisplayProperties": true
     },
-    "EnableDynamicReloadTools": false
+    "EnableDynamicReloadTools": false,
+    "RuntimeMode": "InProcess",
+    "SubprocessHostMode": "Pool",
+    "SubprocessRunspacePoolSize": 0
   }
 }
 ```
+
+### Runtime Mode
+
+`PowerShellConfiguration.RuntimeMode` selects whether commands execute in-process (default) or in a separate `pwsh` subprocess:
+
+- `InProcess` (default) — embedded PowerShell SDK; lowest overhead.
+- `OutOfProcess` — commands run in a managed `pwsh` subprocess for module isolation. Recommended when loading heavy modules such as `Az.*` or `Microsoft.Graph.*`.
+
+When `RuntimeMode` is `OutOfProcess`, `SubprocessHostMode` selects the subprocess topology (`Pool` is the default since 2026-05-06):
+
+| `SubprocessHostMode` | When to use |
+|----------------------|-------------|
+| `Pool` (default) | Best concurrent throughput; recommended for typical MCP workloads. |
+| `ProcessPool` | Trust-boundary or tail-latency-sensitive workloads. |
+| `Single` | Backward-compatible serialized mode; useful for bisecting regressions. |
+
+See [Advanced Configuration → Out-of-Process PowerShell](advanced.md#out-of-process-powershell) for sizing options (`SubprocessRunspacePoolSize`, `SubprocessPoolSize`, `SubprocessMinHealthyForStartup`), the cancellation contract, and the benchmark study driving the default.
 
 ## Environment Variables
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -304,6 +304,8 @@ Full-featured configuration with Azure integration:
 - Advanced module usage
 - Pattern-based function filtering
 
+**Runtime mode:** This sample sets `RuntimeMode: "OutOfProcess"` with `SubprocessHostMode: "Pool"` (the recommended default since 2026-05-06). Heavy modules such as `Az.*` benefit from subprocess isolation, and the runspace pool delivers the best concurrent throughput for typical MCP workloads. Pool size auto-tunes to `min(ProcessorCount, 8)` when `SubprocessRunspacePoolSize` is `0`. See [Advanced Configuration → Out-of-Process PowerShell](../docs/articles/advanced.md#out-of-process-powershell) for the full taxonomy.
+
 ### appsettings.tenant.json
 
 Multi-tenant configuration:
@@ -327,6 +329,8 @@ Multi-tenant configuration:
 - Tenant-specific initialization
 - Per-tenant module management
 - Isolated PowerShell runspaces per tenant
+
+**Runtime mode:** This sample sets `RuntimeMode: "OutOfProcess"` with `SubprocessHostMode: "ProcessPool"` (`SubprocessPoolSize: 4`, `SubprocessMinHealthyForStartup: 2`). `ProcessPool` leases an independent `pwsh` subprocess per request, which gives each tenant invocation hard process isolation and per-slot crash recovery — the right tradeoff when trust boundaries between callers matter more than peak throughput. Tune `SubprocessPoolSize` to your expected concurrency. See [Advanced Configuration → Out-of-Process PowerShell](../docs/articles/advanced.md#out-of-process-powershell).
 
 ## Startup Scripts Explained
 

--- a/examples/appsettings.advanced.json
+++ b/examples/appsettings.advanced.json
@@ -13,6 +13,9 @@
     "ExcludePatterns": [],
     "IncludePatterns": [],
     "EnableDynamicReloadTools": true,
+    "RuntimeMode": "OutOfProcess",
+    "SubprocessHostMode": "Pool",
+    "SubprocessRunspacePoolSize": 0,
     "Environment": {
       "InstallModules": [
         {

--- a/examples/appsettings.tenant.json
+++ b/examples/appsettings.tenant.json
@@ -12,6 +12,10 @@
     "ExcludePatterns": [],
     "IncludePatterns": [],
     "EnableDynamicReloadTools": false,
+    "RuntimeMode": "OutOfProcess",
+    "SubprocessHostMode": "ProcessPool",
+    "SubprocessPoolSize": 4,
+    "SubprocessMinHealthyForStartup": 2,
     "Environment": {
       "InstallModules": [],
       "ImportModules": [


### PR DESCRIPTION
## Summary

Audit of whether the OOP configuration changes from spec 004 (default flip to `Pool`, new `SubprocessHostMode` taxonomy, pool sizing knobs) reached the docs and the sample `appsettings.json` files.

**Verdict per question**

- **Configuration docs (`./docs`)** — gaps existed. `advanced.md` had a stale Out-of-Process section that mentioned only the `POSHMCP_RUNTIME_MODE` env var (with the wrong casing) and made no mention of `SubprocessHostMode`, the Pool default, sizing knobs, or the cancellation contract. `configuration.md` had a full `appsettings.json` reference that omitted `RuntimeMode`/`SubprocessHostMode` entirely. `azure-integration.md` described `RuntimeMode` as "sync/async" — it's `InProcess`/`OutOfProcess`.
- **Sample `appsettings.json` files** — partial. Root `appsettings.json` and `PoshMcp.Server/appsettings.json` were already current. `examples/appsettings.advanced.json` and `examples/appsettings.tenant.json` had no `PowerShell` runtime tuning at all despite being the two samples whose use cases (heavy Az modules; multi-tenant) are exactly what the OOP modes exist for.

## What changed

**Docs (commit `ca0ef07`)**
- `docs/articles/advanced.md` — rewrote the **Out-of-Process PowerShell** section: full `SubprocessHostMode` table, sizing options (`SubprocessRunspacePoolSize` / `SubprocessPoolSize` / `SubprocessMinHealthyForStartup`), cancellation contract per mode, a `ProcessPool` example, link to `specs/004-out-of-process-execution/benchmark-findings.md`, and a note that `poshmcp doctor` reports the resolved settings.
- `docs/articles/configuration.md` — added a **Runtime Mode** section to the `appsettings.json` reference with the host-mode summary table, cross-linked to `advanced.md` for sizing/cancellation/benchmark detail.
- `docs/articles/azure-integration.md` — fixed the stale `PowerShellConfiguration.RuntimeMode` description.

**Samples (commit `ce3c311`)**
- `examples/appsettings.advanced.json` — added `RuntimeMode: "OutOfProcess"` + `SubprocessHostMode: "Pool"` + `SubprocessRunspacePoolSize: 0` (auto-size). Matches the recommended default; this sample loads `Az.*` modules.
- `examples/appsettings.tenant.json` — added `RuntimeMode: "OutOfProcess"` + `SubprocessHostMode: "ProcessPool"` + `SubprocessPoolSize: 4` + `SubprocessMinHealthyForStartup: 2`. Per-tenant process isolation matches the trust-boundary use case `ProcessPool` exists for.
- `examples/README.md` — added a "Runtime mode" note under each updated sample explaining why it picks that mode, with a link to `docs/articles/advanced.md#out-of-process-powershell`.

## What was intentionally left alone

- `examples/appsettings.basic.json` — purpose is simple/learning. Per the audit instructions, do not add OOP config to samples whose purpose doesn't include runtime tuning.
- `PoshMcp.Server/default.appsettings.json`, `appsettings.modules.json`, `appsettings.azure.json`, `appsettings.environment-example.json` — these are loaded by the dev server / tests in source builds. Not adding OOP keys to avoid changing dev/test runtime behavior outside the scope of this audit.
- `README.md`, `DOCKER.md` — already updated in #208 (per task brief).
- `docs/release-notes/` — release-notes for the default flip belong with the release that ships it; not in scope for this audit.

## Build sanity

`dotnet build PoshMcp.sln -c Debug` — green; only the pre-existing nullable-reference warnings.

## Spec cross-reference

- `specs/004-out-of-process-execution/spec.md` § Implementation Notes (added 2026-05-06)
- `specs/004-out-of-process-execution/benchmark-findings.md` (run-3 study; ~4.86× warm-throughput Pool vs Single)
- `PoshMcp.Server/PowerShell/PowerShellConfiguration.cs` (canonical schema)

⚠️ Do not merge — pending Steven's review.
