### PR TITLE
test: pre-spec010 tools/list snapshots (#224)

### DIFF
--- a/PoshMcp.Tests/Fixtures/Modules/HelpParityFixture/HelpParityFixture.psd1
+++ b/PoshMcp.Tests/Fixtures/Modules/HelpParityFixture/HelpParityFixture.psd1
@@ -1,0 +1,19 @@
+@{
+    RootModule        = 'HelpParityFixture.psm1'
+    ModuleVersion     = '1.0.0'
+    GUID              = 'a2f4d9e0-3c1b-4a8f-9d27-3b1f5d8c7a01'
+    Author            = 'PoshMcp'
+    Description       = 'Deterministic fixture module for spec 010 description-source precedence and parity tests.'
+    PowerShellVersion = '5.1'
+    FunctionsToExport = @(
+        'Get-FixtureSynopsisOnly',
+        'Get-FixtureFullHelp',
+        'Get-FixtureHelpMessageOnly',
+        'Get-FixtureValidateSetScalar',
+        'Get-FixtureValidateSetArray',
+        'Get-FixtureBare'
+    )
+    CmdletsToExport   = @()
+    VariablesToExport = @()
+    AliasesToExport   = @()
+}

--- a/PoshMcp.Tests/Fixtures/Modules/HelpParityFixture/HelpParityFixture.psm1
+++ b/PoshMcp.Tests/Fixtures/Modules/HelpParityFixture/HelpParityFixture.psm1
@@ -1,0 +1,103 @@
+# HelpParityFixture
+#
+# Deterministic PowerShell fixture used by spec 010 (Improve MCP Tool
+# Self-Documentation) to exercise the FR-500 / FR-510 description-source
+# precedence chains and verify path parity (FR-520 / FR-521).
+#
+# Each exported function targets one rung of the precedence chain. The
+# behavior of the function body is irrelevant; only its metadata
+# (synopsis, description, parameter help, attributes) matters.
+
+function Get-FixtureSynopsisOnly {
+    <#
+    .SYNOPSIS
+    Returns a fixed sentinel string; exercises FR-500 step 1 (synopsis only, no description, no parameters).
+    #>
+    [CmdletBinding()]
+    param()
+    'synopsis-only'
+}
+
+function Get-FixtureFullHelp {
+    <#
+    .SYNOPSIS
+    Returns the input echoed back; exercises FR-500 step 2 and FR-510 step 1.
+
+    .DESCRIPTION
+    Long-form description for the fixture function. The body intentionally
+    spans multiple paragraphs so that the FR-540 sanitization rules
+    (paragraph separator preservation, intra-paragraph whitespace collapse)
+    can be exercised end-to-end.
+
+    Second paragraph deliberately uses irregular spacing    and  tabs to
+    confirm collapse behavior is consistent across in-process and OOP
+    runspaces regardless of host buffer width.
+
+    .PARAMETER Message
+    The text to echo back to the caller. Used to verify that per-parameter
+    `.PARAMETER` help blocks (FR-510 step 1) are surfaced into the MCP
+    parameter description.
+
+    .PARAMETER Count
+    How many times the message should be repeated. Demonstrates a second
+    `.PARAMETER` block on the same command.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Message,
+
+        [Parameter()]
+        [int]$Count = 1
+    )
+    1..$Count | ForEach-Object { $Message }
+}
+
+function Get-FixtureHelpMessageOnly {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, HelpMessage = 'The user identifier to look up. Sourced from the HelpMessage attribute.')]
+        [string]$UserId,
+
+        [Parameter(HelpMessage = 'Optional region hint used to narrow the lookup. Also from HelpMessage.')]
+        [string]$Region
+    )
+    [pscustomobject]@{ UserId = $UserId; Region = $Region }
+}
+
+function Get-FixtureValidateSetScalar {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Red', 'Green', 'Blue')]
+        [string]$Color
+    )
+    $Color
+}
+
+function Get-FixtureValidateSetArray {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('North', 'South', 'East', 'West')]
+        [string[]]$Directions
+    )
+    $Directions
+}
+
+function Get-FixtureBare {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]$Anything
+    )
+    $Anything
+}
+
+Export-ModuleMember -Function `
+    Get-FixtureSynopsisOnly, `
+    Get-FixtureFullHelp, `
+    Get-FixtureHelpMessageOnly, `
+    Get-FixtureValidateSetScalar, `
+    Get-FixtureValidateSetArray, `
+    Get-FixtureBare

--- a/specs/010-tool-self-documentation/baseline/README.md
+++ b/specs/010-tool-self-documentation/baseline/README.md
@@ -1,0 +1,136 @@
+# Spec 010 — Pre-change `tools/list` Baseline Snapshots
+
+This directory holds the **pre-implementation** `tools/list` snapshots required
+by FR-550 of [spec 010 — Improve MCP Tool Self-Documentation](../spec.md). They
+freeze the existing PoshMcp behavior for both runtime modes so that the
+post-implementation regression test (`ToolDescriptionRegressionTests`) can
+verify the FR-550 backward-compatibility guarantee: every command whose
+pre-change description was a non-empty `Get-Help` `.Synopsis` MUST surface
+that exact synopsis or a strict superset post-change.
+
+## Files
+
+| File | Contents |
+|------|----------|
+| `inprocess-tools-list.json` | Full JSON-RPC `tools/list` response from the in-process runtime path. |
+| `oop-tools-list.json` | Full JSON-RPC `tools/list` response from the out-of-process runtime path (Pool host mode). |
+| `capture-snapshots.ps1` | Reproducible capture script. Re-run to regenerate. |
+
+Both JSON files are the **complete** JSON-RPC envelope (`{ jsonrpc, id, result }`)
+pretty-printed with 2-space indent and LF line endings for diff-friendly review.
+Tests should project to `result.tools[]` when asserting.
+
+## Reference module set
+
+Per FR-550 step 1 — at minimum `Microsoft.PowerShell.Management` plus the
+`HelpParityFixture` module:
+
+- `Microsoft.PowerShell.Management` — ships with PowerShell; supplies the
+  general-purpose cmdlet corpus (Get-Process, Get-Item, etc.).
+- `HelpParityFixture` — fixture module at
+  [`PoshMcp.Tests/Fixtures/Modules/HelpParityFixture/`](../../../PoshMcp.Tests/Fixtures/Modules/HelpParityFixture/),
+  introduced alongside this baseline to exercise the FR-500 / FR-510
+  precedence chains. It exports six deterministic functions:
+  - `Get-FixtureSynopsisOnly` (FR-500 step 1)
+  - `Get-FixtureFullHelp` (FR-500 step 2 + FR-510 step 1)
+  - `Get-FixtureHelpMessageOnly` (FR-510 step 2)
+  - `Get-FixtureValidateSetScalar` (FR-510 step 3 singleton)
+  - `Get-FixtureValidateSetArray` (FR-510 step 3 array)
+  - `Get-FixtureBare` (FR-500 step 3/4 + FR-510 step 4 fallbacks)
+
+## Capture metadata
+
+| | |
+|---|---|
+| Capture date | 2026-05-12 |
+| Server SHA | `16878b84` (`squad/224-toolslist-snapshots` HEAD before this commit) |
+| OS | Windows |
+| .NET | 10 (Release build) |
+| PowerShell | pwsh 7.x (host default) |
+| In-process tool count | 133 |
+| Out-of-process tool count | 144 |
+| Fixture tools present in both modes | 6 |
+
+The tool-count delta (133 vs 144) is itself a pre-change parity artifact:
+the two runtime paths today expose slightly different command surfaces for
+the same configured module set. Spec 010 does not undertake to close that
+gap (FR-551 explicitly keeps tool **names** stable; tool **descriptions**
+are what spec 010 normalizes). The regression assertion is per-tool — it
+matches tools by name across the two snapshots and ignores tools that
+exist in only one side.
+
+## How the snapshots were captured
+
+```powershell
+# From the repository root, after building PoshMcp.Server in Release:
+pwsh -NoProfile -File specs/010-tool-self-documentation/baseline/capture-snapshots.ps1
+```
+
+The script:
+
+1. Builds `PoshMcp.Server` in `Release` configuration.
+2. For each runtime mode (`InProcess`, then `OutOfProcess`):
+   - Writes a temporary `appsettings.json` that loads the reference
+     module set and lists the fixture functions in `CommandNames`.
+   - Sets `PSModulePath` for the spawned process so the in-process
+     runspace auto-loads `HelpParityFixture`.
+   - Launches `dotnet PoshMcp.dll serve --transport stdio` and speaks
+     MCP JSON-RPC 2.0 over stdio: `initialize` →
+     `notifications/initialized` → `tools/list`.
+   - Persists the complete `tools/list` JSON-RPC envelope (pretty-printed)
+     to the corresponding `*-tools-list.json` file.
+
+The script uses no test framework and depends only on `pwsh 7+` and the
+`dotnet` CLI; running it is the canonical way to regenerate the baseline.
+
+## When to regenerate
+
+The baseline is **not** intended to be regenerated after spec 010 lands —
+that would defeat the purpose of pinning pre-change behavior. Regenerate
+**only** if:
+
+1. The fixture module (`HelpParityFixture`) changes in a way that affects
+   discovered command count or synopsis text (e.g., adding/removing
+   exported functions). In that case, regenerate before any spec-010
+   description-source work begins and update the regression test to match.
+2. The reference module set is intentionally extended to cover additional
+   precedence cases not represented by the current fixture.
+
+After spec 010 implementation lands, snapshots in this directory are
+read-only inputs to the regression test.
+
+## Manual capture (out-of-script reference)
+
+For debugging the capture flow, the equivalent manual sequence is:
+
+```powershell
+$config = @{
+    Logging = @{ LogLevel = @{ Default = 'Warning' } }
+    PowerShellConfiguration = @{
+        RuntimeMode  = 'InProcess'   # or 'OutOfProcess'
+        CommandNames = @(
+            'Get-FixtureSynopsisOnly','Get-FixtureFullHelp',
+            'Get-FixtureHelpMessageOnly','Get-FixtureValidateSetScalar',
+            'Get-FixtureValidateSetArray','Get-FixtureBare')
+        Modules         = @('Microsoft.PowerShell.Management','HelpParityFixture')
+        IncludePatterns = @('*')
+        ExcludePatterns = @()
+        Environment     = @{
+            ModulePaths   = @('<repo>/PoshMcp.Tests/Fixtures/Modules')
+            ImportModules = @('HelpParityFixture')
+        }
+    }
+} | ConvertTo-Json -Depth 10
+$config | Set-Content tmp.json -Encoding utf8
+
+$env:PSModulePath = "<repo>/PoshMcp.Tests/Fixtures/Modules;$env:PSModulePath"
+$psi = [System.Diagnostics.ProcessStartInfo]@{
+    FileName = 'dotnet'
+    Arguments = '<repo>/PoshMcp.Server/bin/Release/net10.0/PoshMcp.dll serve --config tmp.json --transport stdio --log-level Warning'
+    RedirectStandardInput = $true; RedirectStandardOutput = $true
+    UseShellExecute = $false
+}
+# ... then write initialize/notifications/initialized/tools/list JSON-RPC
+# frames to stdin and read responses from stdout. See capture-snapshots.ps1
+# for the working implementation.
+```

--- a/specs/010-tool-self-documentation/baseline/capture-snapshots.ps1
+++ b/specs/010-tool-self-documentation/baseline/capture-snapshots.ps1
@@ -1,0 +1,282 @@
+#requires -Version 7.0
+<#
+.SYNOPSIS
+    Captures pre-spec-010 baseline `tools/list` snapshots for both runtime modes.
+
+.DESCRIPTION
+    Implements FR-550 step 1: for each of `InProcess` and `OutOfProcess` runtime
+    modes, this script launches the PoshMcp server over stdio, completes the MCP
+    initialization handshake, sends `tools/list`, and persists the pretty-printed
+    response under `specs/010-tool-self-documentation/baseline/{mode}-tools-list.json`.
+
+    The reference module set is:
+      - `Microsoft.PowerShell.Management` (ships with PowerShell)
+      - `HelpParityFixture` (PoshMcp.Tests/Fixtures/Modules/HelpParityFixture)
+
+.NOTES
+    Run from the repository root. The server is built once in Release before
+    capture. Each capture run uses a temporary appsettings.json so the live
+    repo configuration is not modified.
+#>
+[CmdletBinding()]
+param(
+    [string]$RepoRoot = (Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))),
+    [int]$ResponseTimeoutSeconds = 90
+)
+
+$ErrorActionPreference = 'Stop'
+
+$serverProject = Join-Path $RepoRoot 'PoshMcp.Server' 'PoshMcp.csproj'
+$serverAssembly = Join-Path $RepoRoot 'PoshMcp.Server' 'bin' 'Release' 'net10.0' 'PoshMcp.dll'
+$baselineDir = Join-Path $RepoRoot 'specs' '010-tool-self-documentation' 'baseline'
+$fixtureModule = Join-Path $RepoRoot 'PoshMcp.Tests' 'Fixtures' 'Modules' 'HelpParityFixture' 'HelpParityFixture.psd1'
+
+if (-not (Test-Path -Path $fixtureModule -PathType Leaf)) {
+    throw "Fixture module not found at $fixtureModule"
+}
+
+Write-Host "Building PoshMcp.Server (Release)..." -ForegroundColor Cyan
+& dotnet build $serverProject -c Release --nologo -v:quiet | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    throw "Server build failed with exit code $LASTEXITCODE"
+}
+if (-not (Test-Path -Path $serverAssembly -PathType Leaf)) {
+    throw "Server assembly not produced at $serverAssembly"
+}
+
+if (-not (Test-Path -Path $baselineDir)) {
+    New-Item -Path $baselineDir -ItemType Directory -Force | Out-Null
+}
+
+function New-CaptureAppSettings {
+    param(
+        [Parameter(Mandatory)][string]$RuntimeMode,
+        [Parameter(Mandatory)][string]$FixturePath
+    )
+
+    $fixtureParent = Split-Path -Parent (Split-Path -Parent $FixturePath)
+
+    $config = [ordered]@{
+        Logging = [ordered]@{
+            LogLevel = [ordered]@{
+                Default = 'Warning'
+            }
+        }
+        PowerShellConfiguration = [ordered]@{
+            RuntimeMode = $RuntimeMode
+            # CommandNames lists the fixture functions explicitly so the
+            # in-process discovery path triggers PowerShell command auto-
+            # loading from PSModulePath (the fixture root is appended to
+            # PSModulePath in the spawn environment, see Invoke-Capture).
+            # The OOP path also honours functionNames, so listing them here
+            # makes both modes see the same fixture command set.
+            CommandNames = @(
+                'Get-FixtureSynopsisOnly',
+                'Get-FixtureFullHelp',
+                'Get-FixtureHelpMessageOnly',
+                'Get-FixtureValidateSetScalar',
+                'Get-FixtureValidateSetArray',
+                'Get-FixtureBare'
+            )
+            Modules = @(
+                'Microsoft.PowerShell.Management',
+                'HelpParityFixture'
+            )
+            ExcludePatterns = @()
+            # `*` is required by the OOP discovery path (see oop-host.ps1
+            # Invoke-DiscoverHandler) to enumerate all commands in the
+            # imported modules. The in-process path treats the same value
+            # as the no-filter default, so the two modes see the same
+            # effective command set.
+            IncludePatterns = @('*')
+            EnableDynamicReloadTools = $false
+            EnableConfigurationTroubleshootingTool = $false
+            Performance = [ordered]@{
+                EnableResultCaching = $false
+                UseDefaultDisplayProperties = $true
+            }
+            SubprocessHostMode = 'Pool'
+            Environment = [ordered]@{
+                # ModulePaths is consumed by the OOP setup handler and pushes
+                # the fixture root onto the subprocess PSModulePath. The
+                # in-process path picks up the same path via the spawn-time
+                # PSModulePath environment variable set in Invoke-Capture.
+                ModulePaths = @($fixtureParent)
+                ImportModules = @('HelpParityFixture')
+            }
+        }
+        McpServer = [ordered]@{
+            IdleSessionTimeoutSeconds = 60
+        }
+        Authentication = [ordered]@{
+            Enabled = $false
+        }
+    }
+
+    $temp = [System.IO.Path]::GetTempFileName()
+    $jsonPath = [System.IO.Path]::ChangeExtension($temp, '.json')
+    Remove-Item -Path $temp -Force -ErrorAction SilentlyContinue
+    $config | ConvertTo-Json -Depth 10 | Set-Content -Path $jsonPath -Encoding utf8
+    return $jsonPath
+}
+
+function Invoke-Capture {
+    param(
+        [Parameter(Mandatory)][string]$RuntimeMode,
+        [Parameter(Mandatory)][string]$ConfigPath,
+        [Parameter(Mandatory)][string]$OutputPath,
+        [Parameter(Mandatory)][string]$FixtureModuleRoot
+    )
+
+    Write-Host "Capturing tools/list for runtime mode '$RuntimeMode'..." -ForegroundColor Cyan
+
+    $psi = [System.Diagnostics.ProcessStartInfo]::new()
+    $psi.FileName = 'dotnet'
+    $psi.ArgumentList.Add($serverAssembly)
+    $psi.ArgumentList.Add('serve')
+    $psi.ArgumentList.Add('--config')
+    $psi.ArgumentList.Add($ConfigPath)
+    $psi.ArgumentList.Add('--transport')
+    $psi.ArgumentList.Add('stdio')
+    $psi.ArgumentList.Add('--log-level')
+    $psi.ArgumentList.Add('Warning')
+    $psi.RedirectStandardInput = $true
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.UseShellExecute = $false
+    $psi.WorkingDirectory = $RepoRoot
+
+    # Prepend the fixture module root to PSModulePath so the in-process
+    # PowerShell runspace auto-loads HelpParityFixture by simple name.
+    $existingPSModulePath = $env:PSModulePath
+    $sep = [System.IO.Path]::PathSeparator
+    $effectivePSModulePath = if ([string]::IsNullOrEmpty($existingPSModulePath)) {
+        $FixtureModuleRoot
+    } else {
+        "$FixtureModuleRoot$sep$existingPSModulePath"
+    }
+    $psi.EnvironmentVariables['PSModulePath'] = $effectivePSModulePath
+
+    $proc = [System.Diagnostics.Process]::Start($psi)
+
+    $stderrBuf = [System.Text.StringBuilder]::new()
+    $errReader = Register-ObjectEvent -InputObject $proc -EventName ErrorDataReceived -Action {
+        if ($null -ne $EventArgs.Data) {
+            [void]$Event.MessageData.AppendLine($EventArgs.Data)
+        }
+    } -MessageData $stderrBuf
+    $proc.BeginErrorReadLine()
+
+    try {
+        $send = {
+            param([object]$Payload)
+            $line = ($Payload | ConvertTo-Json -Depth 20 -Compress)
+            $proc.StandardInput.WriteLine($line)
+            $proc.StandardInput.Flush()
+        }
+
+        & $send @{
+            jsonrpc = '2.0'
+            id = 1
+            method = 'initialize'
+            params = @{
+                protocolVersion = '2024-11-05'
+                capabilities = @{ tools = @{} }
+                clientInfo = @{ name = 'spec010-baseline-capture'; version = '1.0.0' }
+            }
+        }
+
+        $initResp = $null
+        $deadline = [DateTime]::UtcNow.AddSeconds($ResponseTimeoutSeconds)
+        while ([DateTime]::UtcNow -lt $deadline) {
+            $line = $proc.StandardOutput.ReadLine()
+            if ($null -eq $line) { break }
+            if ([string]::IsNullOrWhiteSpace($line)) { continue }
+            try {
+                $parsed = $line | ConvertFrom-Json -Depth 50
+                if ($parsed.id -eq 1 -and $parsed.result) {
+                    $initResp = $parsed
+                    break
+                }
+            } catch {
+                # Ignore non-JSON lines
+            }
+        }
+        if ($null -eq $initResp) {
+            throw "Did not receive initialize response within $ResponseTimeoutSeconds seconds"
+        }
+
+        & $send @{
+            jsonrpc = '2.0'
+            method = 'notifications/initialized'
+        }
+
+        & $send @{
+            jsonrpc = '2.0'
+            id = 2
+            method = 'tools/list'
+        }
+
+        $listResp = $null
+        $deadline = [DateTime]::UtcNow.AddSeconds($ResponseTimeoutSeconds)
+        while ([DateTime]::UtcNow -lt $deadline) {
+            $line = $proc.StandardOutput.ReadLine()
+            if ($null -eq $line) { break }
+            if ([string]::IsNullOrWhiteSpace($line)) { continue }
+            try {
+                $parsed = $line | ConvertFrom-Json -Depth 50
+                if ($parsed.id -eq 2 -and $parsed.result) {
+                    $listResp = $parsed
+                    break
+                }
+            } catch {
+                # Ignore non-JSON lines (e.g. log output that slipped through)
+            }
+        }
+        if ($null -eq $listResp) {
+            throw "Did not receive tools/list response within $ResponseTimeoutSeconds seconds"
+        }
+
+        # Persist the full JSON-RPC envelope (jsonrpc + id + result) for diff-friendly
+        # snapshotting; consumers can project to .result.tools if needed.
+        $pretty = $listResp | ConvertTo-Json -Depth 50
+        # Force LF line endings + 2-space indent so the file is stable across hosts.
+        $pretty = $pretty -replace "`r`n", "`n"
+        Set-Content -Path $OutputPath -Value $pretty -Encoding utf8NoBOM -NoNewline
+        Write-Host "  → wrote $OutputPath ($(($listResp.result.tools).Count) tools)" -ForegroundColor Green
+    }
+    finally {
+        try {
+            if (-not $proc.HasExited) {
+                $proc.StandardInput.Close()
+                if (-not $proc.WaitForExit(5000)) {
+                    $proc.Kill($true)
+                }
+            }
+        } catch {}
+        Unregister-Event -SourceIdentifier $errReader.Name -ErrorAction SilentlyContinue
+        Remove-Job -Job $errReader -Force -ErrorAction SilentlyContinue
+        $stderrText = $stderrBuf.ToString().Trim()
+        if ($stderrText) {
+            Write-Verbose ("Server stderr for {0}: {1}" -f $RuntimeMode, $stderrText)
+        }
+    }
+}
+
+$modes = @(
+    @{ Mode = 'InProcess'; Out = Join-Path $baselineDir 'inprocess-tools-list.json' }
+    @{ Mode = 'OutOfProcess'; Out = Join-Path $baselineDir 'oop-tools-list.json' }
+)
+
+foreach ($entry in $modes) {
+    $configPath = New-CaptureAppSettings -RuntimeMode $entry.Mode -FixturePath $fixtureModule
+    try {
+        $fixtureModuleRoot = Split-Path -Parent (Split-Path -Parent $fixtureModule)
+        Invoke-Capture -RuntimeMode $entry.Mode -ConfigPath $configPath -OutputPath $entry.Out -FixtureModuleRoot $fixtureModuleRoot
+    }
+    finally {
+        Remove-Item -Path $configPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Write-Host "Baseline capture complete." -ForegroundColor Green

--- a/specs/010-tool-self-documentation/baseline/inprocess-tools-list.json
+++ b/specs/010-tool-self-documentation/baseline/inprocess-tools-list.json
@@ -1,0 +1,14563 @@
+{
+  "result": {
+    "tools": [
+      {
+        "name": "set_service_input_object",
+        "title": "Set-Service",
+        "description": "Set-Service [-InputObject] <ServiceController> [-DisplayName <string>] [-Credential <pscredential>] [-Description <string>] [-StartupType <ServiceStartupType>] [-SecurityDescriptorSddl <string>] [-Status <string>] [-Force] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Description": {
+              "type": "string",
+              "default": null
+            },
+            "DisplayName": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "SecurityDescriptorSddl": {
+              "type": "string",
+              "default": null
+            },
+            "StartupType": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "Automatic",
+                "Manual",
+                "Disabled",
+                "AutomaticDelayedStart",
+                "InvalidValue",
+                null
+              ],
+              "default": null
+            },
+            "Status": {
+              "type": "string",
+              "default": null
+            },
+            "InputObject": {
+              "type": "object",
+              "properties": {
+                "canPauseAndContinue": {
+                  "type": "boolean"
+                },
+                "canShutdown": {
+                  "type": "boolean"
+                },
+                "canStop": {
+                  "type": "boolean"
+                },
+                "displayName": {
+                  "type": "string"
+                },
+                "dependentServices": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "$ref": "#/properties/InputObject"
+                  }
+                },
+                "machineName": {
+                  "type": "string"
+                },
+                "serviceName": {
+                  "type": "string"
+                },
+                "servicesDependedOn": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "$ref": "#/properties/InputObject"
+                  }
+                },
+                "startType": {
+                  "type": "string",
+                  "enum": [
+                    "Boot",
+                    "System",
+                    "Automatic",
+                    "Manual",
+                    "Disabled"
+                  ]
+                },
+                "serviceHandle": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "isClosed": {
+                      "type": "boolean"
+                    },
+                    "isInvalid": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "Stopped",
+                    "StartPending",
+                    "StopPending",
+                    "Running",
+                    "ContinuePending",
+                    "PausePending",
+                    "Paused"
+                  ]
+                },
+                "serviceType": {
+                  "type": "string"
+                },
+                "site": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "component": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "site": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "component": {
+                              "$ref": "#/properties/InputObject/properties/site/properties/component"
+                            },
+                            "container": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "components": {
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ],
+                                  "items": {}
+                                }
+                              }
+                            },
+                            "designMode": {
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "container": {
+                      "$ref": "#/properties/InputObject/properties/site/properties/component/properties/site/properties/container"
+                    },
+                    "designMode": {
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "container": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "components": {
+                      "$ref": "#/properties/InputObject/properties/site/properties/component/properties/site/properties/container/properties/components",
+                      "items": {}
+                    }
+                  }
+                }
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "InputObject"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-Service",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_fixture_validate_set_array",
+        "title": "Get-FixtureValidateSetArray",
+        "description": "Get-FixtureValidateSetArray [-Directions] <string[]> [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Directions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Directions"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-FixtureValidateSetArray",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_time_zone_name",
+        "title": "Set-TimeZone",
+        "description": "Set-TimeZone [-Name] <string> [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Name": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-TimeZone",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_service_name",
+        "title": "Set-Service",
+        "description": "Set-Service [-Name] <string> [-DisplayName <string>] [-Credential <pscredential>] [-Description <string>] [-StartupType <ServiceStartupType>] [-SecurityDescriptorSddl <string>] [-Status <string>] [-Force] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Description": {
+              "type": "string",
+              "default": null
+            },
+            "DisplayName": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "SecurityDescriptorSddl": {
+              "type": "string",
+              "default": null
+            },
+            "StartupType": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "Automatic",
+                "Manual",
+                "Disabled",
+                "AutomaticDelayedStart",
+                "InvalidValue",
+                null
+              ],
+              "default": null
+            },
+            "Status": {
+              "type": "string",
+              "default": null
+            },
+            "Name": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-Service",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "debug_process_id",
+        "title": "Debug-Process",
+        "description": "Debug-Process [-Id] <int[]> [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Id"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Debug-Process",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_item_literal_path",
+        "title": "Set-Item",
+        "description": "Set-Item [[-Value] <Object>] -LiteralPath <string[]> [-Force] [-PassThru] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-Item",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_psdrive_literal_name",
+        "title": "Get-PSDrive",
+        "description": "Get-PSDrive [-LiteralName] <string[]> [-Scope <string>] [-PSProvider <string[]>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "PSProvider": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Scope": {
+              "type": "string",
+              "default": null
+            },
+            "LiteralName": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-PSDrive",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "resume_service_display_name",
+        "title": "Resume-Service",
+        "description": "Resume-Service -DisplayName <string[]> [-PassThru] [-Include <string[]>] [-Exclude <string[]>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "DisplayName": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "DisplayName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Resume-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "debug_process_name",
+        "title": "Debug-Process",
+        "description": "Debug-Process [-Name] <string[]> [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Debug-Process",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "push_location_literal_path",
+        "title": "Push-Location",
+        "description": "Push-Location [-LiteralPath <string>] [-PassThru] [-StackName <string>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string",
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "StackName": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Push-Location",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "remove_item_path",
+        "title": "Remove-Item",
+        "description": "Remove-Item [-Path] <string[]> [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Recurse] [-Force] [-Credential <pscredential>] [-WhatIf] [-Confirm] [-Stream <string[]>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Recurse": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Stream": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Remove-Item",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "stop_service_default",
+        "title": "Stop-Service",
+        "description": "Stop-Service [-Name] <string[]> [-Force] [-NoWait] [-PassThru] [-Include <string[]>] [-Exclude <string[]>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "NoWait": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Name": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Stop-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_fixture_synopsis_only",
+        "title": "Get-FixtureSynopsisOnly",
+        "description": "Get-FixtureSynopsisOnly [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-FixtureSynopsisOnly",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "remove_service_input_object",
+        "title": "Remove-Service",
+        "description": "Remove-Service [-InputObject <ServiceController>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "InputObject": {
+              "type": "object",
+              "properties": {
+                "canPauseAndContinue": {
+                  "type": "boolean"
+                },
+                "canShutdown": {
+                  "type": "boolean"
+                },
+                "canStop": {
+                  "type": "boolean"
+                },
+                "displayName": {
+                  "type": "string"
+                },
+                "dependentServices": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "$ref": "#/properties/InputObject"
+                  }
+                },
+                "machineName": {
+                  "type": "string"
+                },
+                "serviceName": {
+                  "type": "string"
+                },
+                "servicesDependedOn": {
+                  "type": [
+                    "array",
+                    "null"
+                  ],
+                  "items": {
+                    "$ref": "#/properties/InputObject"
+                  }
+                },
+                "startType": {
+                  "type": "string",
+                  "enum": [
+                    "Boot",
+                    "System",
+                    "Automatic",
+                    "Manual",
+                    "Disabled"
+                  ]
+                },
+                "serviceHandle": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "isClosed": {
+                      "type": "boolean"
+                    },
+                    "isInvalid": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "Stopped",
+                    "StartPending",
+                    "StopPending",
+                    "Running",
+                    "ContinuePending",
+                    "PausePending",
+                    "Paused"
+                  ]
+                },
+                "serviceType": {
+                  "type": "string"
+                },
+                "site": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "component": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "properties": {
+                        "site": {
+                          "type": [
+                            "object",
+                            "null"
+                          ],
+                          "properties": {
+                            "component": {
+                              "$ref": "#/properties/InputObject/properties/site/properties/component"
+                            },
+                            "container": {
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "properties": {
+                                "components": {
+                                  "type": [
+                                    "array",
+                                    "null"
+                                  ],
+                                  "items": {}
+                                }
+                              }
+                            },
+                            "designMode": {
+                              "type": "boolean"
+                            },
+                            "name": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "container": {
+                      "$ref": "#/properties/InputObject/properties/site/properties/component/properties/site/properties/container"
+                    },
+                    "designMode": {
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "container": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "components": {
+                      "$ref": "#/properties/InputObject/properties/site/properties/component/properties/site/properties/container/properties/components",
+                      "items": {}
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Remove-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "test_path_literal_path",
+        "title": "Test-Path",
+        "description": "Test-Path -LiteralPath <string[]> [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-PathType <TestPathType>] [-IsValid] [-Credential <pscredential>] [-OlderThan <datetime>] [-NewerThan <datetime>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "IsValid": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "NewerThan": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "default": null
+            },
+            "OlderThan": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "default": null
+            },
+            "PathType": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "Any",
+                "Container",
+                "Leaf",
+                null
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Test-Path",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_hot_fix_description",
+        "title": "Get-HotFix",
+        "description": "Get-HotFix [-Description <string[]>] [-ComputerName <string[]>] [-Credential <pscredential>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "ComputerName": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Description": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-HotFix",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "remove_psdrive_literal_name",
+        "title": "Remove-PSDrive",
+        "description": "Remove-PSDrive [-LiteralName] <string[]> [-PSProvider <string[]>] [-Scope <string>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "PSProvider": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Scope": {
+              "type": "string",
+              "default": null
+            },
+            "LiteralName": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Remove-PSDrive",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "test_connection_tcp_port",
+        "title": "Test-Connection",
+        "description": "Test-Connection [-TargetName] <string[]> -TcpPort <int> [-IPv4] [-IPv6] [-ResolveDestination] [-Source <string>] [-Count <int>] [-Delay <int>] [-Repeat] [-Quiet] [-TimeoutSeconds <int>] [-Detailed] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Delay": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Detailed": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "IPv4": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "IPv6": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Quiet": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Repeat": {
+              "type": "object",
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "ResolveDestination": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Source": {
+              "type": "string",
+              "default": null
+            },
+            "TcpPort": {
+              "type": "integer"
+            },
+            "TimeoutSeconds": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "TargetName": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Repeat",
+            "TcpPort",
+            "TargetName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Test-Connection",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "stop_process_name",
+        "title": "Stop-Process",
+        "description": "Stop-Process -Name <string[]> [-PassThru] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Name": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Stop-Process",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "resume_service_default",
+        "title": "Resume-Service",
+        "description": "Resume-Service [-Name] <string[]> [-PassThru] [-Include <string[]>] [-Exclude <string[]>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Name": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Resume-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "move_item_property_literal_path",
+        "title": "Move-ItemProperty",
+        "description": "Move-ItemProperty [-Destination] <string> [-Name] <string[]> -LiteralPath <string[]> [-PassThru] [-Force] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Destination": {
+              "type": "string"
+            },
+            "Name": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath",
+            "Destination",
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Move-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_item_property_value_literal_path",
+        "title": "Get-ItemPropertyValue",
+        "description": "Get-ItemPropertyValue [-Name] <string[]> -LiteralPath <string[]> [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Credential <pscredential>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Name": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath",
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-ItemPropertyValue",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "move_item_literal_path",
+        "title": "Move-Item",
+        "description": "Move-Item [[-Destination] <string>] -LiteralPath <string[]> [-Force] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-PassThru] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Destination": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Move-Item",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_location_literal_path",
+        "title": "Set-Location",
+        "description": "Set-Location -LiteralPath <string> [-PassThru] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-Location",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "remove_psdrive_name",
+        "title": "Remove-PSDrive",
+        "description": "Remove-PSDrive [-Name] <string[]> [-PSProvider <string[]>] [-Scope <string>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "PSProvider": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Scope": {
+              "type": "string",
+              "default": null
+            },
+            "Name": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Remove-PSDrive",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "test_connection_mtu_size_detect",
+        "title": "Test-Connection",
+        "description": "Test-Connection [-TargetName] <string[]> -MtuSize [-IPv4] [-IPv6] [-ResolveDestination] [-Quiet] [-TimeoutSeconds <int>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "IPv4": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "IPv6": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "MtuSize": {
+              "type": "object",
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "Quiet": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "ResolveDestination": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "TimeoutSeconds": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "TargetName": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "MtuSize",
+            "TargetName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Test-Connection",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_hot_fix_default",
+        "title": "Get-HotFix",
+        "description": "Get-HotFix [[-Id] <string[]>] [-ComputerName <string[]>] [-Credential <pscredential>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "ComputerName": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Id": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-HotFix",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_clipboard",
+        "title": "Set-Clipboard",
+        "description": "Set-Clipboard [-Value] <string[]> [-Append] [-PassThru] [-AsOSC52] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Append": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "AsOSC52": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Value": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Value"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-Clipboard",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "rename_item_property_literal_path",
+        "title": "Rename-ItemProperty",
+        "description": "Rename-ItemProperty [-Name] <string> [-NewName] <string> -LiteralPath <string> [-PassThru] [-Force] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Name": {
+              "type": "string"
+            },
+            "NewName": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath",
+            "Name",
+            "NewName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Rename-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "resume_service_input_object",
+        "title": "Resume-Service",
+        "description": "Resume-Service [-InputObject] <ServiceController[]> [-PassThru] [-Include <string[]>] [-Exclude <string[]>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "InputObject": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "canPauseAndContinue": {
+                    "type": "boolean"
+                  },
+                  "canShutdown": {
+                    "type": "boolean"
+                  },
+                  "canStop": {
+                    "type": "boolean"
+                  },
+                  "displayName": {
+                    "type": "string"
+                  },
+                  "dependentServices": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/properties/InputObject/items"
+                    }
+                  },
+                  "machineName": {
+                    "type": "string"
+                  },
+                  "serviceName": {
+                    "type": "string"
+                  },
+                  "servicesDependedOn": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/properties/InputObject/items"
+                    }
+                  },
+                  "startType": {
+                    "type": "string",
+                    "enum": [
+                      "Boot",
+                      "System",
+                      "Automatic",
+                      "Manual",
+                      "Disabled"
+                    ]
+                  },
+                  "serviceHandle": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "isClosed": {
+                        "type": "boolean"
+                      },
+                      "isInvalid": {
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "Stopped",
+                      "StartPending",
+                      "StopPending",
+                      "Running",
+                      "ContinuePending",
+                      "PausePending",
+                      "Paused"
+                    ]
+                  },
+                  "serviceType": {
+                    "type": "string"
+                  },
+                  "site": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "component": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "site": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "component": {
+                                "$ref": "#/properties/InputObject/items/properties/site/properties/component"
+                              },
+                              "container": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "components": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {}
+                                  }
+                                }
+                              },
+                              "designMode": {
+                                "type": "boolean"
+                              },
+                              "name": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "container": {
+                        "$ref": "#/properties/InputObject/items/properties/site/properties/component/properties/site/properties/container"
+                      },
+                      "designMode": {
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "container": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "components": {
+                        "$ref": "#/properties/InputObject/items/properties/site/properties/component/properties/site/properties/container/properties/components",
+                        "items": {}
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "InputObject"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Resume-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "rename_item_property_path",
+        "title": "Rename-ItemProperty",
+        "description": "Rename-ItemProperty [-Path] <string> [-Name] <string> [-NewName] <string> [-PassThru] [-Force] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "string"
+            },
+            "Name": {
+              "type": "string"
+            },
+            "NewName": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "Name",
+            "NewName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Rename-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "clear_content_path",
+        "title": "Clear-Content",
+        "description": "Clear-Content [-Path] <string[]> [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-WhatIf] [-Confirm] [-Stream <string>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Stream": {
+              "type": "string",
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Clear-Content",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "invoke_item_path",
+        "title": "Invoke-Item",
+        "description": "Invoke-Item [-Path] <string[]> [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Invoke-Item",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "split_path_leaf_base_set",
+        "title": "Split-Path",
+        "description": "Split-Path [-Path] <string[]> -LeafBase [-Resolve] [-Credential <pscredential>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "LeafBase": {
+              "type": "object",
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "Resolve": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LeafBase",
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Split-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "remove_item_property_literal_path",
+        "title": "Remove-ItemProperty",
+        "description": "Remove-ItemProperty [-Name] <string[]> -LiteralPath <string[]> [-Force] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Name": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath",
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Remove-ItemProperty",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "convert_path_literal_path",
+        "title": "Convert-Path",
+        "description": "Convert-Path -LiteralPath <string[]> [-Force] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Convert-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_time_zone_id",
+        "title": "Get-TimeZone",
+        "description": "Get-TimeZone -Id <string[]> [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Id"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-TimeZone",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "join_path",
+        "title": "Join-Path",
+        "description": "Join-Path [-Path] <string[]> [-ChildPath] <string[]> [[-AdditionalChildPath] <string[]>] [-Resolve] [-Credential <pscredential>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Resolve": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ChildPath": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "AdditionalChildPath": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "ChildPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Join-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_location_path",
+        "title": "Set-Location",
+        "description": "Set-Location [[-Path] <string>] [-PassThru] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-Location",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_clipboard",
+        "title": "Get-Clipboard",
+        "description": "Get-Clipboard [-Raw] [-Delimiter <string[]>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Delimiter": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Raw": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Clipboard",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "split_path_leaf_set",
+        "title": "Split-Path",
+        "description": "Split-Path [-Path] <string[]> -Leaf [-Resolve] [-Credential <pscredential>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Leaf": {
+              "type": "object",
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "Resolve": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Leaf",
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Split-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "clear_item_literal_path",
+        "title": "Clear-Item",
+        "description": "Clear-Item -LiteralPath <string[]> [-Force] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Clear-Item",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "stop_service_input_object",
+        "title": "Stop-Service",
+        "description": "Stop-Service [-InputObject] <ServiceController[]> [-Force] [-NoWait] [-PassThru] [-Include <string[]>] [-Exclude <string[]>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "NoWait": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "InputObject": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "canPauseAndContinue": {
+                    "type": "boolean"
+                  },
+                  "canShutdown": {
+                    "type": "boolean"
+                  },
+                  "canStop": {
+                    "type": "boolean"
+                  },
+                  "displayName": {
+                    "type": "string"
+                  },
+                  "dependentServices": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/properties/InputObject/items"
+                    }
+                  },
+                  "machineName": {
+                    "type": "string"
+                  },
+                  "serviceName": {
+                    "type": "string"
+                  },
+                  "servicesDependedOn": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/properties/InputObject/items"
+                    }
+                  },
+                  "startType": {
+                    "type": "string",
+                    "enum": [
+                      "Boot",
+                      "System",
+                      "Automatic",
+                      "Manual",
+                      "Disabled"
+                    ]
+                  },
+                  "serviceHandle": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "isClosed": {
+                        "type": "boolean"
+                      },
+                      "isInvalid": {
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "Stopped",
+                      "StartPending",
+                      "StopPending",
+                      "Running",
+                      "ContinuePending",
+                      "PausePending",
+                      "Paused"
+                    ]
+                  },
+                  "serviceType": {
+                    "type": "string"
+                  },
+                  "site": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "component": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "site": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "component": {
+                                "$ref": "#/properties/InputObject/items/properties/site/properties/component"
+                              },
+                              "container": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "components": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {}
+                                  }
+                                }
+                              },
+                              "designMode": {
+                                "type": "boolean"
+                              },
+                              "name": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "container": {
+                        "$ref": "#/properties/InputObject/items/properties/site/properties/component/properties/site/properties/container"
+                      },
+                      "designMode": {
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "container": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "components": {
+                        "$ref": "#/properties/InputObject/items/properties/site/properties/component/properties/site/properties/container/properties/components",
+                        "items": {}
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "InputObject"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Stop-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "push_location_path",
+        "title": "Push-Location",
+        "description": "Push-Location [[-Path] <string>] [-PassThru] [-StackName <string>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "StackName": {
+              "type": "string",
+              "default": null
+            },
+            "Path": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Push-Location",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_time_zone_input_object",
+        "title": "Set-TimeZone",
+        "description": "Set-TimeZone [-InputObject] <TimeZoneInfo> [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "InputObject": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "hasIanaId": {
+                  "type": "boolean"
+                },
+                "displayName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "standardName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "daylightName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "baseUtcOffset": {
+                  "$comment": "Represents a System.TimeSpan value.",
+                  "type": "string",
+                  "pattern": "^-?(\\d+\\.)?\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,7})?$"
+                },
+                "supportsDaylightSavingTime": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "InputObject"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-TimeZone",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_item_property_value_path",
+        "title": "Get-ItemPropertyValue",
+        "description": "Get-ItemPropertyValue [[-Path] <string[]>] [-Name] <string[]> [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Credential <pscredential>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Name": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-ItemPropertyValue",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "new_service",
+        "title": "New-Service",
+        "description": "New-Service [-Name] <string> [-BinaryPathName] <string> [-DisplayName <string>] [-Description <string>] [-StartupType <ServiceStartupType>] [-Credential <pscredential>] [-SecurityDescriptorSddl <string>] [-DependsOn <string[]>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "DependsOn": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Description": {
+              "type": "string",
+              "default": null
+            },
+            "DisplayName": {
+              "type": "string",
+              "default": null
+            },
+            "SecurityDescriptorSddl": {
+              "type": "string",
+              "default": null
+            },
+            "StartupType": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "Automatic",
+                "Manual",
+                "Disabled",
+                "AutomaticDelayedStart",
+                "InvalidValue",
+                null
+              ],
+              "default": null
+            },
+            "Name": {
+              "type": "string"
+            },
+            "BinaryPathName": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name",
+            "BinaryPathName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "New-Service",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "copy_item_literal_path",
+        "title": "Copy-Item",
+        "description": "Copy-Item [[-Destination] <string>] -LiteralPath <string[]> [-Container] [-Force] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Recurse] [-PassThru] [-Credential <pscredential>] [-WhatIf] [-Confirm] [-FromSession <PSSession>] [-ToSession <PSSession>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Container": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Recurse": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Destination": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Copy-Item",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_process_name",
+        "title": "Get-Process",
+        "description": "Get-Process [[-Name] <string[]>] [-Module] [-FileVersionInfo] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "FileVersionInfo": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Module": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Name": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Process",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "copy_item_property_literal_path",
+        "title": "Copy-ItemProperty",
+        "description": "Copy-ItemProperty [-Destination] <string> [-Name] <string> -LiteralPath <string[]> [-PassThru] [-Force] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Destination": {
+              "type": "string"
+            },
+            "Name": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath",
+            "Destination",
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Copy-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "remove_service_name",
+        "title": "Remove-Service",
+        "description": "Remove-Service [-Name] <string> [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Remove-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "split_path_is_absolute_set",
+        "title": "Split-Path",
+        "description": "Split-Path [-Path] <string[]> -IsAbsolute [-Resolve] [-Credential <pscredential>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "IsAbsolute": {
+              "type": "object",
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "Resolve": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "IsAbsolute",
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Split-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "split_path_parent_set",
+        "title": "Split-Path",
+        "description": "Split-Path [-Path] <string[]> [-Parent] [-Resolve] [-Credential <pscredential>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Parent": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Resolve": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Split-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_process_id_with_user_name",
+        "title": "Get-Process",
+        "description": "Get-Process -Id <int[]> -IncludeUserName [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "IncludeUserName": {
+              "type": "object",
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Id",
+            "IncludeUserName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Process",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set-result-caching",
+        "title": "Set Result Caching",
+        "description": "Enable or disable result caching at runtime. When enabled, command output is cached for replay by filter/sort/group tools. Pass enabled=null or enabled='reset' to clear the runtime override and fall back to configuration. Runtime settings are ephemeral and do not persist across server restarts.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "scope": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "functionName": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "enabled",
+            "scope",
+            "functionName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set Result Caching",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": false,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "wait_process_name",
+        "title": "Wait-Process",
+        "description": "Wait-Process [-Name] <string[]> [[-Timeout] <int>] [-Any] [-PassThru] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Any": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Name": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Timeout": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Wait-Process",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_location_stack",
+        "title": "Get-Location",
+        "description": "Get-Location [-Stack] [-StackName <string[]>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Stack": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "StackName": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Location",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "split_path_qualifier_set",
+        "title": "Split-Path",
+        "description": "Split-Path [-Path] <string[]> -Qualifier [-Resolve] [-Credential <pscredential>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Qualifier": {
+              "type": "object",
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "Resolve": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Qualifier",
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Split-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "clear_item_path",
+        "title": "Clear-Item",
+        "description": "Clear-Item [-Path] <string[]> [-Force] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Clear-Item",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "clear_item_property_literal_path",
+        "title": "Clear-ItemProperty",
+        "description": "Clear-ItemProperty [-Name] <string> -LiteralPath <string[]> [-PassThru] [-Force] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Name": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath",
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Clear-ItemProperty",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "start_service_input_object",
+        "title": "Start-Service",
+        "description": "Start-Service [-InputObject] <ServiceController[]> [-PassThru] [-Include <string[]>] [-Exclude <string[]>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "InputObject": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "canPauseAndContinue": {
+                    "type": "boolean"
+                  },
+                  "canShutdown": {
+                    "type": "boolean"
+                  },
+                  "canStop": {
+                    "type": "boolean"
+                  },
+                  "displayName": {
+                    "type": "string"
+                  },
+                  "dependentServices": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/properties/InputObject/items"
+                    }
+                  },
+                  "machineName": {
+                    "type": "string"
+                  },
+                  "serviceName": {
+                    "type": "string"
+                  },
+                  "servicesDependedOn": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/properties/InputObject/items"
+                    }
+                  },
+                  "startType": {
+                    "type": "string",
+                    "enum": [
+                      "Boot",
+                      "System",
+                      "Automatic",
+                      "Manual",
+                      "Disabled"
+                    ]
+                  },
+                  "serviceHandle": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "isClosed": {
+                        "type": "boolean"
+                      },
+                      "isInvalid": {
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "Stopped",
+                      "StartPending",
+                      "StopPending",
+                      "Running",
+                      "ContinuePending",
+                      "PausePending",
+                      "Paused"
+                    ]
+                  },
+                  "serviceType": {
+                    "type": "string"
+                  },
+                  "site": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "component": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "site": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "component": {
+                                "$ref": "#/properties/InputObject/items/properties/site/properties/component"
+                              },
+                              "container": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "components": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {}
+                                  }
+                                }
+                              },
+                              "designMode": {
+                                "type": "boolean"
+                              },
+                              "name": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "container": {
+                        "$ref": "#/properties/InputObject/items/properties/site/properties/component/properties/site/properties/container"
+                      },
+                      "designMode": {
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "container": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "components": {
+                        "$ref": "#/properties/InputObject/items/properties/site/properties/component/properties/site/properties/container/properties/components",
+                        "items": {}
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "InputObject"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Start-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "restart_service_input_object",
+        "title": "Restart-Service",
+        "description": "Restart-Service [-InputObject] <ServiceController[]> [-Force] [-PassThru] [-Include <string[]>] [-Exclude <string[]>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "InputObject": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "canPauseAndContinue": {
+                    "type": "boolean"
+                  },
+                  "canShutdown": {
+                    "type": "boolean"
+                  },
+                  "canStop": {
+                    "type": "boolean"
+                  },
+                  "displayName": {
+                    "type": "string"
+                  },
+                  "dependentServices": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/properties/InputObject/items"
+                    }
+                  },
+                  "machineName": {
+                    "type": "string"
+                  },
+                  "serviceName": {
+                    "type": "string"
+                  },
+                  "servicesDependedOn": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/properties/InputObject/items"
+                    }
+                  },
+                  "startType": {
+                    "type": "string",
+                    "enum": [
+                      "Boot",
+                      "System",
+                      "Automatic",
+                      "Manual",
+                      "Disabled"
+                    ]
+                  },
+                  "serviceHandle": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "isClosed": {
+                        "type": "boolean"
+                      },
+                      "isInvalid": {
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "Stopped",
+                      "StartPending",
+                      "StopPending",
+                      "Running",
+                      "ContinuePending",
+                      "PausePending",
+                      "Paused"
+                    ]
+                  },
+                  "serviceType": {
+                    "type": "string"
+                  },
+                  "site": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "component": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "site": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "component": {
+                                "$ref": "#/properties/InputObject/items/properties/site/properties/component"
+                              },
+                              "container": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "components": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {}
+                                  }
+                                }
+                              },
+                              "designMode": {
+                                "type": "boolean"
+                              },
+                              "name": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "container": {
+                        "$ref": "#/properties/InputObject/items/properties/site/properties/component/properties/site/properties/container"
+                      },
+                      "designMode": {
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "container": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "components": {
+                        "$ref": "#/properties/InputObject/items/properties/site/properties/component/properties/site/properties/container/properties/components",
+                        "items": {}
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "InputObject"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Restart-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_service_input_object",
+        "title": "Get-Service",
+        "description": "Get-Service [-DependentServices] [-RequiredServices] [-Include <string[]>] [-Exclude <string[]>] [-InputObject <ServiceController[]>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "DependentServices": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "InputObject": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "canPauseAndContinue": {
+                    "type": "boolean"
+                  },
+                  "canShutdown": {
+                    "type": "boolean"
+                  },
+                  "canStop": {
+                    "type": "boolean"
+                  },
+                  "displayName": {
+                    "type": "string"
+                  },
+                  "dependentServices": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/properties/InputObject/items"
+                    }
+                  },
+                  "machineName": {
+                    "type": "string"
+                  },
+                  "serviceName": {
+                    "type": "string"
+                  },
+                  "servicesDependedOn": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/properties/InputObject/items"
+                    }
+                  },
+                  "startType": {
+                    "type": "string",
+                    "enum": [
+                      "Boot",
+                      "System",
+                      "Automatic",
+                      "Manual",
+                      "Disabled"
+                    ]
+                  },
+                  "serviceHandle": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "isClosed": {
+                        "type": "boolean"
+                      },
+                      "isInvalid": {
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "Stopped",
+                      "StartPending",
+                      "StopPending",
+                      "Running",
+                      "ContinuePending",
+                      "PausePending",
+                      "Paused"
+                    ]
+                  },
+                  "serviceType": {
+                    "type": "string"
+                  },
+                  "site": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "component": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "site": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "component": {
+                                "$ref": "#/properties/InputObject/items/properties/site/properties/component"
+                              },
+                              "container": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "components": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {}
+                                  }
+                                }
+                              },
+                              "designMode": {
+                                "type": "boolean"
+                              },
+                              "name": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "container": {
+                        "$ref": "#/properties/InputObject/items/properties/site/properties/component/properties/site/properties/container"
+                      },
+                      "designMode": {
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "container": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "components": {
+                        "$ref": "#/properties/InputObject/items/properties/site/properties/component/properties/site/properties/container/properties/components",
+                        "items": {}
+                      }
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "RequiredServices": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Service",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "clear_content_literal_path",
+        "title": "Clear-Content",
+        "description": "Clear-Content -LiteralPath <string[]> [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-WhatIf] [-Confirm] [-Stream <string>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Stream": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Clear-Content",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "test_path_path",
+        "title": "Test-Path",
+        "description": "Test-Path [-Path] <string[]> [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-PathType <TestPathType>] [-IsValid] [-Credential <pscredential>] [-OlderThan <datetime>] [-NewerThan <datetime>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "IsValid": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "NewerThan": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "default": null
+            },
+            "OlderThan": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time",
+              "default": null
+            },
+            "PathType": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "Any",
+                "Container",
+                "Leaf",
+                null
+              ],
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Test-Path",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "start_service_default",
+        "title": "Start-Service",
+        "description": "Start-Service [-Name] <string[]> [-PassThru] [-Include <string[]>] [-Exclude <string[]>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Name": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Start-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "move_item_path",
+        "title": "Move-Item",
+        "description": "Move-Item [-Path] <string[]> [[-Destination] <string>] [-Force] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-PassThru] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Destination": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Move-Item",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "sort_last_command_output",
+        "title": "sort-last-command-output",
+        "description": "sort-last-command-output",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "property": {
+              "type": "string"
+            },
+            "descending": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "property",
+            "descending"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "sort-last-command-output",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_item_path",
+        "title": "Get-Item",
+        "description": "Get-Item [-Path] <string[]> [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-Stream <string[]>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Stream": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Item",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "start_service_display_name",
+        "title": "Start-Service",
+        "description": "Start-Service -DisplayName <string[]> [-PassThru] [-Include <string[]>] [-Exclude <string[]>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "DisplayName": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "DisplayName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Start-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_time_zone_name",
+        "title": "Get-TimeZone",
+        "description": "Get-TimeZone [[-Name] <string[]>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-TimeZone",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_location_location",
+        "title": "Get-Location",
+        "description": "Get-Location [-PSProvider <string[]>] [-PSDrive <string[]>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "PSDrive": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "PSProvider": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Location",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "pop_location",
+        "title": "Pop-Location",
+        "description": "Pop-Location [-PassThru] [-StackName <string>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "StackName": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Pop-Location",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_fixture_validate_set_scalar",
+        "title": "Get-FixtureValidateSetScalar",
+        "description": "Get-FixtureValidateSetScalar [-Color] <string> [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Color": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Color"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-FixtureValidateSetScalar",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "remove_item_literal_path",
+        "title": "Remove-Item",
+        "description": "Remove-Item -LiteralPath <string[]> [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Recurse] [-Force] [-Credential <pscredential>] [-WhatIf] [-Confirm] [-Stream <string[]>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Recurse": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Stream": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Remove-Item",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "clear_recycle_bin",
+        "title": "Clear-RecycleBin",
+        "description": "Clear-RecycleBin [[-DriveLetter] <string[]>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "DriveLetter": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Clear-RecycleBin",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "stop_computer",
+        "title": "Stop-Computer",
+        "description": "Stop-Computer [[-ComputerName] <string[]>] [[-Credential] <pscredential>] [-WsmanAuthentication <string>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "WsmanAuthentication": {
+              "type": "string",
+              "default": null
+            },
+            "ComputerName": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Stop-Computer",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_item_path",
+        "title": "Set-Item",
+        "description": "Set-Item [-Path] <string[]> [[-Value] <Object>] [-Force] [-PassThru] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-Item",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_location_stack",
+        "title": "Set-Location",
+        "description": "Set-Location [-PassThru] [-StackName <string>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "StackName": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-Location",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "new_item_path_set",
+        "title": "New-Item",
+        "description": "New-Item [-Path] <string[]> [-ItemType <string>] [-Value <Object>] [-Force] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "ItemType": {
+              "type": "string",
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "New-Item",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_process_id",
+        "title": "Get-Process",
+        "description": "Get-Process -Id <int[]> [-Module] [-FileVersionInfo] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "FileVersionInfo": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Id": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "Module": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Id"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Process",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "split_path_extension_set",
+        "title": "Split-Path",
+        "description": "Split-Path [-Path] <string[]> -Extension [-Resolve] [-Credential <pscredential>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Extension": {
+              "type": "object",
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "Resolve": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Extension",
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Split-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "rename_item_by_path",
+        "title": "Rename-Item",
+        "description": "Rename-Item [-Path] <string> [-NewName] <string> [-Force] [-PassThru] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "string"
+            },
+            "NewName": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "NewName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Rename-Item",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "suspend_service_input_object",
+        "title": "Suspend-Service",
+        "description": "Suspend-Service [-InputObject] <ServiceController[]> [-PassThru] [-Include <string[]>] [-Exclude <string[]>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "InputObject": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "canPauseAndContinue": {
+                    "type": "boolean"
+                  },
+                  "canShutdown": {
+                    "type": "boolean"
+                  },
+                  "canStop": {
+                    "type": "boolean"
+                  },
+                  "displayName": {
+                    "type": "string"
+                  },
+                  "dependentServices": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/properties/InputObject/items"
+                    }
+                  },
+                  "machineName": {
+                    "type": "string"
+                  },
+                  "serviceName": {
+                    "type": "string"
+                  },
+                  "servicesDependedOn": {
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/properties/InputObject/items"
+                    }
+                  },
+                  "startType": {
+                    "type": "string",
+                    "enum": [
+                      "Boot",
+                      "System",
+                      "Automatic",
+                      "Manual",
+                      "Disabled"
+                    ]
+                  },
+                  "serviceHandle": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "isClosed": {
+                        "type": "boolean"
+                      },
+                      "isInvalid": {
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "Stopped",
+                      "StartPending",
+                      "StopPending",
+                      "Running",
+                      "ContinuePending",
+                      "PausePending",
+                      "Paused"
+                    ]
+                  },
+                  "serviceType": {
+                    "type": "string"
+                  },
+                  "site": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "component": {
+                        "type": [
+                          "object",
+                          "null"
+                        ],
+                        "properties": {
+                          "site": {
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "properties": {
+                              "component": {
+                                "$ref": "#/properties/InputObject/items/properties/site/properties/component"
+                              },
+                              "container": {
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "properties": {
+                                  "components": {
+                                    "type": [
+                                      "array",
+                                      "null"
+                                    ],
+                                    "items": {}
+                                  }
+                                }
+                              },
+                              "designMode": {
+                                "type": "boolean"
+                              },
+                              "name": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "container": {
+                        "$ref": "#/properties/InputObject/items/properties/site/properties/component/properties/site/properties/container"
+                      },
+                      "designMode": {
+                        "type": "boolean"
+                      },
+                      "name": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    }
+                  },
+                  "container": {
+                    "type": [
+                      "object",
+                      "null"
+                    ],
+                    "properties": {
+                      "components": {
+                        "$ref": "#/properties/InputObject/items/properties/site/properties/component/properties/site/properties/container/properties/components",
+                        "items": {}
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "InputObject"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Suspend-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "restart_service_default",
+        "title": "Restart-Service",
+        "description": "Restart-Service [-Name] <string[]> [-Force] [-PassThru] [-Include <string[]>] [-Exclude <string[]>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Name": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Restart-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "test_connection_repeat_ping",
+        "title": "Test-Connection",
+        "description": "Test-Connection [-TargetName] <string[]> -Repeat [-Ping] [-IPv4] [-IPv6] [-ResolveDestination] [-Source <string>] [-MaxHops <int>] [-Delay <int>] [-BufferSize <int>] [-DontFragment] [-Quiet] [-TimeoutSeconds <int>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "BufferSize": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Delay": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "DontFragment": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "IPv4": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "IPv6": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "MaxHops": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Ping": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Quiet": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Repeat": {
+              "type": "object",
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "ResolveDestination": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Source": {
+              "type": "string",
+              "default": null
+            },
+            "TimeoutSeconds": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "TargetName": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Repeat",
+            "TargetName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Test-Connection",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "new_item_property_literal_path",
+        "title": "New-ItemProperty",
+        "description": "New-ItemProperty [-Name] <string> -LiteralPath <string[]> [-PropertyType <string>] [-Value <Object>] [-Force] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "PropertyType": {
+              "type": "string",
+              "default": null
+            },
+            "Name": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath",
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "New-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "convert_path_path",
+        "title": "Convert-Path",
+        "description": "Convert-Path [-Path] <string[]> [-Force] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Convert-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "stop_service_display_name",
+        "title": "Stop-Service",
+        "description": "Stop-Service -DisplayName <string[]> [-Force] [-NoWait] [-PassThru] [-Include <string[]>] [-Exclude <string[]>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "DisplayName": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "NoWait": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "DisplayName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Stop-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "restart_service_display_name",
+        "title": "Restart-Service",
+        "description": "Restart-Service -DisplayName <string[]> [-Force] [-PassThru] [-Include <string[]>] [-Exclude <string[]>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "DisplayName": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "DisplayName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Restart-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_service_display_name",
+        "title": "Get-Service",
+        "description": "Get-Service -DisplayName <string[]> [-DependentServices] [-RequiredServices] [-Include <string[]>] [-Exclude <string[]>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "DependentServices": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "DisplayName": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "RequiredServices": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "DisplayName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Service",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "start_process_use_shell_execute",
+        "title": "Start-Process",
+        "description": "Start-Process [-FilePath] <string> [[-ArgumentList] <string[]>] [-WorkingDirectory <string>] [-PassThru] [-Verb <string>] [-WindowStyle <ProcessWindowStyle>] [-Wait] [-Environment <hashtable>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Environment": {
+              "type": "object",
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Verb": {
+              "type": "string",
+              "default": null
+            },
+            "Wait": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "WindowStyle": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "Normal",
+                "Hidden",
+                "Minimized",
+                "Maximized",
+                null
+              ],
+              "default": null
+            },
+            "WorkingDirectory": {
+              "type": "string",
+              "default": null
+            },
+            "FilePath": {
+              "type": "string"
+            },
+            "ArgumentList": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "FilePath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Start-Process",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_fixture_help_message_only",
+        "title": "Get-FixtureHelpMessageOnly",
+        "description": "Get-FixtureHelpMessageOnly [-UserId] <string> [[-Region] <string>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "UserId": {
+              "type": "string"
+            },
+            "Region": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "UserId"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-FixtureHelpMessageOnly",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "group_last_command_output",
+        "title": "group-last-command-output",
+        "description": "group-last-command-output",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "property": {
+              "type": "string"
+            },
+            "noElement": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "property",
+            "noElement"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "group-last-command-output",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_child_item_literal_items",
+        "title": "Get-ChildItem",
+        "description": "Get-ChildItem [[-Filter] <string>] -LiteralPath <string[]> [-Include <string[]>] [-Exclude <string[]>] [-Recurse] [-Depth <uint>] [-Force] [-Name] [-Attributes <FlagsExpression[FileAttributes]>] [-FollowSymlink] [-Directory] [-File] [-Hidden] [-ReadOnly] [-System] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Attributes": {
+              "type": "object",
+              "default": null
+            },
+            "Depth": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Directory": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "File": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "FollowSymlink": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Hidden": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Name": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "_ReadOnly": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Recurse": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "System": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-ChildItem",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "filter_last_command_output",
+        "title": "filter-last-command-output",
+        "description": "filter-last-command-output",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "filterScript": {
+              "type": "string"
+            },
+            "updateCache": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "required": [
+            "filterScript"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "filter-last-command-output",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "new_psdrive",
+        "title": "New-PSDrive",
+        "description": "New-PSDrive [-Name] <string> [-PSProvider] <string> [-Root] <string> [-Description <string>] [-Scope <string>] [-Persist] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Description": {
+              "type": "string",
+              "default": null
+            },
+            "Persist": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Scope": {
+              "type": "string",
+              "default": null
+            },
+            "Name": {
+              "type": "string"
+            },
+            "PSProvider": {
+              "type": "string"
+            },
+            "Root": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name",
+            "PSProvider",
+            "Root"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "New-PSDrive",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "suspend_service_display_name",
+        "title": "Suspend-Service",
+        "description": "Suspend-Service -DisplayName <string[]> [-PassThru] [-Include <string[]>] [-Exclude <string[]>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "DisplayName": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "DisplayName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Suspend-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_last_command_output",
+        "title": "get-last-command-output",
+        "description": "get-last-command-output",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "get-last-command-output",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_time_zone_id",
+        "title": "Set-TimeZone",
+        "description": "Set-TimeZone -Id <string> [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Id"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-TimeZone",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "remove_item_property_path",
+        "title": "Remove-ItemProperty",
+        "description": "Remove-ItemProperty [-Path] <string[]> [-Name] <string[]> [-Force] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Name": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Remove-ItemProperty",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "resolve_path_literal_path",
+        "title": "Resolve-Path",
+        "description": "Resolve-Path -LiteralPath <string[]> [-Relative] [-RelativeBasePath <string>] [-Force] [-Credential <pscredential>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Relative": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "RelativeBasePath": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Resolve-Path",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "split_path_no_qualifier_set",
+        "title": "Split-Path",
+        "description": "Split-Path [-Path] <string[]> -NoQualifier [-Resolve] [-Credential <pscredential>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "NoQualifier": {
+              "type": "object",
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "Resolve": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "NoQualifier",
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Split-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_item_literal_path",
+        "title": "Get-Item",
+        "description": "Get-Item -LiteralPath <string[]> [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Force] [-Credential <pscredential>] [-Stream <string[]>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Stream": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Item",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "split_path_literal_path_set",
+        "title": "Split-Path",
+        "description": "Split-Path -LiteralPath <string[]> [-Resolve] [-Credential <pscredential>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Resolve": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Split-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_computer_info",
+        "title": "Get-ComputerInfo",
+        "description": "Get-ComputerInfo [[-Property] <string[]>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Property": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-ComputerInfo",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "rename_item_by_literal_path",
+        "title": "Rename-Item",
+        "description": "Rename-Item [-NewName] <string> -LiteralPath <string> [-Force] [-PassThru] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "NewName": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath",
+            "NewName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Rename-Item",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_child_item_items",
+        "title": "Get-ChildItem",
+        "description": "Get-ChildItem [[-Path] <string[]>] [[-Filter] <string>] [-Include <string[]>] [-Exclude <string[]>] [-Recurse] [-Depth <uint>] [-Force] [-Name] [-Attributes <FlagsExpression[FileAttributes]>] [-FollowSymlink] [-Directory] [-File] [-Hidden] [-ReadOnly] [-System] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Attributes": {
+              "type": "object",
+              "default": null
+            },
+            "Depth": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Directory": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "File": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "FollowSymlink": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Hidden": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Name": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "_ReadOnly": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Recurse": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "System": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-ChildItem",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "new_item_name_set",
+        "title": "New-Item",
+        "description": "New-Item [[-Path] <string[]>] -Name <string> [-ItemType <string>] [-Value <Object>] [-Force] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "ItemType": {
+              "type": "string",
+              "default": null
+            },
+            "Name": {
+              "type": "string"
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name",
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "New-Item",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "copy_item_path",
+        "title": "Copy-Item",
+        "description": "Copy-Item [-Path] <string[]> [[-Destination] <string>] [-Container] [-Force] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Recurse] [-PassThru] [-Credential <pscredential>] [-WhatIf] [-Confirm] [-FromSession <PSSession>] [-ToSession <PSSession>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Container": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Recurse": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Destination": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Copy-Item",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "move_item_property_path",
+        "title": "Move-ItemProperty",
+        "description": "Move-ItemProperty [-Path] <string[]> [-Destination] <string> [-Name] <string[]> [-PassThru] [-Force] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Destination": {
+              "type": "string"
+            },
+            "Name": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "Destination",
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Move-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "test_connection_trace_route",
+        "title": "Test-Connection",
+        "description": "Test-Connection [-TargetName] <string[]> -Traceroute [-IPv4] [-IPv6] [-ResolveDestination] [-Source <string>] [-MaxHops <int>] [-Quiet] [-TimeoutSeconds <int>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "IPv4": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "IPv6": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "MaxHops": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Quiet": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "ResolveDestination": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Source": {
+              "type": "string",
+              "default": null
+            },
+            "TimeoutSeconds": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Traceroute": {
+              "type": "object",
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "TargetName": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Traceroute",
+            "TargetName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Test-Connection",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_item_property_path",
+        "title": "Get-ItemProperty",
+        "description": "Get-ItemProperty [-Path] <string[]> [[-Name] <string[]>] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Credential <pscredential>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Name": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_fixture_bare",
+        "title": "Get-FixtureBare",
+        "description": "Get-FixtureBare [[-Anything] <string>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Anything": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-FixtureBare",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "resolve_path_path",
+        "title": "Resolve-Path",
+        "description": "Resolve-Path [-Path] <string[]> [-Relative] [-RelativeBasePath <string>] [-Force] [-Credential <pscredential>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Relative": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "RelativeBasePath": {
+              "type": "string",
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Resolve-Path",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "stop_process_id",
+        "title": "Stop-Process",
+        "description": "Stop-Process [-Id] <int[]> [-PassThru] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Id": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Id"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Stop-Process",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "invoke_item_literal_path",
+        "title": "Invoke-Item",
+        "description": "Invoke-Item -LiteralPath <string[]> [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Invoke-Item",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_service_default",
+        "title": "Get-Service",
+        "description": "Get-Service [[-Name] <string[]>] [-DependentServices] [-RequiredServices] [-Include <string[]>] [-Exclude <string[]>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "DependentServices": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "RequiredServices": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Name": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Service",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "clear_item_property_path",
+        "title": "Clear-ItemProperty",
+        "description": "Clear-ItemProperty [-Path] <string[]> [-Name] <string> [-PassThru] [-Force] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Name": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Clear-ItemProperty",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "wait_process_id",
+        "title": "Wait-Process",
+        "description": "Wait-Process [-Id] <int[]> [[-Timeout] <int>] [-Any] [-PassThru] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Any": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Id": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "Timeout": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Id"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Wait-Process",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "copy_item_property_path",
+        "title": "Copy-ItemProperty",
+        "description": "Copy-ItemProperty [-Path] <string[]> [-Destination] <string> [-Name] <string> [-PassThru] [-Force] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Destination": {
+              "type": "string"
+            },
+            "Name": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "Destination",
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Copy-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "rename_computer",
+        "title": "Rename-Computer",
+        "description": "Rename-Computer [-NewName] <string> [-ComputerName <string>] [-PassThru] [-DomainCredential <pscredential>] [-LocalCredential <pscredential>] [-Force] [-Restart] [-WsmanAuthentication <string>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "ComputerName": {
+              "type": "string",
+              "default": null
+            },
+            "DomainCredential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "LocalCredential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Restart": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "WsmanAuthentication": {
+              "type": "string",
+              "default": null
+            },
+            "NewName": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "NewName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Rename-Computer",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "test_connection_default_ping",
+        "title": "Test-Connection",
+        "description": "Test-Connection [-TargetName] <string[]> [-Ping] [-IPv4] [-IPv6] [-ResolveDestination] [-Source <string>] [-MaxHops <int>] [-Count <int>] [-Delay <int>] [-BufferSize <int>] [-DontFragment] [-Quiet] [-TimeoutSeconds <int>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "BufferSize": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Delay": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "DontFragment": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "IPv4": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "IPv6": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "MaxHops": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Ping": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Quiet": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "ResolveDestination": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Source": {
+              "type": "string",
+              "default": null
+            },
+            "TimeoutSeconds": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "TargetName": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "TargetName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Test-Connection",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_process_name_with_user_name",
+        "title": "Get-Process",
+        "description": "Get-Process [[-Name] <string[]>] -IncludeUserName [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "IncludeUserName": {
+              "type": "object",
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "Name": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "IncludeUserName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Process",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_time_zone_list_available",
+        "title": "Get-TimeZone",
+        "description": "Get-TimeZone -ListAvailable [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "ListAvailable": {
+              "type": "object",
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "ListAvailable"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-TimeZone",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_item_property_literal_path",
+        "title": "Get-ItemProperty",
+        "description": "Get-ItemProperty [[-Name] <string[]>] -LiteralPath <string[]> [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Credential <pscredential>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Name": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_psprovider",
+        "title": "Get-PSProvider",
+        "description": "Get-PSProvider [[-PSProvider] <string[]>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "PSProvider": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-PSProvider",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "restart_computer_default_set",
+        "title": "Restart-Computer",
+        "description": "Restart-Computer [[-ComputerName] <string[]>] [[-Credential] <pscredential>] [-WsmanAuthentication <string>] [-Force] [-Wait] [-Timeout <int>] [-For <WaitForServiceTypes>] [-Delay <short>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Delay": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_For": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "Wmi",
+                "WinRM",
+                "PowerShell",
+                null
+              ],
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Timeout": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Wait": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "WsmanAuthentication": {
+              "type": "string",
+              "default": null
+            },
+            "ComputerName": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Restart-Computer",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_fixture_full_help",
+        "title": "Get-FixtureFullHelp",
+        "description": "Get-FixtureFullHelp [-Message] <string> [[-Count] <int>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Message": {
+              "type": "string"
+            },
+            "Count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Message"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-FixtureFullHelp",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "start_process_default",
+        "title": "Start-Process",
+        "description": "Start-Process [-FilePath] <string> [[-ArgumentList] <string[]>] [-Credential <pscredential>] [-WorkingDirectory <string>] [-LoadUserProfile] [-NoNewWindow] [-PassThru] [-RedirectStandardError <string>] [-RedirectStandardInput <string>] [-RedirectStandardOutput <string>] [-WindowStyle <ProcessWindowStyle>] [-Wait] [-UseNewEnvironment] [-Environment <hashtable>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Environment": {
+              "type": "object",
+              "default": null
+            },
+            "LoadUserProfile": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "NoNewWindow": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "RedirectStandardError": {
+              "type": "string",
+              "default": null
+            },
+            "RedirectStandardInput": {
+              "type": "string",
+              "default": null
+            },
+            "RedirectStandardOutput": {
+              "type": "string",
+              "default": null
+            },
+            "UseNewEnvironment": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Wait": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "WindowStyle": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "Normal",
+                "Hidden",
+                "Minimized",
+                "Maximized",
+                null
+              ],
+              "default": null
+            },
+            "WorkingDirectory": {
+              "type": "string",
+              "default": null
+            },
+            "FilePath": {
+              "type": "string"
+            },
+            "ArgumentList": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "FilePath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Start-Process",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "new_item_property_path",
+        "title": "New-ItemProperty",
+        "description": "New-ItemProperty [-Path] <string[]> [-Name] <string> [-PropertyType <string>] [-Value <Object>] [-Force] [-Filter <string>] [-Include <string[]>] [-Exclude <string[]>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Credential": {
+              "type": "object",
+              "properties": {
+                "userName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "password": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "properties": {
+                    "length": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "default": null
+            },
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "PropertyType": {
+              "type": "string",
+              "default": null
+            },
+            "Path": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "Name": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "New-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "suspend_service_default",
+        "title": "Suspend-Service",
+        "description": "Suspend-Service [-Name] <string[]> [-PassThru] [-Include <string[]>] [-Exclude <string[]>] [-WhatIf] [-Confirm] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "properties": {
+                "isPresent": {
+                  "type": "boolean"
+                }
+              },
+              "default": null
+            },
+            "Name": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Suspend-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_psdrive_name",
+        "title": "Get-PSDrive",
+        "description": "Get-PSDrive [[-Name] <string[]>] [-Scope <string>] [-PSProvider <string[]>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "PSProvider": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "Scope": {
+              "type": "string",
+              "default": null
+            },
+            "Name": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-PSDrive",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      }
+    ]
+  },
+  "id": 2,
+  "jsonrpc": "2.0"
+}

--- a/specs/010-tool-self-documentation/baseline/oop-tools-list.json
+++ b/specs/010-tool-self-documentation/baseline/oop-tools-list.json
@@ -1,0 +1,11689 @@
+{
+  "result": {
+    "tools": [
+      {
+        "name": "set_service_input_object",
+        "title": "Set-Service",
+        "description": "Starts, stops, and suspends a service, and changes its properties.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "InputObject": {
+              "type": "string"
+            },
+            "DisplayName": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "Description": {
+              "type": "string",
+              "default": null
+            },
+            "StartupType": {
+              "type": "string",
+              "default": null
+            },
+            "SecurityDescriptorSddl": {
+              "type": "string",
+              "default": null
+            },
+            "Status": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "InputObject"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-Service",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_fixture_validate_set_array",
+        "title": "Get-FixtureValidateSetArray",
+        "description": "Get-FixtureValidateSetArray [-Directions] <string[]> [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Directions": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Directions"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-FixtureValidateSetArray",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_time_zone_name",
+        "title": "Set-TimeZone",
+        "description": "Sets the system time zone to a specified time zone.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-TimeZone",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_service_name",
+        "title": "Set-Service",
+        "description": "Starts, stops, and suspends a service, and changes its properties.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "string"
+            },
+            "DisplayName": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "Description": {
+              "type": "string",
+              "default": null
+            },
+            "StartupType": {
+              "type": "string",
+              "default": null
+            },
+            "SecurityDescriptorSddl": {
+              "type": "string",
+              "default": null
+            },
+            "Status": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-Service",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "debug_process_id",
+        "title": "Debug-Process",
+        "description": "Debugs one or more processes running on the local computer.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Id"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Debug-Process",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_item_literal_path",
+        "title": "Set-Item",
+        "description": "Changes the value of an item to the value specified in the command.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Value": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-Item",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_psdrive_literal_name",
+        "title": "Get-PSDrive",
+        "description": "Gets drives in the current session.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralName": {
+              "type": "string"
+            },
+            "Scope": {
+              "type": "string",
+              "default": null
+            },
+            "PSProvider": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-PSDrive",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "resume_service_display_name",
+        "title": "Resume-Service",
+        "description": "Resumes one or more suspended (paused) services.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "DisplayName": {
+              "type": "string"
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "DisplayName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Resume-Service",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "debug_process_name",
+        "title": "Debug-Process",
+        "description": "Debugs one or more processes running on the local computer.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Debug-Process",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "push_location_literal_path",
+        "title": "Push-Location",
+        "description": "Adds the current location to the top of a location stack.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string",
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "StackName": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Push-Location",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "remove_item_path",
+        "title": "Remove-Item",
+        "description": "Deletes the specified items.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Recurse": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "Stream": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Remove-Item",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "stop_service_default",
+        "title": "Stop-Service",
+        "description": "Stops one or more running services.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "NoWait": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Name": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Stop-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_fixture_synopsis_only",
+        "title": "Get-FixtureSynopsisOnly",
+        "description": "Returns a fixed sentinel string; exercises FR-500 step 1 (synopsis only, no description, no parameters).",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-FixtureSynopsisOnly",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "remove_service_input_object",
+        "title": "Remove-Service",
+        "description": "Removes a Windows service.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "InputObject": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Remove-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "test_path_literal_path",
+        "title": "Test-Path",
+        "description": "Determines whether all elements of a path exist.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "PathType": {
+              "type": "string",
+              "default": null
+            },
+            "IsValid": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "OlderThan": {
+              "type": "string",
+              "default": null
+            },
+            "NewerThan": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Test-Path",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_hot_fix_description",
+        "title": "Get-HotFix",
+        "description": "Gets the hotfixes that are installed on local or remote computers.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Description": {
+              "type": "string",
+              "default": null
+            },
+            "ComputerName": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-HotFix",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "remove_psdrive_literal_name",
+        "title": "Remove-PSDrive",
+        "description": "Deletes temporary PowerShell drives and disconnects mapped network drives.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralName": {
+              "type": "string"
+            },
+            "PSProvider": {
+              "type": "string",
+              "default": null
+            },
+            "Scope": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Remove-PSDrive",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "test_connection_tcp_port",
+        "title": "Test-Connection",
+        "description": "Sends ICMP echo request packets, or pings, to one or more computers.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "IPv4": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "IPv6": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "ResolveDestination": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Source": {
+              "type": "string",
+              "default": null
+            },
+            "Count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Delay": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Repeat": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Quiet": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "TimeoutSeconds": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "TargetName": {
+              "type": "string"
+            },
+            "TcpPort": {
+              "type": "integer"
+            },
+            "Detailed": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "TargetName",
+            "TcpPort"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Test-Connection",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "stop_process_name",
+        "title": "Stop-Process",
+        "description": "Stops one or more running processes.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Stop-Process",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "resume_service_default",
+        "title": "Resume-Service",
+        "description": "Resumes one or more suspended (paused) services.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Resume-Service",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_content_literal_path",
+        "title": "Get-Content",
+        "description": "Gets the content of the item at the specified location.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "ReadCount": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "TotalCount": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Tail": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "Delimiter": {
+              "type": "string",
+              "default": null
+            },
+            "Wait": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Raw": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Encoding": {
+              "type": "string",
+              "default": null
+            },
+            "AsByteStream": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Stream": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Content",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "move_item_property_literal_path",
+        "title": "Move-ItemProperty",
+        "description": "Moves a property from one location to another.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Name": {
+              "type": "string"
+            },
+            "Destination": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath",
+            "Name",
+            "Destination"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Move-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_item_property_value_literal_path",
+        "title": "Get-ItemPropertyValue",
+        "description": "Gets the value for one or more properties of a specified item.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Name": {
+              "type": "string"
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath",
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-ItemPropertyValue",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "move_item_literal_path",
+        "title": "Move-Item",
+        "description": "Moves an item from one location to another.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Destination": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Move-Item",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_location_literal_path",
+        "title": "Set-Location",
+        "description": "Sets the current working location to a specified location.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-Location",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "remove_psdrive_name",
+        "title": "Remove-PSDrive",
+        "description": "Deletes temporary PowerShell drives and disconnects mapped network drives.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "string"
+            },
+            "PSProvider": {
+              "type": "string",
+              "default": null
+            },
+            "Scope": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Remove-PSDrive",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "test_connection_mtu_size_detect",
+        "title": "Test-Connection",
+        "description": "Sends ICMP echo request packets, or pings, to one or more computers.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "IPv4": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "IPv6": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "ResolveDestination": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Quiet": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "TimeoutSeconds": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "TargetName": {
+              "type": "string"
+            },
+            "MtuSize": {
+              "type": "boolean"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "TargetName",
+            "MtuSize"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Test-Connection",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_hot_fix_default",
+        "title": "Get-HotFix",
+        "description": "Gets the hotfixes that are installed on local or remote computers.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "default": null
+            },
+            "ComputerName": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-HotFix",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_clipboard",
+        "title": "Set-Clipboard",
+        "description": "Sets the contents of the clipboard.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Value": {
+              "type": "string"
+            },
+            "Append": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "AsOSC52": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Value"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-Clipboard",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "rename_item_property_literal_path",
+        "title": "Rename-ItemProperty",
+        "description": "Renames a property of an item.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Name": {
+              "type": "string"
+            },
+            "NewName": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath",
+            "Name",
+            "NewName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Rename-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "resume_service_input_object",
+        "title": "Resume-Service",
+        "description": "Resumes one or more suspended (paused) services.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "InputObject": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "InputObject"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Resume-Service",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "rename_item_property_path",
+        "title": "Rename-ItemProperty",
+        "description": "Renames a property of an item.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Name": {
+              "type": "string"
+            },
+            "NewName": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "Name",
+            "NewName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Rename-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "clear_content_path",
+        "title": "Clear-Content",
+        "description": "Deletes the contents of an item, but does not delete the item.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "Stream": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Clear-Content",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "invoke_item_path",
+        "title": "Invoke-Item",
+        "description": "Performs the default action on the specified item.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Invoke-Item",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "split_path_leaf_base_set",
+        "title": "Split-Path",
+        "description": "Returns the specified part of a path.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "LeafBase": {
+              "type": "boolean"
+            },
+            "Resolve": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "LeafBase"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Split-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "remove_item_property_literal_path",
+        "title": "Remove-ItemProperty",
+        "description": "Deletes the property and its value from an item.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Name": {
+              "type": "string"
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath",
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Remove-ItemProperty",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_item_property_property_psobject_path_set",
+        "title": "Set-ItemProperty",
+        "description": "Creates or changes the value of a property of an item.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "InputObject": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "InputObject"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "convert_path_literal_path",
+        "title": "Convert-Path",
+        "description": "Converts a path from a PowerShell path to a PowerShell provider path.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Convert-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_time_zone_id",
+        "title": "Get-TimeZone",
+        "description": "Gets the current time zone or a list of available time zones.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Id"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-TimeZone",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "join_path",
+        "title": "Join-Path",
+        "description": "Combines a path and a child path into a single path.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "ChildPath": {
+              "type": "string"
+            },
+            "AdditionalChildPath": {
+              "type": "string",
+              "default": null
+            },
+            "Resolve": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "ChildPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Join-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_location_path",
+        "title": "Set-Location",
+        "description": "Sets the current working location to a specified location.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string",
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-Location",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_clipboard",
+        "title": "Get-Clipboard",
+        "description": "Gets the contents of the clipboard.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Raw": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Delimiter": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Clipboard",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_content_path",
+        "title": "Set-Content",
+        "description": "Writes new content or replaces existing content in a file.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Value": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Path": {
+              "type": "string"
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "NoNewline": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Encoding": {
+              "type": "string",
+              "default": null
+            },
+            "AsByteStream": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Stream": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Value",
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-Content",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "split_path_leaf_set",
+        "title": "Split-Path",
+        "description": "Returns the specified part of a path.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Leaf": {
+              "type": "boolean"
+            },
+            "Resolve": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "Leaf"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Split-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "clear_item_literal_path",
+        "title": "Clear-Item",
+        "description": "Clears the contents of an item, but does not delete the item.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Clear-Item",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "stop_service_input_object",
+        "title": "Stop-Service",
+        "description": "Stops one or more running services.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "NoWait": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "InputObject": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "InputObject"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Stop-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "push_location_path",
+        "title": "Push-Location",
+        "description": "Adds the current location to the top of a location stack.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string",
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "StackName": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Push-Location",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_time_zone_input_object",
+        "title": "Set-TimeZone",
+        "description": "Sets the system time zone to a specified time zone.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "InputObject": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "InputObject"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-TimeZone",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_item_property_value_path",
+        "title": "Get-ItemPropertyValue",
+        "description": "Gets the value for one or more properties of a specified item.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string",
+              "default": null
+            },
+            "Name": {
+              "type": "string"
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-ItemPropertyValue",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "debug_process_input_object",
+        "title": "Debug-Process",
+        "description": "Debugs one or more processes running on the local computer.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "InputObject": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "InputObject"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Debug-Process",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "new_service",
+        "title": "New-Service",
+        "description": "Creates a new Windows service.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "string"
+            },
+            "BinaryPathName": {
+              "type": "string"
+            },
+            "DisplayName": {
+              "type": "string",
+              "default": null
+            },
+            "Description": {
+              "type": "string",
+              "default": null
+            },
+            "StartupType": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "SecurityDescriptorSddl": {
+              "type": "string",
+              "default": null
+            },
+            "DependsOn": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name",
+            "BinaryPathName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "New-Service",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "copy_item_literal_path",
+        "title": "Copy-Item",
+        "description": "Copies an item from one location to another.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Destination": {
+              "type": "string",
+              "default": null
+            },
+            "Container": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Recurse": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "FromSession": {
+              "type": "string",
+              "default": null
+            },
+            "ToSession": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Copy-Item",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_process_name",
+        "title": "Get-Process",
+        "description": "Gets the processes that are running on the local computer.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "string",
+              "default": null
+            },
+            "Module": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "FileVersionInfo": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Process",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "copy_item_property_literal_path",
+        "title": "Copy-ItemProperty",
+        "description": "Copies a property and value from a specified location to another location.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Name": {
+              "type": "string"
+            },
+            "Destination": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath",
+            "Name",
+            "Destination"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Copy-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "remove_service_name",
+        "title": "Remove-Service",
+        "description": "Removes a Windows service.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Remove-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "split_path_is_absolute_set",
+        "title": "Split-Path",
+        "description": "Returns the specified part of a path.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Resolve": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "IsAbsolute": {
+              "type": "boolean"
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "IsAbsolute"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Split-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "split_path_parent_set",
+        "title": "Split-Path",
+        "description": "Returns the specified part of a path.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Parent": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Resolve": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Split-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_process_id_with_user_name",
+        "title": "Get-Process",
+        "description": "Gets the processes that are running on the local computer.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string"
+            },
+            "IncludeUserName": {
+              "type": "boolean"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Id",
+            "IncludeUserName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Process",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set-result-caching",
+        "title": "Set Result Caching",
+        "description": "Enable or disable result caching at runtime. When enabled, command output is cached for replay by filter/sort/group tools. Pass enabled=null or enabled='reset' to clear the runtime override and fall back to configuration. Runtime settings are ephemeral and do not persist across server restarts.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "scope": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "functionName": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "enabled",
+            "scope",
+            "functionName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set Result Caching",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": false,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "wait_process_name",
+        "title": "Wait-Process",
+        "description": "Waits for the processes to be stopped before accepting more input.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "string"
+            },
+            "Timeout": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Any": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Wait-Process",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_location_stack",
+        "title": "Get-Location",
+        "description": "Gets information about the current working location or a location stack.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Stack": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "StackName": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Location",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "split_path_qualifier_set",
+        "title": "Split-Path",
+        "description": "Returns the specified part of a path.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Qualifier": {
+              "type": "boolean"
+            },
+            "Resolve": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "Qualifier"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Split-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "clear_item_path",
+        "title": "Clear-Item",
+        "description": "Clears the contents of an item, but does not delete the item.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Clear-Item",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "clear_item_property_literal_path",
+        "title": "Clear-ItemProperty",
+        "description": "Clears the value of a property but does not delete the property.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Name": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath",
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Clear-ItemProperty",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "start_service_input_object",
+        "title": "Start-Service",
+        "description": "Starts one or more stopped services.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "InputObject": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "InputObject"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Start-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "restart_service_input_object",
+        "title": "Restart-Service",
+        "description": "Stops and then starts one or more services.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "InputObject": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "InputObject"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Restart-Service",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_service_input_object",
+        "title": "Get-Service",
+        "description": "Gets the services on the computer.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "DependentServices": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "RequiredServices": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "InputObject": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Service",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "clear_content_literal_path",
+        "title": "Clear-Content",
+        "description": "Deletes the contents of an item, but does not delete the item.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "Stream": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Clear-Content",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "test_path_path",
+        "title": "Test-Path",
+        "description": "Determines whether all elements of a path exist.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "PathType": {
+              "type": "string",
+              "default": null
+            },
+            "IsValid": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "OlderThan": {
+              "type": "string",
+              "default": null
+            },
+            "NewerThan": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Test-Path",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "start_service_default",
+        "title": "Start-Service",
+        "description": "Starts one or more stopped services.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Start-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "move_item_path",
+        "title": "Move-Item",
+        "description": "Moves an item from one location to another.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Destination": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Move-Item",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_item_path",
+        "title": "Get-Item",
+        "description": "Gets the item at the specified location.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "Stream": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Item",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "start_service_display_name",
+        "title": "Start-Service",
+        "description": "Starts one or more stopped services.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "DisplayName": {
+              "type": "string"
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "DisplayName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Start-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_time_zone_name",
+        "title": "Get-TimeZone",
+        "description": "Gets the current time zone or a list of available time zones.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-TimeZone",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_location_location",
+        "title": "Get-Location",
+        "description": "Gets information about the current working location or a location stack.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "PSProvider": {
+              "type": "string",
+              "default": null
+            },
+            "PSDrive": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Location",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_item_property_property_value_literal_path_set",
+        "title": "Set-ItemProperty",
+        "description": "Creates or changes the value of a property of an item.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Name": {
+              "type": "string"
+            },
+            "Value": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath",
+            "Name",
+            "Value"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "pop_location",
+        "title": "Pop-Location",
+        "description": "Changes the current location to the location most recently pushed onto the stack.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "StackName": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Pop-Location",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_fixture_validate_set_scalar",
+        "title": "Get-FixtureValidateSetScalar",
+        "description": "Get-FixtureValidateSetScalar [-Color] <string> [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Color": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Color"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-FixtureValidateSetScalar",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "remove_item_literal_path",
+        "title": "Remove-Item",
+        "description": "Deletes the specified items.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Recurse": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "Stream": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Remove-Item",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "clear_recycle_bin",
+        "title": "Clear-RecycleBin",
+        "description": "Clears the contents of the current user's recycle bin.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "DriveLetter": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Clear-RecycleBin",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "stop_computer",
+        "title": "Stop-Computer",
+        "description": "Stops (shuts down) local and remote computers.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "WsmanAuthentication": {
+              "type": "string",
+              "default": null
+            },
+            "ComputerName": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Stop-Computer",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_item_path",
+        "title": "Set-Item",
+        "description": "Changes the value of an item to the value specified in the command.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Value": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-Item",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_location_stack",
+        "title": "Set-Location",
+        "description": "Sets the current working location to a specified location.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "StackName": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-Location",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "new_item_path_set",
+        "title": "New-Item",
+        "description": "Creates a new item.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "ItemType": {
+              "type": "string",
+              "default": null
+            },
+            "Value": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "New-Item",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_process_id",
+        "title": "Get-Process",
+        "description": "Gets the processes that are running on the local computer.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string"
+            },
+            "Module": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "FileVersionInfo": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Id"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Process",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "split_path_extension_set",
+        "title": "Split-Path",
+        "description": "Returns the specified part of a path.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Extension": {
+              "type": "boolean"
+            },
+            "Resolve": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "Extension"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Split-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "rename_item_by_path",
+        "title": "Rename-Item",
+        "description": "Renames an item in a PowerShell provider namespace.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "NewName": {
+              "type": "string"
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "NewName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Rename-Item",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "suspend_service_input_object",
+        "title": "Suspend-Service",
+        "description": "Suspends (pauses) one or more running services.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "InputObject": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "InputObject"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Suspend-Service",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "restart_service_default",
+        "title": "Restart-Service",
+        "description": "Stops and then starts one or more services.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Name": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Restart-Service",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "test_connection_repeat_ping",
+        "title": "Test-Connection",
+        "description": "Sends ICMP echo request packets, or pings, to one or more computers.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Ping": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "IPv4": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "IPv6": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "ResolveDestination": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Source": {
+              "type": "string",
+              "default": null
+            },
+            "MaxHops": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Delay": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "BufferSize": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "DontFragment": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Repeat": {
+              "type": "boolean"
+            },
+            "Quiet": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "TimeoutSeconds": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "TargetName": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Repeat",
+            "TargetName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Test-Connection",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "wait_process_input_object",
+        "title": "Wait-Process",
+        "description": "Waits for the processes to be stopped before accepting more input.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Timeout": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Any": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "InputObject": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "InputObject"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Wait-Process",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_process_input_object",
+        "title": "Get-Process",
+        "description": "Gets the processes that are running on the local computer.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "InputObject": {
+              "type": "string"
+            },
+            "Module": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "FileVersionInfo": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "InputObject"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Process",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "new_item_property_literal_path",
+        "title": "New-ItemProperty",
+        "description": "Creates a new property for an item and sets its value.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Name": {
+              "type": "string"
+            },
+            "PropertyType": {
+              "type": "string",
+              "default": null
+            },
+            "Value": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath",
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "New-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "convert_path_path",
+        "title": "Convert-Path",
+        "description": "Converts a path from a PowerShell path to a PowerShell provider path.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Convert-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "stop_service_display_name",
+        "title": "Stop-Service",
+        "description": "Stops one or more running services.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "NoWait": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "DisplayName": {
+              "type": "string"
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "DisplayName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Stop-Service",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "restart_service_display_name",
+        "title": "Restart-Service",
+        "description": "Stops and then starts one or more services.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "DisplayName": {
+              "type": "string"
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "DisplayName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Restart-Service",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_process_input_object_with_user_name",
+        "title": "Get-Process",
+        "description": "Gets the processes that are running on the local computer.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "InputObject": {
+              "type": "string"
+            },
+            "IncludeUserName": {
+              "type": "boolean"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "InputObject",
+            "IncludeUserName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Process",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_item_property_property_psobject_literal_path_set",
+        "title": "Set-ItemProperty",
+        "description": "Creates or changes the value of a property of an item.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "InputObject": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath",
+            "InputObject"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_service_display_name",
+        "title": "Get-Service",
+        "description": "Gets the services on the computer.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "DependentServices": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "RequiredServices": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "DisplayName": {
+              "type": "string"
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "DisplayName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Service",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "start_process_use_shell_execute",
+        "title": "Start-Process",
+        "description": "Starts one or more processes on the local computer.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "FilePath": {
+              "type": "string"
+            },
+            "ArgumentList": {
+              "type": "string",
+              "default": null
+            },
+            "WorkingDirectory": {
+              "type": "string",
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Verb": {
+              "type": "string",
+              "default": null
+            },
+            "WindowStyle": {
+              "type": "string",
+              "default": null
+            },
+            "Wait": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Environment": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "FilePath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Start-Process",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_fixture_help_message_only",
+        "title": "Get-FixtureHelpMessageOnly",
+        "description": "Get-FixtureHelpMessageOnly [-UserId] <string> [[-Region] <string>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "UserId": {
+              "type": "string"
+            },
+            "Region": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "UserId"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-FixtureHelpMessageOnly",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "stop_process_input_object",
+        "title": "Stop-Process",
+        "description": "Stops one or more running processes.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "InputObject": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "InputObject"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Stop-Process",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_child_item_literal_items",
+        "title": "Get-ChildItem",
+        "description": "Gets the items and child items in one or more specified locations.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Recurse": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Depth": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Name": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Attributes": {
+              "type": "string",
+              "default": null
+            },
+            "FollowSymlink": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Directory": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "File": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Hidden": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_ReadOnly": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "System": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-ChildItem",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "new_psdrive",
+        "title": "New-PSDrive",
+        "description": "Creates temporary and persistent drives that are associated with a location in an item data store.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "string"
+            },
+            "PSProvider": {
+              "type": "string"
+            },
+            "Root": {
+              "type": "string"
+            },
+            "Description": {
+              "type": "string",
+              "default": null
+            },
+            "Scope": {
+              "type": "string",
+              "default": null
+            },
+            "Persist": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name",
+            "PSProvider",
+            "Root"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "New-PSDrive",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "suspend_service_display_name",
+        "title": "Suspend-Service",
+        "description": "Suspends (pauses) one or more running services.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "DisplayName": {
+              "type": "string"
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "DisplayName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Suspend-Service",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "add_content_path",
+        "title": "Add-Content",
+        "description": "Adds content to the specified items, such as adding words to a file.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Value": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Path": {
+              "type": "string"
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "NoNewline": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Encoding": {
+              "type": "string",
+              "default": null
+            },
+            "AsByteStream": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Stream": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Value",
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Add-Content",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_content_literal_path",
+        "title": "Set-Content",
+        "description": "Writes new content or replaces existing content in a file.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Value": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "NoNewline": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Encoding": {
+              "type": "string",
+              "default": null
+            },
+            "AsByteStream": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Stream": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Value",
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-Content",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_time_zone_id",
+        "title": "Set-TimeZone",
+        "description": "Sets the system time zone to a specified time zone.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Id"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-TimeZone",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "remove_item_property_path",
+        "title": "Remove-ItemProperty",
+        "description": "Deletes the property and its value from an item.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Name": {
+              "type": "string"
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Remove-ItemProperty",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "resolve_path_literal_path",
+        "title": "Resolve-Path",
+        "description": "Resolves the wildcard characters in a path, and displays the path contents.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Relative": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "RelativeBasePath": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Resolve-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "split_path_no_qualifier_set",
+        "title": "Split-Path",
+        "description": "Returns the specified part of a path.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "NoQualifier": {
+              "type": "boolean"
+            },
+            "Resolve": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "NoQualifier"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Split-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_item_literal_path",
+        "title": "Get-Item",
+        "description": "Gets the item at the specified location.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "Stream": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Item",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "split_path_literal_path_set",
+        "title": "Split-Path",
+        "description": "Returns the specified part of a path.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Resolve": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Split-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_computer_info",
+        "title": "Get-ComputerInfo",
+        "description": "Gets a consolidated object of system and operating system properties.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Property": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-ComputerInfo",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "rename_item_by_literal_path",
+        "title": "Rename-Item",
+        "description": "Renames an item in a PowerShell provider namespace.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "NewName": {
+              "type": "string"
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath",
+            "NewName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Rename-Item",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_child_item_items",
+        "title": "Get-ChildItem",
+        "description": "Gets the items and child items in one or more specified locations.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string",
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Recurse": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Depth": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Name": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Attributes": {
+              "type": "string",
+              "default": null
+            },
+            "FollowSymlink": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Directory": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "File": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Hidden": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_ReadOnly": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "System": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-ChildItem",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "new_item_name_set",
+        "title": "New-Item",
+        "description": "Creates a new item.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string",
+              "default": null
+            },
+            "Name": {
+              "type": "string"
+            },
+            "ItemType": {
+              "type": "string",
+              "default": null
+            },
+            "Value": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "New-Item",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "copy_item_path",
+        "title": "Copy-Item",
+        "description": "Copies an item from one location to another.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Destination": {
+              "type": "string",
+              "default": null
+            },
+            "Container": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Recurse": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "FromSession": {
+              "type": "string",
+              "default": null
+            },
+            "ToSession": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Copy-Item",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "move_item_property_path",
+        "title": "Move-ItemProperty",
+        "description": "Moves a property from one location to another.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Name": {
+              "type": "string"
+            },
+            "Destination": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "Name",
+            "Destination"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Move-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "test_connection_trace_route",
+        "title": "Test-Connection",
+        "description": "Sends ICMP echo request packets, or pings, to one or more computers.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "IPv4": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "IPv6": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "ResolveDestination": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Source": {
+              "type": "string",
+              "default": null
+            },
+            "MaxHops": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Quiet": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "TimeoutSeconds": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "TargetName": {
+              "type": "string"
+            },
+            "Traceroute": {
+              "type": "boolean"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "TargetName",
+            "Traceroute"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Test-Connection",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_item_property_path",
+        "title": "Get-ItemProperty",
+        "description": "Gets the properties of a specified item.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Name": {
+              "type": "string",
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_fixture_bare",
+        "title": "Get-FixtureBare",
+        "description": "Get-FixtureBare [[-Anything] <string>] [<CommonParameters>]",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Anything": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-FixtureBare",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "resolve_path_path",
+        "title": "Resolve-Path",
+        "description": "Resolves the wildcard characters in a path, and displays the path contents.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Relative": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "RelativeBasePath": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Resolve-Path",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "stop_process_id",
+        "title": "Stop-Process",
+        "description": "Stops one or more running processes.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Id"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Stop-Process",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "invoke_item_literal_path",
+        "title": "Invoke-Item",
+        "description": "Performs the default action on the specified item.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Invoke-Item",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_service_default",
+        "title": "Get-Service",
+        "description": "Gets the services on the computer.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "string",
+              "default": null
+            },
+            "DependentServices": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "RequiredServices": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Service",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "clear_item_property_path",
+        "title": "Clear-ItemProperty",
+        "description": "Clears the value of a property but does not delete the property.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Name": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Clear-ItemProperty",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "wait_process_id",
+        "title": "Wait-Process",
+        "description": "Waits for the processes to be stopped before accepting more input.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string"
+            },
+            "Timeout": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Any": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Id"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Wait-Process",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "copy_item_property_path",
+        "title": "Copy-ItemProperty",
+        "description": "Copies a property and value from a specified location to another location.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Name": {
+              "type": "string"
+            },
+            "Destination": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "Name",
+            "Destination"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Copy-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "set_item_property_property_value_path_set",
+        "title": "Set-ItemProperty",
+        "description": "Creates or changes the value of a property of an item.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Name": {
+              "type": "string"
+            },
+            "Value": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "Name",
+            "Value"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Set-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "rename_computer",
+        "title": "Rename-Computer",
+        "description": "Renames a computer.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "ComputerName": {
+              "type": "string",
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "DomainCredential": {
+              "type": "string",
+              "default": null
+            },
+            "LocalCredential": {
+              "type": "string",
+              "default": null
+            },
+            "NewName": {
+              "type": "string"
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Restart": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "WsmanAuthentication": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "NewName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Rename-Computer",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "add_content_literal_path",
+        "title": "Add-Content",
+        "description": "Adds content to the specified items, such as adding words to a file.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Value": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "NoNewline": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Encoding": {
+              "type": "string",
+              "default": null
+            },
+            "AsByteStream": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Stream": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Value",
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Add-Content",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "test_connection_default_ping",
+        "title": "Test-Connection",
+        "description": "Sends ICMP echo request packets, or pings, to one or more computers.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Ping": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "IPv4": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "IPv6": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "ResolveDestination": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Source": {
+              "type": "string",
+              "default": null
+            },
+            "MaxHops": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Delay": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "BufferSize": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "DontFragment": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Quiet": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "TimeoutSeconds": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "TargetName": {
+              "type": "string"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "TargetName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Test-Connection",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_process_name_with_user_name",
+        "title": "Get-Process",
+        "description": "Gets the processes that are running on the local computer.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "string",
+              "default": null
+            },
+            "IncludeUserName": {
+              "type": "boolean"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "IncludeUserName"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Process",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_time_zone_list_available",
+        "title": "Get-TimeZone",
+        "description": "Gets the current time zone or a list of available time zones.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "ListAvailable": {
+              "type": "boolean"
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "ListAvailable"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-TimeZone",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_item_property_literal_path",
+        "title": "Get-ItemProperty",
+        "description": "Gets the properties of a specified item.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "LiteralPath": {
+              "type": "string"
+            },
+            "Name": {
+              "type": "string",
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "LiteralPath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_content_path",
+        "title": "Get-Content",
+        "description": "Gets the content of the item at the specified location.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "ReadCount": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "TotalCount": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Tail": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "Path": {
+              "type": "string"
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "Delimiter": {
+              "type": "string",
+              "default": null
+            },
+            "Wait": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Raw": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Encoding": {
+              "type": "string",
+              "default": null
+            },
+            "AsByteStream": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Stream": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-Content",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_psprovider",
+        "title": "Get-PSProvider",
+        "description": "Gets information about the specified PowerShell provider.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "PSProvider": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-PSProvider",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "restart_computer_default_set",
+        "title": "Restart-Computer",
+        "description": "Restarts the operating system on local and remote computers.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "WsmanAuthentication": {
+              "type": "string",
+              "default": null
+            },
+            "ComputerName": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Wait": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Timeout": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_For": {
+              "type": "string",
+              "default": null
+            },
+            "Delay": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Restart-Computer",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_fixture_full_help",
+        "title": "Get-FixtureFullHelp",
+        "description": "Returns the input echoed back; exercises FR-500 step 2 and FR-510 step 1.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Message": {
+              "type": "string"
+            },
+            "Count": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Message"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-FixtureFullHelp",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "start_process_default",
+        "title": "Start-Process",
+        "description": "Starts one or more processes on the local computer.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "FilePath": {
+              "type": "string"
+            },
+            "ArgumentList": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "WorkingDirectory": {
+              "type": "string",
+              "default": null
+            },
+            "LoadUserProfile": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "NoNewWindow": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "RedirectStandardError": {
+              "type": "string",
+              "default": null
+            },
+            "RedirectStandardInput": {
+              "type": "string",
+              "default": null
+            },
+            "RedirectStandardOutput": {
+              "type": "string",
+              "default": null
+            },
+            "WindowStyle": {
+              "type": "string",
+              "default": null
+            },
+            "Wait": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "UseNewEnvironment": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Environment": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "FilePath"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Start-Process",
+          "destructiveHint": true,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "new_item_property_path",
+        "title": "New-ItemProperty",
+        "description": "Creates a new property for an item and sets its value.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Path": {
+              "type": "string"
+            },
+            "Name": {
+              "type": "string"
+            },
+            "PropertyType": {
+              "type": "string",
+              "default": null
+            },
+            "Value": {
+              "type": "string",
+              "default": null
+            },
+            "Force": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Filter": {
+              "type": "string",
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "Credential": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Path",
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "New-ItemProperty",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "suspend_service_default",
+        "title": "Suspend-Service",
+        "description": "Suspends (pauses) one or more running services.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "string"
+            },
+            "PassThru": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "Include": {
+              "type": "string",
+              "default": null
+            },
+            "Exclude": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          },
+          "required": [
+            "Name"
+          ]
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Suspend-Service",
+          "destructiveHint": false,
+          "idempotentHint": false,
+          "openWorldHint": true,
+          "readOnlyHint": false
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      },
+      {
+        "name": "get_psdrive_name",
+        "title": "Get-PSDrive",
+        "description": "Gets drives in the current session.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "string",
+              "default": null
+            },
+            "Scope": {
+              "type": "string",
+              "default": null
+            },
+            "PSProvider": {
+              "type": "string",
+              "default": null
+            },
+            "_AllProperties": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "_MaxResults": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "default": null
+            },
+            "_RequestedProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": null
+            }
+          }
+        },
+        "outputSchema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        },
+        "annotations": {
+          "title": "Get-PSDrive",
+          "destructiveHint": false,
+          "idempotentHint": true,
+          "openWorldHint": true,
+          "readOnlyHint": true
+        },
+        "execution": {
+          "taskSupport": "optional"
+        }
+      }
+    ]
+  },
+  "id": 2,
+  "jsonrpc": "2.0"
+}


### PR DESCRIPTION
Closes #224

Captures baseline tools/list JSON for in-process and OOP modes per FR-550 (spec 010 step 2).

**What this PR adds**
- specs/010-tool-self-documentation/baseline/inprocess-tools-list.json (133 tools)
- specs/010-tool-self-documentation/baseline/oop-tools-list.json (144 tools)
- specs/010-tool-self-documentation/baseline/capture-snapshots.ps1 — reproducible capture script
- specs/010-tool-self-documentation/baseline/README.md — capture date, server SHA, commands, regeneration policy
- PoshMcp.Tests/Fixtures/Modules/HelpParityFixture/ — the FR-521 fixture module (six deterministic functions, one per precedence-chain rung). Required to capture FR-500/FR-510 baselines and reused later by the parity + regression tests.

**Capture protocol**
The script launches dotnet PoshMcp.dll serve --transport stdio per mode, speaks initialize → notifications/initialized → tools/list, and persists the full JSON-RPC envelope pretty-printed (2-space indent, LF endings) for diff-friendly review.

**Notable pre-change parity artifacts (already documented in baseline/README.md)**
- Tool-count delta (133 vs 144) — the two runtime paths expose slightly different command surfaces today for the same configured module set. Out of scope for spec 010 (FR-551).
- The in-process discovery path requires explicit `CommandNames` to auto-load modules from PSModulePath; the OOP path imports `config.Modules` during `setup`. Captured as-is.
- `Environment.ImportModules` / `Environment.ModulePaths` are honored only by the OOP path in the current code (`PowerShellEnvironmentSetup` is unwired for in-process). The capture works around it by setting `PSModulePath` on the spawned process.

Reviewers: Farnsworth + Cubert (squad).