### PR TITLE
feat(metadata): extract IToolMetadataSource seam (#225)

### DIFF
--- a/PoshMcp.Server/McpToolFactoryV2.cs
+++ b/PoshMcp.Server/McpToolFactoryV2.cs
@@ -40,6 +40,7 @@ public class McpToolFactoryV2
     private readonly PowerShellAssemblyGenerator? _assemblyGenerator;
     private readonly OutOfProcessToolAssemblyGenerator? _outOfProcessAssemblyGenerator;
     private readonly ICommandExecutor? _commandExecutor;
+    private readonly IToolMetadataSource _toolMetadataSource;
     private static McpMetrics? _metrics;
 
     /// <summary>
@@ -55,8 +56,21 @@ public class McpToolFactoryV2
     /// Initializes a new instance of McpToolFactoryV2 with default runspace
     /// </summary>
     public McpToolFactoryV2()
+        : this(metadataSource: null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of McpToolFactoryV2 with default runspace and an
+    /// explicit tool-metadata source.
+    /// </summary>
+    /// <param name="metadataSource">Source that resolves MCP tool/parameter descriptions
+    /// per spec 010. <c>null</c> selects <see cref="DefaultToolMetadataSource"/> which
+    /// preserves pre-spec-010 behavior.</param>
+    public McpToolFactoryV2(IToolMetadataSource? metadataSource)
     {
         _assemblyGenerator = new PowerShellAssemblyGenerator(new SingletonPowerShellRunspace());
+        _toolMetadataSource = metadataSource ?? new DefaultToolMetadataSource();
     }
 
     /// <summary>
@@ -64,14 +78,42 @@ public class McpToolFactoryV2
     /// </summary>
     /// <param name="runspace">PowerShell runspace to use</param>
     public McpToolFactoryV2(IPowerShellRunspace runspace)
+        : this(runspace, metadataSource: null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of McpToolFactoryV2 with a specified runspace and an
+    /// explicit tool-metadata source.
+    /// </summary>
+    /// <param name="runspace">PowerShell runspace to use.</param>
+    /// <param name="metadataSource">Source that resolves MCP tool/parameter descriptions
+    /// per spec 010. <c>null</c> selects <see cref="DefaultToolMetadataSource"/> which
+    /// preserves pre-spec-010 behavior.</param>
+    public McpToolFactoryV2(IPowerShellRunspace runspace, IToolMetadataSource? metadataSource)
     {
         _assemblyGenerator = new PowerShellAssemblyGenerator(runspace);
+        _toolMetadataSource = metadataSource ?? new DefaultToolMetadataSource();
     }
 
     public McpToolFactoryV2(ICommandExecutor commandExecutor)
+        : this(commandExecutor, metadataSource: null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of McpToolFactoryV2 backed by an out-of-process command
+    /// executor and an explicit tool-metadata source.
+    /// </summary>
+    /// <param name="commandExecutor">Out-of-process command executor.</param>
+    /// <param name="metadataSource">Source that resolves MCP tool/parameter descriptions
+    /// per spec 010. <c>null</c> selects <see cref="DefaultToolMetadataSource"/> which
+    /// preserves pre-spec-010 behavior.</param>
+    public McpToolFactoryV2(ICommandExecutor commandExecutor, IToolMetadataSource? metadataSource)
     {
         _commandExecutor = commandExecutor ?? throw new ArgumentNullException(nameof(commandExecutor));
         _outOfProcessAssemblyGenerator = new OutOfProcessToolAssemblyGenerator(commandExecutor);
+        _toolMetadataSource = metadataSource ?? new DefaultToolMetadataSource();
     }
 
     /// <summary>
@@ -96,7 +138,7 @@ public class McpToolFactoryV2
         var metadata = CreateDefaultCommandMetadata(commandInfo);
         try
         {
-            SetParameterSetDescription(metadata, commandInfo, parameterSet, logger);
+            SetParameterSetDescription(metadata, commandInfo, parameterSet, _toolMetadataSource, logger);
             AnalyzeCommandVerbSafety(metadata, commandInfo, powerShell, logger);
         }
         catch (Exception ex)
@@ -120,25 +162,24 @@ public class McpToolFactoryV2
         };
     }
 
-    private static void SetParameterSetDescription(PowerShellCommandMetadata metadata, CommandInfo commandInfo, CommandParameterSetInfo parameterSet, ILogger logger)
+    private static void SetParameterSetDescription(PowerShellCommandMetadata metadata, CommandInfo commandInfo, CommandParameterSetInfo parameterSet, IToolMetadataSource metadataSource, ILogger logger)
     {
         try
         {
             var parameterSetSyntax = parameterSet.ToString();
-            if (!string.IsNullOrWhiteSpace(parameterSetSyntax))
-            {
-                metadata.Description = $"{commandInfo.Name} {parameterSetSyntax}";
-                logger.LogDebug($"Generated parameter-set-specific description for {commandInfo.Name} ({parameterSet.Name}): {metadata.Description}");
-            }
-            else
-            {
-                metadata.Description = commandInfo.Name;
-                logger.LogDebug($"No parameter set syntax available for {commandInfo.Name} ({parameterSet.Name}), using command name as fallback");
-            }
+            var request = new ToolDescriptionRequest(
+                CommandName: commandInfo.Name,
+                ParameterSetName: parameterSet.Name,
+                Synopsis: null,
+                LongDescription: null,
+                ParameterSetSyntax: parameterSetSyntax);
+            var result = metadataSource.ResolveToolDescription(in request);
+            metadata.Description = result.Description;
+            logger.LogDebug($"Resolved description for {commandInfo.Name} ({parameterSet.Name}) via {result.Source}: {metadata.Description}");
         }
         catch (Exception ex)
         {
-            logger.LogWarning($"Could not generate parameter-set syntax for command {commandInfo.Name} ({parameterSet.Name}): {ex.Message}");
+            logger.LogWarning($"Could not resolve tool description for command {commandInfo.Name} ({parameterSet.Name}): {ex.Message}");
             metadata.Description = commandInfo.Name;
         }
     }
@@ -351,7 +392,7 @@ public class McpToolFactoryV2
         _outOfProcessAssemblyGenerator.GenerateAssembly(schemas, logger);
         var generatedInstance = _outOfProcessAssemblyGenerator.GetGeneratedInstance(logger);
         var generatedMethods = _outOfProcessAssemblyGenerator.GetGeneratedMethods();
-        var methodToCommandMap = CreateRemoteCommandMetadataMapping(schemas);
+        var methodToCommandMap = CreateRemoteCommandMetadataMapping(schemas, _toolMetadataSource);
         var tools = CreateMcpToolsFromMethods(generatedMethods, generatedInstance, methodToCommandMap, logger);
         LogToolGenerationResults(tools, logger);
         return tools;
@@ -429,17 +470,24 @@ public class McpToolFactoryV2
         return methodToCommandMap;
     }
 
-    private static Dictionary<string, PowerShellCommandMetadata> CreateRemoteCommandMetadataMapping(IReadOnlyList<RemoteToolSchema> schemas)
+    private static Dictionary<string, PowerShellCommandMetadata> CreateRemoteCommandMetadataMapping(IReadOnlyList<RemoteToolSchema> schemas, IToolMetadataSource metadataSource)
     {
         var methodToCommandMap = new Dictionary<string, PowerShellCommandMetadata>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var schema in schemas)
         {
             var methodName = PowerShellAssemblyGenerator.SanitizeMethodName(schema.Name, schema.ParameterSetName);
+            var request = new ToolDescriptionRequest(
+                CommandName: schema.Name,
+                ParameterSetName: schema.ParameterSetName,
+                Synopsis: string.IsNullOrWhiteSpace(schema.Description) ? null : schema.Description,
+                LongDescription: null,
+                ParameterSetSyntax: null);
+            var result = metadataSource.ResolveToolDescription(in request);
             var metadata = new PowerShellCommandMetadata
             {
                 CommandName = schema.Name,
-                Description = string.IsNullOrWhiteSpace(schema.Description) ? schema.Name : schema.Description,
+                Description = result.Description,
                 IsDestructive = false,
                 IsReadOnly = false,
                 IsIdempotent = false

--- a/PoshMcp.Server/PowerShell/DefaultToolMetadataSource.cs
+++ b/PoshMcp.Server/PowerShell/DefaultToolMetadataSource.cs
@@ -1,0 +1,83 @@
+using System;
+
+namespace PoshMcp.Server.PowerShell;
+
+/// <summary>
+/// Default <see cref="IToolMetadataSource"/> implementation. Preserves the pre-spec-010
+/// behavior byte-for-byte so wiring this seam into both execution paths does not change any
+/// observable tool or parameter description text.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Tool descriptions: prefers <c>Synopsis</c> when supplied and non-empty (the OOP path's
+/// current behavior); otherwise falls back to the in-process behavior of
+/// <c>"{CommandName} {ParameterSetSyntax}"</c>; otherwise returns the bare command name.
+/// The <c>LongDescription</c> input is intentionally ignored at this stage — Get-Help
+/// long-description sourcing is the responsibility of follow-up issues #226 (in-process)
+/// and #227 (out-of-process).
+/// </para>
+/// <para>
+/// Parameter descriptions: always returns the type fallback string. The richer precedence
+/// chain (Get-Help parameter, HelpMessage, ValidateSet) is also implemented in #226/#227.
+/// </para>
+/// <para>
+/// Thread-safe: stateless.
+/// </para>
+/// </remarks>
+public sealed class DefaultToolMetadataSource : IToolMetadataSource
+{
+    /// <inheritdoc />
+    public ToolDescriptionResult ResolveToolDescription(in ToolDescriptionRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.CommandName))
+        {
+            throw new ArgumentException(
+                $"{nameof(ToolDescriptionRequest.CommandName)} must not be null or whitespace.",
+                nameof(request));
+        }
+
+        // Pre-spec-010 OOP behavior: use Synopsis when present, non-empty, and not equal to
+        // the command name. The spec records this comparison rule in FR-500 step 1.
+        if (!string.IsNullOrWhiteSpace(request.Synopsis))
+        {
+            var synopsis = request.Synopsis!.Trim();
+            if (!string.Equals(synopsis, request.CommandName, StringComparison.Ordinal))
+            {
+                return new ToolDescriptionResult(synopsis, ToolDescriptionSource.Synopsis);
+            }
+        }
+
+        // Pre-spec-010 in-process behavior: "{CommandName} {ParameterSetSyntax}".
+        if (!string.IsNullOrWhiteSpace(request.ParameterSetSyntax))
+        {
+            return new ToolDescriptionResult(
+                $"{request.CommandName} {request.ParameterSetSyntax}",
+                ToolDescriptionSource.Syntax);
+        }
+
+        // Final fallback: bare command name.
+        return new ToolDescriptionResult(request.CommandName, ToolDescriptionSource.Name);
+    }
+
+    /// <inheritdoc />
+    public ParameterDescriptionResult ResolveParameterDescription(in ParameterDescriptionRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.ParameterName))
+        {
+            throw new ArgumentException(
+                $"{nameof(ParameterDescriptionRequest.ParameterName)} must not be null or whitespace.",
+                nameof(request));
+        }
+
+        var typeName = string.IsNullOrWhiteSpace(request.ParameterTypeName)
+            ? "Object"
+            : request.ParameterTypeName;
+
+        // Pre-spec-010 behavior, preserved at every call site: "Parameter of type <Type>".
+        // Richer sources (HelpParameter, HelpMessage, ValidateSet) are intentionally NOT
+        // consulted here — they land in #226 / #227.
+        return new ParameterDescriptionResult(
+            $"Parameter of type {typeName}",
+            ParameterDescriptionSource.TypeFallback);
+    }
+}

--- a/PoshMcp.Server/PowerShell/IToolMetadataSource.cs
+++ b/PoshMcp.Server/PowerShell/IToolMetadataSource.cs
@@ -1,0 +1,160 @@
+using System.Collections.Generic;
+
+namespace PoshMcp.Server.PowerShell;
+
+/// <summary>
+/// Shared sourcing seam for MCP tool and parameter descriptions, applied identically by
+/// both the in-process and out-of-process execution paths.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This seam exists to satisfy spec 010 (Improve MCP Tool Self-Documentation) Approach
+/// Option A: a single precedence implementation consumed by both
+/// <c>McpToolFactoryV2.SetParameterSetDescription</c> (in-process) and
+/// <c>McpToolFactoryV2.CreateRemoteCommandMetadataMapping</c> (out-of-process). The
+/// default implementation supplied with this seam preserves pre-spec-010 behavior
+/// exactly — Get-Help-based precedence chains land in follow-up work (issues #226 and
+/// #227); this seam is the API surface they will plug into.
+/// </para>
+/// <para>
+/// Implementations MUST be thread-safe: a single instance is shared across all tool
+/// discovery on a server.
+/// </para>
+/// </remarks>
+public interface IToolMetadataSource
+{
+    /// <summary>
+    /// Resolves the MCP tool description for a single parameter set of a PowerShell command,
+    /// applying the documented precedence chain (synopsis → long description → syntax line →
+    /// bare command name).
+    /// </summary>
+    /// <param name="request">Inputs known to the caller (command name, optional pre-resolved
+    /// help fields, optional parameter-set syntax). Members that the caller cannot provide
+    /// MUST be left null/empty.</param>
+    /// <returns>The resolved description and the precedence step that produced it.</returns>
+    ToolDescriptionResult ResolveToolDescription(in ToolDescriptionRequest request);
+
+    /// <summary>
+    /// Resolves the MCP parameter description for a single parameter of a PowerShell command,
+    /// applying the documented precedence chain (Get-Help parameter → ParameterAttribute
+    /// HelpMessage → ValidateSet phrasing → type fallback).
+    /// </summary>
+    /// <param name="request">Inputs known to the caller. Members that the caller cannot
+    /// provide MUST be left null/empty.</param>
+    /// <returns>The resolved description and the precedence step that produced it.</returns>
+    ParameterDescriptionResult ResolveParameterDescription(in ParameterDescriptionRequest request);
+}
+
+/// <summary>
+/// Inputs to <see cref="IToolMetadataSource.ResolveToolDescription"/>.
+/// </summary>
+/// <param name="CommandName">The full PowerShell command name (e.g., "Get-AzContext").
+/// Always required.</param>
+/// <param name="ParameterSetName">The parameter set name this description applies to, or
+/// <c>null</c> for <c>__AllParameterSets</c>. Used for logging/diagnostics only — tool
+/// description text is per-command, not per-parameter-set (spec 010 FR-501).</param>
+/// <param name="Synopsis">Pre-resolved Get-Help <c>.Synopsis</c>, when the caller has it
+/// (the OOP path supplies this from the subprocess; the in-process path will supply it once
+/// #226 lands). <c>null</c> or empty means "not available."</param>
+/// <param name="LongDescription">Pre-resolved Get-Help <c>.Description</c> body, joined per
+/// the sanitization rules in spec 010 FR-540. <c>null</c> or empty means "not available."</param>
+/// <param name="ParameterSetSyntax">The <c>CommandParameterSetInfo.ToString()</c> syntax
+/// string for the in-process path. <c>null</c> or empty means "not available."</param>
+public readonly record struct ToolDescriptionRequest(
+    string CommandName,
+    string? ParameterSetName,
+    string? Synopsis,
+    string? LongDescription,
+    string? ParameterSetSyntax);
+
+/// <summary>
+/// Output of <see cref="IToolMetadataSource.ResolveToolDescription"/>.
+/// </summary>
+/// <param name="Description">The final, sanitized, length-capped description string to be
+/// surfaced to MCP clients. Never <c>null</c>; falls back to the bare command name when no
+/// other source has content.</param>
+/// <param name="Source">The precedence step that produced <paramref name="Description"/>.
+/// Reported by doctor output (spec 010 FR-583) and emitted as a metric tag (FR-590).</param>
+public readonly record struct ToolDescriptionResult(
+    string Description,
+    ToolDescriptionSource Source);
+
+/// <summary>
+/// Identifies which step of the tool-description precedence chain produced a result.
+/// Values map one-to-one with the <c>descriptionSource</c> string literals in spec 010
+/// FR-583 (<c>synopsis | description | syntax | name</c>).
+/// </summary>
+public enum ToolDescriptionSource
+{
+    /// <summary>Get-Help <c>.Synopsis</c> (FR-500 step 1).</summary>
+    Synopsis,
+
+    /// <summary>Get-Help <c>.Description</c> body (FR-500 step 2).</summary>
+    Description,
+
+    /// <summary><c>CommandParameterSetInfo.ToString()</c> syntax line (FR-500 step 3).</summary>
+    Syntax,
+
+    /// <summary>Bare command name fallback (FR-500 step 4).</summary>
+    Name,
+}
+
+/// <summary>
+/// Inputs to <see cref="IToolMetadataSource.ResolveParameterDescription"/>.
+/// </summary>
+/// <param name="CommandName">The owning command name (e.g., "Get-AzContext"). Always
+/// required.</param>
+/// <param name="ParameterName">The parameter name without the leading dash (e.g., "Name").
+/// Always required.</param>
+/// <param name="ParameterTypeName">The .NET type name of the parameter (e.g.,
+/// "System.String"). Always required — used by the type-fallback step
+/// (<see cref="ParameterDescriptionSource.TypeFallback"/>).</param>
+/// <param name="HelpParameterDescription">Pre-resolved Get-Help parameter description text,
+/// joined and sanitized per spec 010 FR-540. <c>null</c> or empty means "not available."</param>
+/// <param name="HelpMessage">Value of <c>[Parameter(HelpMessage="...")]</c>, when present.
+/// <c>null</c> or empty means "not available."</param>
+/// <param name="ValidateSetValues">Allowed values from a <c>[ValidateSet(...)]</c>
+/// attribute, in declaration order. <c>null</c> or empty means "not available."</param>
+/// <param name="ValidateSetAppliesToArrayElement">When <paramref name="ValidateSetValues"/>
+/// is supplied, indicates whether the validated set constrains array elements (true) or the
+/// scalar parameter itself (false). Drives the FR-510 step 3 phrasing
+/// ("Each item is one of: ..." vs. "One of: ...").</param>
+public readonly record struct ParameterDescriptionRequest(
+    string CommandName,
+    string ParameterName,
+    string ParameterTypeName,
+    string? HelpParameterDescription,
+    string? HelpMessage,
+    IReadOnlyList<string>? ValidateSetValues,
+    bool ValidateSetAppliesToArrayElement);
+
+/// <summary>
+/// Output of <see cref="IToolMetadataSource.ResolveParameterDescription"/>.
+/// </summary>
+/// <param name="Description">The final, sanitized, length-capped description string. Never
+/// <c>null</c>; falls back to <c>"Parameter of type &lt;TypeName&gt;"</c> when no other
+/// source has content.</param>
+/// <param name="Source">The precedence step that produced <paramref name="Description"/>.</param>
+public readonly record struct ParameterDescriptionResult(
+    string Description,
+    ParameterDescriptionSource Source);
+
+/// <summary>
+/// Identifies which step of the parameter-description precedence chain produced a result.
+/// Values map one-to-one with the <c>descriptionSource</c> string literals in spec 010
+/// FR-583 (<c>helpParameter | helpMessage | validateSet | typeFallback</c>).
+/// </summary>
+public enum ParameterDescriptionSource
+{
+    /// <summary>Get-Help <c>.Parameters.parameter[].description</c> (FR-510 step 1).</summary>
+    HelpParameter,
+
+    /// <summary><c>[Parameter(HelpMessage="...")]</c> (FR-510 step 2).</summary>
+    HelpMessage,
+
+    /// <summary><c>[ValidateSet(...)]</c> allowed-values phrasing (FR-510 step 3).</summary>
+    ValidateSet,
+
+    /// <summary><c>Parameter of type &lt;TypeName&gt;</c> fallback (FR-510 step 4).</summary>
+    TypeFallback,
+}

--- a/PoshMcp.Server/Server/HttpServerHost.cs
+++ b/PoshMcp.Server/Server/HttpServerHost.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -278,6 +279,11 @@ internal static class HttpServerHost
     private static void ConfigureOpenTelemetryForHttp(WebApplicationBuilder builder)
     {
         builder.Services.AddSingleton<McpMetrics>();
+
+        // Spec 010 seam: shared MCP tool/parameter description sourcing. The default impl
+        // preserves pre-spec-010 behavior; #226 / #227 replace this registration with an
+        // implementation that consults Get-Help.
+        builder.Services.TryAddSingleton<IToolMetadataSource, DefaultToolMetadataSource>();
 
         builder.Services.AddOpenTelemetry()
             .WithTracing(tracingBuilder =>

--- a/PoshMcp.Server/Server/McpToolSetupService.cs
+++ b/PoshMcp.Server/Server/McpToolSetupService.cs
@@ -30,7 +30,8 @@ internal static class McpToolSetupService
         ILogger logger,
         string finalConfigPath,
         string configurationPathSource,
-        ICommandExecutor? commandExecutor)
+        ICommandExecutor? commandExecutor,
+        IToolMetadataSource? toolMetadataSource = null)
     {
         // Create RuntimeCachingState singleton and wire into assembly generator static state
         var runtimeCachingState = new RuntimeCachingState();
@@ -38,7 +39,7 @@ internal static class McpToolSetupService
         PowerShellAssemblyGenerator.SetConfiguration(config);
         logger.LogInformation("RuntimeCachingState initialized and wired into PowerShellAssemblyGenerator");
 
-        var toolFactory = CreateToolFactory(config, commandExecutor);
+        var toolFactory = CreateToolFactory(config, commandExecutor, runspace: null, toolMetadataSource);
         var tools = await toolFactory.GetToolsListAsync(config, logger);
 
         if (config.EnableDynamicReloadTools)
@@ -75,14 +76,15 @@ internal static class McpToolSetupService
         string configurationPathSource,
         IPowerShellRunspace sessionAwareRunspace,
         ICommandExecutor? commandExecutor,
-        IHttpContextAccessor? httpContextAccessor = null)
+        IHttpContextAccessor? httpContextAccessor = null,
+        IToolMetadataSource? toolMetadataSource = null)
     {
         var runtimeCachingState = new RuntimeCachingState();
         PowerShellAssemblyGenerator.SetRuntimeCachingState(runtimeCachingState);
         PowerShellAssemblyGenerator.SetConfiguration(config);
         logger.LogInformation("RuntimeCachingState initialized and wired into PowerShellAssemblyGenerator");
 
-        var toolFactory = CreateToolFactory(config, commandExecutor, sessionAwareRunspace);
+        var toolFactory = CreateToolFactory(config, commandExecutor, sessionAwareRunspace, toolMetadataSource);
         var tools = await toolFactory.GetToolsListAsync(config, logger);
 
         if (config.EnableDynamicReloadTools)
@@ -129,19 +131,29 @@ internal static class McpToolSetupService
     /// Creates an appropriate tool factory based on configuration and runtime mode.
     /// Handles both in-process and out-of-process execution modes.
     /// </summary>
+    /// <param name="config">Runtime configuration.</param>
+    /// <param name="commandExecutor">Out-of-process command executor; required when
+    /// <see cref="RuntimeMode"/> is <see cref="RuntimeMode.OutOfProcess"/>.</param>
+    /// <param name="runspace">Optional in-process runspace override (HTTP session-aware path).</param>
+    /// <param name="toolMetadataSource">Optional spec-010 description source.
+    /// When <c>null</c>, <see cref="DefaultToolMetadataSource"/> is selected, which
+    /// preserves pre-spec-010 behavior.</param>
     private static McpToolFactoryV2 CreateToolFactory(
         PowerShellConfiguration config,
         ICommandExecutor? commandExecutor,
-        IPowerShellRunspace? runspace = null)
+        IPowerShellRunspace? runspace = null,
+        IToolMetadataSource? toolMetadataSource = null)
     {
         if (config.RuntimeMode == RuntimeMode.OutOfProcess)
         {
             return commandExecutor is null
                 ? throw new InvalidOperationException("Out-of-process runtime mode requires a started command executor.")
-                : new McpToolFactoryV2(commandExecutor);
+                : new McpToolFactoryV2(commandExecutor, toolMetadataSource);
         }
 
-        return runspace is null ? new McpToolFactoryV2() : new McpToolFactoryV2(runspace);
+        return runspace is null
+            ? new McpToolFactoryV2(toolMetadataSource)
+            : new McpToolFactoryV2(runspace, toolMetadataSource);
     }
 
     /// <summary>

--- a/PoshMcp.Server/Server/StdioServerHost.cs
+++ b/PoshMcp.Server/Server/StdioServerHost.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Serilog;
@@ -139,6 +140,11 @@ internal static class StdioServerHost
     {
         // Register and configure OpenTelemetry metrics
         builder.Services.AddSingleton<McpMetrics>();
+
+        // Spec 010 seam: shared MCP tool/parameter description sourcing. The default impl
+        // preserves pre-spec-010 behavior; #226 / #227 replace this registration with an
+        // implementation that consults Get-Help.
+        builder.Services.TryAddSingleton<IToolMetadataSource, DefaultToolMetadataSource>();
 
         builder.Services.AddOpenTelemetry()
             .WithTracing(tracingBuilder =>


### PR DESCRIPTION
Closes #225

Introduces IToolMetadataSource per spec 010 Option A. Seam only - no behavior change. Foundational for #226, #227, #228.

## What's in this PR

- PoshMcp.Server/PowerShell/IToolMetadataSource.cs - interface + request/result records, source enums (values align 1:1 with spec 010 FR-583 descriptionSource literals).
- PoshMcp.Server/PowerShell/DefaultToolMetadataSource.cs - pass-through implementation preserving pre-spec-010 behavior byte-for-byte.
- McpToolFactoryV2 - both SetParameterSetDescription (in-process) and CreateRemoteCommandMetadataMapping (OOP) route through the seam.
- StdioServerHost / HttpServerHost - TryAddSingleton<IToolMetadataSource, DefaultToolMetadataSource>() so #226/#227 can swap in a replacement via DI.
- McpToolSetupService.CreateToolFactory - accepts optional IToolMetadataSource, defaults to no-op.

## Behavior preservation

Default impl reproduces existing paths: in-process Syntax->Name fallback identical; OOP Synopsis-when-non-empty identical to schema.Description path.

## Not in this PR (deferred)

- Get-Help precedence chain (FR-500/FR-510): #226 + #227.
- RemoteToolSchema wire-format extension: #227.
- Doctor descriptionSource + metrics counters: #228.
- PowerShellSchemaGenerator parameter-description wiring: deferred to #226.

## Validation

- dotnet build PoshMcp.sln -c Release: 0 errors. 20 warnings all pre-existing.
- dotnet test --filter Category!=Integration: 661 passed, 7 skipped, 0 failed.

## Spec gaps

None material. Minor reviewer call: ToolDescriptionRequest.LongDescription is on the interface but default impl ignores it (spec assigns long-description sourcing to #226's caller-side Get-Help integration, not the seam itself).

Reviewers: Farnsworth + Cubert (squad).