### PR TITLE
docs: fix misleading RemoteToolSchema XML doc (#233)

### DIFF
--- a/PoshMcp.Server/PowerShell/OutOfProcess/RemoteToolSchema.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/RemoteToolSchema.cs
@@ -14,7 +14,12 @@ public class RemoteToolSchema
     public string Name { get; set; } = string.Empty;
 
     /// <summary>
-    /// Human-readable description (from Get-Help or parameter set syntax).
+    /// Human-readable description for the command. Populated by the OOP host
+    /// from <c>Get-Help</c>'s <c>.Synopsis</c> field (trimmed, and only when
+    /// it differs from the command name); otherwise the empty string. The
+    /// long <c>Description</c> body and parameter set syntax are NOT read.
+    /// When empty, downstream tool schema generation falls back to the bare
+    /// command name.
     /// </summary>
     public string Description { get; set; } = string.Empty;
 


### PR DESCRIPTION
Closes #233

Corrects XML doc on RemoteToolSchema.Description to match current OOP behavior per FR-560 (spec 010 step 10). Doc-only change, no runtime impact.

The previous text claimed the field came from `Get-Help` *or* parameter set syntax. In reality, the OOP host (`oop-host-pool.ps1` ~L824-829) only reads `Get-Help .Synopsis`, trims it, and assigns it when it differs from the command name; otherwise the field is the empty string (which downstream becomes the bare command name).

No other stale property docs spotted in this file.

Reviewers: Farnsworth + Cubert (squad).