### PR TITLE
feat(oop): extend RemoteToolSchema with full description + per-parameter metadata (#227)

### DIFF
--- a/PoshMcp.Server/PowerShell/OutOfProcess/RemoteToolSchema.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/RemoteToolSchema.cs
@@ -17,11 +17,36 @@ public class RemoteToolSchema
     /// Human-readable description for the command. Populated by the OOP host
     /// from <c>Get-Help</c>'s <c>.Synopsis</c> field (trimmed, and only when
     /// it differs from the command name); otherwise the empty string. The
-    /// long <c>Description</c> body and parameter set syntax are NOT read.
+    /// long <c>Description</c> body is exposed separately via
+    /// <see cref="FullDescription"/>; parameter set syntax is NOT read here.
     /// When empty, downstream tool schema generation falls back to the bare
     /// command name.
     /// </summary>
+    /// <remarks>
+    /// Preserved verbatim for backward compatibility with consumers that
+    /// only know about this field. Spec 010 introduces <see cref="FullDescription"/>
+    /// alongside it; the precedence chain (FR-500) is applied on the .NET
+    /// consumer side, not by the host script.
+    /// </remarks>
     public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional long-form description body sourced from
+    /// <c>Get-Help &lt;command&gt;.Description</c>, an array of
+    /// <c>MamlParaText</c> objects whose <c>.Text</c> values are joined with
+    /// the paragraph separator <c>"\n\n"</c>. Raw text — no sanitization or
+    /// length capping is applied by the host; the .NET consumer applies
+    /// FR-540 sanitization and FR-541 length caps.
+    /// </summary>
+    /// <remarks>
+    /// <c>null</c> when <c>Get-Help</c> returned no help record, threw, or
+    /// returned a record whose <c>.Description</c> property was absent or
+    /// empty. The empty string is also possible when <c>Description</c>
+    /// existed but contained only whitespace after the join.
+    /// Consumers MUST treat <c>null</c> and empty-or-whitespace as
+    /// "no value" and fall through to the next precedence step.
+    /// </remarks>
+    public string? FullDescription { get; set; }
 
     /// <summary>
     /// The parameter set name this schema represents
@@ -52,4 +77,48 @@ public class RemoteParameterSchema
 
     public bool IsMandatory { get; set; }
     public int Position { get; set; } = int.MaxValue;
+
+    /// <summary>
+    /// Optional per-parameter description text sourced from
+    /// <c>Get-Help &lt;command&gt;.Parameters.parameter[name=&lt;Name&gt;].description</c>,
+    /// joined paragraph-by-paragraph with <c>"\n\n"</c>. Raw text — the
+    /// .NET consumer applies FR-540 sanitization and FR-542 length caps.
+    /// </summary>
+    /// <remarks>
+    /// <c>null</c> when the help record had no entry for this parameter, the
+    /// entry's <c>description</c> array was absent, or <c>Get-Help</c>
+    /// itself was unavailable. Consumers treat <c>null</c> or
+    /// empty-or-whitespace as "no value" and fall through to the next
+    /// precedence step (HelpMessage → ValidateSet → type fallback) per
+    /// FR-510.
+    /// </remarks>
+    public string? HelpDescription { get; set; }
+
+    /// <summary>
+    /// Optional <c>HelpMessage</c> value from <c>[Parameter(HelpMessage="...")]</c>
+    /// on this parameter, read from <c>CommandInfo.Parameters[Name].Attributes</c>
+    /// of type <c>System.Management.Automation.ParameterAttribute</c>.
+    /// </summary>
+    /// <remarks>
+    /// <c>null</c> when no <c>ParameterAttribute</c> sets <c>HelpMessage</c>,
+    /// or when the attribute was unavailable. If multiple parameter sets
+    /// declare the parameter with different <c>HelpMessage</c> values, the
+    /// first non-empty value encountered is emitted; the host does not
+    /// attempt to reconcile divergent values across attributes.
+    /// </remarks>
+    public string? HelpMessage { get; set; }
+
+    /// <summary>
+    /// Optional list of allowed values from <c>[ValidateSet(...)]</c> on this
+    /// parameter, read from the parameter's
+    /// <c>System.Management.Automation.ValidateSetAttribute.ValidValues</c>
+    /// collection.
+    /// </summary>
+    /// <remarks>
+    /// <c>null</c> when the parameter has no <c>ValidateSetAttribute</c>.
+    /// An empty array is theoretically possible but treated equivalently to
+    /// <c>null</c> by FR-510 step 3. Order is preserved as declared in the
+    /// attribute.
+    /// </remarks>
+    public string[]? ValidateSetValues { get; set; }
 }

--- a/PoshMcp.Server/PowerShell/OutOfProcess/oop-host-pool.ps1
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/oop-host-pool.ps1
@@ -820,29 +820,118 @@ function Invoke-DiscoverHandler {
         }
 
         $schemas = [System.Collections.ArrayList]::new()
-        foreach ($cmd in $unique) {
-            $description = ''
+
+        # Helper: project a Get-Help record into raw RemoteToolSchema fields.
+        # Sanitization, length capping, and FR-500/FR-510 precedence resolution
+        # happen on the .NET consumer side. The host emits source data only.
+        function Get-HelpMeta {
+            param($Cmd, $HelpInfo)
+            $synopsis = ''
+            $fullDescription = $null
+            $paramHelpMap = @{}
+            if ($null -ne $HelpInfo) {
+                if ($null -ne $HelpInfo.Synopsis) {
+                    $s = "$($HelpInfo.Synopsis)".Trim()
+                    if ($s -and $s -ne $Cmd.Name) { $synopsis = $s }
+                }
+                try {
+                    $descArray = $HelpInfo.Description
+                    if ($null -ne $descArray) {
+                        $paragraphs = @()
+                        foreach ($p in @($descArray)) {
+                            $t = $null
+                            if ($p -is [string]) { $t = $p }
+                            elseif ($null -ne $p -and $null -ne $p.Text) { $t = "$($p.Text)" }
+                            if ($null -ne $t) { $paragraphs += $t }
+                        }
+                        if ($paragraphs.Count -gt 0) {
+                            $joined = ($paragraphs -join "`n`n")
+                            if (-not [string]::IsNullOrWhiteSpace($joined)) { $fullDescription = $joined }
+                        }
+                    }
+                } catch { }
+                try {
+                    $helpParams = $HelpInfo.Parameters
+                    if ($null -ne $helpParams -and $null -ne $helpParams.parameter) {
+                        foreach ($hp in @($helpParams.parameter)) {
+                            if ($null -eq $hp) { continue }
+                            $pn = "$($hp.name)"
+                            if ([string]::IsNullOrWhiteSpace($pn)) { continue }
+                            $paragraphs = @()
+                            foreach ($d in @($hp.description)) {
+                                $t = $null
+                                if ($d -is [string]) { $t = $d }
+                                elseif ($null -ne $d -and $null -ne $d.Text) { $t = "$($d.Text)" }
+                                if ($null -ne $t) { $paragraphs += $t }
+                            }
+                            if ($paragraphs.Count -gt 0) {
+                                $joined = ($paragraphs -join "`n`n")
+                                if (-not [string]::IsNullOrWhiteSpace($joined)) { $paramHelpMap[$pn] = $joined }
+                            }
+                        }
+                    }
+                } catch { }
+            }
+            return [pscustomobject]@{ Synopsis = $synopsis; FullDescription = $fullDescription; ParamHelp = $paramHelpMap }
+        }
+
+        # Helper: walk CommandInfo.Parameters[name].Attributes for HelpMessage and ValidateSet values.
+        function Get-ParamAttrMeta {
+            param($Cmd, [string]$ParameterName)
+            $helpMessage = $null
+            $validateSet = $null
             try {
-                $helpInfo = Get-Help -Name $cmd.Name -ErrorAction SilentlyContinue
-                if ($null -ne $helpInfo -and $null -ne $helpInfo.Synopsis) {
-                    $synopsis = "$($helpInfo.Synopsis)".Trim()
-                    if ($synopsis -and $synopsis -ne $cmd.Name) { $description = $synopsis }
+                $pmeta = $null
+                if ($null -ne $Cmd.Parameters) { $pmeta = $Cmd.Parameters[$ParameterName] }
+                if ($null -ne $pmeta -and $null -ne $pmeta.Attributes) {
+                    foreach ($attr in $pmeta.Attributes) {
+                        if ($null -eq $attr) { continue }
+                        $tn = $attr.GetType().FullName
+                        if ($tn -eq 'System.Management.Automation.ParameterAttribute') {
+                            if ($null -eq $helpMessage) {
+                                $hm = $attr.HelpMessage
+                                if ($null -ne $hm -and -not [string]::IsNullOrWhiteSpace("$hm")) { $helpMessage = "$hm" }
+                            }
+                        }
+                        elseif ($tn -eq 'System.Management.Automation.ValidateSetAttribute') {
+                            if ($null -eq $validateSet -and $null -ne $attr.ValidValues) {
+                                $vals = @()
+                                foreach ($v in $attr.ValidValues) { $vals += "$v" }
+                                if ($vals.Count -gt 0) { $validateSet = $vals }
+                            }
+                        }
+                    }
                 }
             } catch { }
+            return [pscustomobject]@{ HelpMessage = $helpMessage; ValidateSetValues = $validateSet }
+        }
+
+        foreach ($cmd in $unique) {
+            $helpInfo = $null
+            try { $helpInfo = Get-Help -Name $cmd.Name -ErrorAction SilentlyContinue } catch { $helpInfo = $null }
+            $helpMeta = Get-HelpMeta -Cmd $cmd -HelpInfo $helpInfo
+
             foreach ($paramSet in $cmd.ParameterSets) {
                 $parameters = [System.Collections.ArrayList]::new()
                 foreach ($param in $paramSet.Parameters) {
                     if ($commonParameters -contains $param.Name) { continue }
+                    $paramAttrMeta = Get-ParamAttrMeta -Cmd $cmd -ParameterName $param.Name
+                    $paramHelpDesc = $null
+                    if ($helpMeta.ParamHelp.ContainsKey($param.Name)) { $paramHelpDesc = $helpMeta.ParamHelp[$param.Name] }
                     $null = $parameters.Add([ordered]@{
-                        Name        = $param.Name
-                        TypeName    = $param.ParameterType.FullName
-                        IsMandatory = [bool]$param.IsMandatory
-                        Position    = $param.Position
+                        Name              = $param.Name
+                        TypeName          = $param.ParameterType.FullName
+                        IsMandatory       = [bool]$param.IsMandatory
+                        Position          = $param.Position
+                        HelpDescription   = $paramHelpDesc
+                        HelpMessage       = $paramAttrMeta.HelpMessage
+                        ValidateSetValues = $paramAttrMeta.ValidateSetValues
                     })
                 }
                 $null = $schemas.Add([ordered]@{
                     Name             = $cmd.Name
-                    Description      = $description
+                    Description      = $helpMeta.Synopsis
+                    FullDescription  = $helpMeta.FullDescription
                     ParameterSetName = $paramSet.Name
                     Parameters       = @($parameters)
                 })

--- a/PoshMcp.Server/PowerShell/OutOfProcess/oop-host.ps1
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/oop-host.ps1
@@ -29,6 +29,142 @@ function Write-Diag {
     [Console]::Error.WriteLine("[oop-host] $Message")
 }
 
+function Get-RemoteCommandHelpMetadata {
+    <#
+    .SYNOPSIS
+        Project a Get-Help record into the raw fields RemoteToolSchema needs.
+        Emits source data only — no sanitization, no precedence resolution
+        (those happen on the .NET consumer per FR-500/FR-510/FR-540).
+    .OUTPUTS
+        PSCustomObject with: Synopsis (string, may be empty),
+                             FullDescription (string or $null),
+                             ParamHelp (hashtable: paramName -> description string).
+    #>
+    param(
+        [Parameter(Mandatory)] $Command,
+        $HelpInfo
+    )
+
+    $synopsis = ''
+    $fullDescription = $null
+    $paramHelpMap = @{}
+
+    if ($null -ne $HelpInfo) {
+        if ($null -ne $HelpInfo.Synopsis) {
+            $s = "$($HelpInfo.Synopsis)".Trim()
+            if ($s -and $s -ne $Command.Name) {
+                $synopsis = $s
+            }
+        }
+
+        try {
+            $descArray = $HelpInfo.Description
+            if ($null -ne $descArray) {
+                $paragraphs = @()
+                foreach ($p in @($descArray)) {
+                    $t = $null
+                    if ($p -is [string]) { $t = $p }
+                    elseif ($null -ne $p -and $null -ne $p.Text) { $t = "$($p.Text)" }
+                    if ($null -ne $t) { $paragraphs += $t }
+                }
+                if ($paragraphs.Count -gt 0) {
+                    $joined = ($paragraphs -join "`n`n")
+                    if (-not [string]::IsNullOrWhiteSpace($joined)) {
+                        $fullDescription = $joined
+                    }
+                }
+            }
+        }
+        catch { }
+
+        try {
+            $helpParams = $HelpInfo.Parameters
+            if ($null -ne $helpParams -and $null -ne $helpParams.parameter) {
+                foreach ($hp in @($helpParams.parameter)) {
+                    if ($null -eq $hp) { continue }
+                    $pn = "$($hp.name)"
+                    if ([string]::IsNullOrWhiteSpace($pn)) { continue }
+                    $paragraphs = @()
+                    foreach ($d in @($hp.description)) {
+                        $t = $null
+                        if ($d -is [string]) { $t = $d }
+                        elseif ($null -ne $d -and $null -ne $d.Text) { $t = "$($d.Text)" }
+                        if ($null -ne $t) { $paragraphs += $t }
+                    }
+                    if ($paragraphs.Count -gt 0) {
+                        $joined = ($paragraphs -join "`n`n")
+                        if (-not [string]::IsNullOrWhiteSpace($joined)) {
+                            $paramHelpMap[$pn] = $joined
+                        }
+                    }
+                }
+            }
+        }
+        catch { }
+    }
+
+    return [pscustomobject]@{
+        Synopsis        = $synopsis
+        FullDescription = $fullDescription
+        ParamHelp       = $paramHelpMap
+    }
+}
+
+function Get-RemoteParameterAttributeMetadata {
+    <#
+    .SYNOPSIS
+        Walk CommandInfo.Parameters[name].Attributes to extract HelpMessage
+        (from ParameterAttribute) and ValidValues (from ValidateSetAttribute).
+        Defensive — any missing piece returns $null in that slot.
+    .OUTPUTS
+        PSCustomObject with: HelpMessage (string or $null),
+                             ValidateSetValues (string[] or $null).
+    #>
+    param(
+        [Parameter(Mandatory)] $Command,
+        [Parameter(Mandatory)] [string] $ParameterName
+    )
+
+    $helpMessage = $null
+    $validateSet = $null
+
+    try {
+        $pmeta = $null
+        if ($null -ne $Command.Parameters) {
+            $pmeta = $Command.Parameters[$ParameterName]
+        }
+        if ($null -ne $pmeta -and $null -ne $pmeta.Attributes) {
+            foreach ($attr in $pmeta.Attributes) {
+                if ($null -eq $attr) { continue }
+                $tn = $attr.GetType().FullName
+                if ($tn -eq 'System.Management.Automation.ParameterAttribute') {
+                    if ($null -eq $helpMessage) {
+                        $hm = $attr.HelpMessage
+                        if ($null -ne $hm -and -not [string]::IsNullOrWhiteSpace("$hm")) {
+                            $helpMessage = "$hm"
+                        }
+                    }
+                }
+                elseif ($tn -eq 'System.Management.Automation.ValidateSetAttribute') {
+                    if ($null -eq $validateSet -and $null -ne $attr.ValidValues) {
+                        $vals = @()
+                        foreach ($v in $attr.ValidValues) { $vals += "$v" }
+                        if ($vals.Count -gt 0) {
+                            $validateSet = $vals
+                        }
+                    }
+                }
+            }
+        }
+    }
+    catch { }
+
+    return [pscustomobject]@{
+        HelpMessage       = $helpMessage
+        ValidateSetValues = $validateSet
+    }
+}
+
 # --- C# single-host dispatcher (for cancellation propagation, issue #188) ---
 # Compiled once per process. Owns a single worker thread that processes
 # invokes serially against a shared runspace; tracks active items by request
@@ -759,19 +895,19 @@ function Invoke-DiscoverHandler {
     $schemas = [System.Collections.ArrayList]::new()
 
     foreach ($cmd in $uniqueCommands) {
-        $description = ''
+        # Read Get-Help once per command (FR-570) and project the raw fields
+        # the .NET consumer needs to apply the FR-500 / FR-510 precedence
+        # chains. This host emits raw source data only — no sanitization,
+        # no length capping, no precedence resolution.
+        $helpInfo = $null
         try {
             $helpInfo = Get-Help -Name $cmd.Name -ErrorAction SilentlyContinue
-            if ($null -ne $helpInfo -and $null -ne $helpInfo.Synopsis) {
-                $synopsis = "$($helpInfo.Synopsis)".Trim()
-                if ($synopsis -and $synopsis -ne $cmd.Name) {
-                    $description = $synopsis
-                }
-            }
         }
         catch {
-            # Best effort — description stays empty
+            $helpInfo = $null
         }
+
+        $helpMeta = Get-RemoteCommandHelpMetadata -Command $cmd -HelpInfo $helpInfo
 
         foreach ($paramSet in $cmd.ParameterSets) {
             $parameters = [System.Collections.ArrayList]::new()
@@ -782,17 +918,27 @@ function Invoke-DiscoverHandler {
                     continue
                 }
 
+                $paramAttrMeta = Get-RemoteParameterAttributeMetadata -Command $cmd -ParameterName $param.Name
+                $paramHelpDesc = $null
+                if ($helpMeta.ParamHelp.ContainsKey($param.Name)) {
+                    $paramHelpDesc = $helpMeta.ParamHelp[$param.Name]
+                }
+
                 $null = $parameters.Add([ordered]@{
-                    Name        = $param.Name
-                    TypeName    = $param.ParameterType.FullName
-                    IsMandatory = [bool]$param.IsMandatory
-                    Position    = $param.Position
+                    Name              = $param.Name
+                    TypeName          = $param.ParameterType.FullName
+                    IsMandatory       = [bool]$param.IsMandatory
+                    Position          = $param.Position
+                    HelpDescription   = $paramHelpDesc
+                    HelpMessage       = $paramAttrMeta.HelpMessage
+                    ValidateSetValues = $paramAttrMeta.ValidateSetValues
                 })
             }
 
             $null = $schemas.Add([ordered]@{
                 Name             = $cmd.Name
-                Description      = $description
+                Description      = $helpMeta.Synopsis
+                FullDescription  = $helpMeta.FullDescription
                 ParameterSetName = $paramSet.Name
                 Parameters       = @($parameters)
             })


### PR DESCRIPTION
Closes #227

Adds additive metadata fields to RemoteToolSchema and emits them from oop-host.ps1 + oop-host-pool.ps1 per FR-500/FR-510. Existing Description field unchanged for backward compatibility. Consumer side wiring is in #228.

Reviewers: Farnsworth + Cubert (squad).