### PR TITLE
feat(metadata): in-process Help-aware precedence + sanitization (#226)

### DIFF
--- a/PoshMcp.Server/McpToolFactoryV2.cs
+++ b/PoshMcp.Server/McpToolFactoryV2.cs
@@ -41,6 +41,7 @@ public class McpToolFactoryV2
     private readonly OutOfProcessToolAssemblyGenerator? _outOfProcessAssemblyGenerator;
     private readonly ICommandExecutor? _commandExecutor;
     private readonly IToolMetadataSource _toolMetadataSource;
+    private readonly PowerShellHelpResolver _helpResolver = new();
     private static McpMetrics? _metrics;
 
     /// <summary>
@@ -133,12 +134,12 @@ public class McpToolFactoryV2
     /// <param name="powerShell">PowerShell instance for executing queries</param>
     /// <param name="logger">Logger instance</param>
     /// <returns>Command metadata with parameter-set-specific syntax, verb info, and safety characteristics</returns>
-    private PowerShellCommandMetadata GetCommandMetadata(CommandInfo commandInfo, CommandParameterSetInfo parameterSet, PSPowerShell powerShell, ILogger logger)
+    private PowerShellCommandMetadata GetCommandMetadata(CommandInfo commandInfo, CommandParameterSetInfo parameterSet, PSPowerShell powerShell, CommandHelpInfo help, ILogger logger)
     {
         var metadata = CreateDefaultCommandMetadata(commandInfo);
         try
         {
-            SetParameterSetDescription(metadata, commandInfo, parameterSet, _toolMetadataSource, logger);
+            SetParameterSetDescription(metadata, commandInfo, parameterSet, _toolMetadataSource, help, logger);
             AnalyzeCommandVerbSafety(metadata, commandInfo, powerShell, logger);
         }
         catch (Exception ex)
@@ -162,7 +163,7 @@ public class McpToolFactoryV2
         };
     }
 
-    private static void SetParameterSetDescription(PowerShellCommandMetadata metadata, CommandInfo commandInfo, CommandParameterSetInfo parameterSet, IToolMetadataSource metadataSource, ILogger logger)
+    private static void SetParameterSetDescription(PowerShellCommandMetadata metadata, CommandInfo commandInfo, CommandParameterSetInfo parameterSet, IToolMetadataSource metadataSource, CommandHelpInfo help, ILogger logger)
     {
         try
         {
@@ -170,8 +171,8 @@ public class McpToolFactoryV2
             var request = new ToolDescriptionRequest(
                 CommandName: commandInfo.Name,
                 ParameterSetName: parameterSet.Name,
-                Synopsis: null,
-                LongDescription: null,
+                Synopsis: help.Synopsis,
+                LongDescription: help.LongDescription,
                 ParameterSetSyntax: parameterSetSyntax);
             var result = metadataSource.ResolveToolDescription(in request);
             metadata.Description = result.Description;
@@ -362,8 +363,14 @@ public class McpToolFactoryV2
                 var commands = ValidateAndGetCommands(config, logger);
                 if (!commands.Any()) return new List<McpServerTool>();
 
-                var (generatedAssembly, generatedInstance, generatedMethods) = GenerateAssemblyAndMethods(commands, logger);
-                var methodToCommandMap = CreateCommandMetadataMapping(commands, logger);
+                // Resolve Get-Help once per command (FR-570) so both the command-level
+                // metadata mapping and the parameter-level [Description] emission below
+                // share a single, cached lookup. Empty / missing help is tolerated.
+                var helpMap = ResolveHelpForCommands(commands, logger);
+                var parameterDescriptions = BuildParameterDescriptionMap(commands, helpMap);
+
+                var (generatedAssembly, generatedInstance, generatedMethods) = GenerateAssemblyAndMethods(commands, parameterDescriptions, logger);
+                var methodToCommandMap = CreateCommandMetadataMapping(commands, helpMap, logger);
                 var tools = CreateMcpToolsFromMethods(generatedMethods, generatedInstance, methodToCommandMap, logger);
                 LogToolGenerationResults(tools, logger);
                 return tools;
@@ -425,13 +432,13 @@ public class McpToolFactoryV2
         logger.LogDebug("  - Review include/exclude patterns");
     }
 
-    private (Assembly assembly, object instance, Dictionary<string, MethodInfo> methods) GenerateAssemblyAndMethods(List<CommandInfo> commands, ILogger logger)
+    private (Assembly assembly, object instance, Dictionary<string, MethodInfo> methods) GenerateAssemblyAndMethods(List<CommandInfo> commands, IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> parameterDescriptions, ILogger logger)
     {
         logger.LogInformation($"Found {commands.Count} PowerShell commands");
         logger.LogTrace($"Commands to process: [{string.Join(", ", commands.Select(c => c.Name))}]");
 
         logger.LogDebug("Generating dynamic assembly for PowerShell commands...");
-        var generatedAssembly = _assemblyGenerator.GenerateAssembly(commands, logger);
+        var generatedAssembly = _assemblyGenerator.GenerateAssembly(commands, parameterDescriptions, logger);
         var generatedInstance = _assemblyGenerator.GetGeneratedInstance(logger);
         var generatedMethods = _assemblyGenerator.GetGeneratedMethods();
 
@@ -457,7 +464,89 @@ public class McpToolFactoryV2
         }
     }
 
-    private Dictionary<string, PowerShellCommandMetadata> CreateCommandMetadataMapping(List<CommandInfo> commands, ILogger logger)
+    private Dictionary<string, CommandHelpInfo> ResolveHelpForCommands(List<CommandInfo> commands, ILogger logger)
+    {
+        var map = new Dictionary<string, CommandHelpInfo>(StringComparer.OrdinalIgnoreCase);
+        if (_assemblyGenerator == null)
+        {
+            return map;
+        }
+
+        var powerShell = _assemblyGenerator.PowerShellRunspace.Instance;
+        foreach (var command in commands)
+        {
+            if (map.ContainsKey(command.Name))
+            {
+                continue;
+            }
+            map[command.Name] = _helpResolver.Resolve(command.Name, powerShell, logger);
+        }
+        return map;
+    }
+
+    private IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> BuildParameterDescriptionMap(List<CommandInfo> commands, IReadOnlyDictionary<string, CommandHelpInfo> helpMap)
+    {
+        var result = new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var command in commands)
+        {
+            if (result.ContainsKey(command.Name))
+            {
+                continue;
+            }
+
+            var help = helpMap.TryGetValue(command.Name, out var info) ? info : CommandHelpInfo.Empty;
+            var perParameter = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var paramKvp in command.Parameters)
+            {
+                if (PowerShellParameterUtils.IsCommonParameter(paramKvp.Key))
+                {
+                    continue;
+                }
+
+                var paramName = paramKvp.Key;
+                var paramMetadata = paramKvp.Value;
+
+                help.ParameterDescriptions.TryGetValue(paramName, out var helpParamText);
+                var helpMessage = paramMetadata.Attributes.OfType<ParameterAttribute>()
+                    .Select(attr => attr.HelpMessage)
+                    .FirstOrDefault(msg => !string.IsNullOrWhiteSpace(msg));
+
+                var validateSetAttr = paramMetadata.Attributes.OfType<ValidateSetAttribute>().FirstOrDefault();
+                IReadOnlyList<string>? validateValues = validateSetAttr?.ValidValues != null
+                    ? validateSetAttr.ValidValues.ToArray()
+                    : null;
+                var appliesToArrayElement = validateValues != null && paramMetadata.ParameterType.IsArray;
+
+                var typeName = paramMetadata.ParameterType.Name;
+                var request = new ParameterDescriptionRequest(
+                    CommandName: command.Name,
+                    ParameterName: paramName,
+                    ParameterTypeName: typeName,
+                    HelpParameterDescription: helpParamText,
+                    HelpMessage: helpMessage,
+                    ValidateSetValues: validateValues,
+                    ValidateSetAppliesToArrayElement: appliesToArrayElement);
+
+                var resolved = _toolMetadataSource.ResolveParameterDescription(in request);
+                if (resolved.Source != ParameterDescriptionSource.TypeFallback
+                    && !string.IsNullOrWhiteSpace(resolved.Description))
+                {
+                    perParameter[paramName] = resolved.Description;
+                }
+            }
+
+            if (perParameter.Count > 0)
+            {
+                result[command.Name] = perParameter;
+            }
+        }
+
+        return result;
+    }
+
+    private Dictionary<string, PowerShellCommandMetadata> CreateCommandMetadataMapping(List<CommandInfo> commands, IReadOnlyDictionary<string, CommandHelpInfo> helpMap, ILogger logger)
     {
         var methodToCommandMap = new Dictionary<string, PowerShellCommandMetadata>();
         // Use the injected runspace instance instead of the singleton to support session-aware runspaces
@@ -465,7 +554,8 @@ public class McpToolFactoryV2
 
         foreach (var command in commands)
         {
-            MapParameterSetsToMetadata(command, powerShell, methodToCommandMap, logger);
+            var help = helpMap.TryGetValue(command.Name, out var info) ? info : CommandHelpInfo.Empty;
+            MapParameterSetsToMetadata(command, powerShell, help, methodToCommandMap, logger);
         }
         return methodToCommandMap;
     }
@@ -514,12 +604,12 @@ public class McpToolFactoryV2
         return methodToCommandMap;
     }
 
-    private void MapParameterSetsToMetadata(CommandInfo command, PSPowerShell powerShell, Dictionary<string, PowerShellCommandMetadata> methodToCommandMap, ILogger logger)
+    private void MapParameterSetsToMetadata(CommandInfo command, PSPowerShell powerShell, CommandHelpInfo help, Dictionary<string, PowerShellCommandMetadata> methodToCommandMap, ILogger logger)
     {
         foreach (var parameterSet in command.ParameterSets)
         {
             var methodName = PowerShellAssemblyGenerator.SanitizeMethodName(command.Name, parameterSet.Name);
-            var metadata = GetCommandMetadata(command, parameterSet, powerShell, logger);
+            var metadata = GetCommandMetadata(command, parameterSet, powerShell, help, logger);
             methodToCommandMap[methodName] = metadata;
             logger.LogDebug($"Created parameter-set-specific metadata for method '{methodName}' from command '{command.Name}' parameter set '{parameterSet.Name}'");
         }

--- a/PoshMcp.Server/PowerShell/DescriptionSanitizer.cs
+++ b/PoshMcp.Server/PowerShell/DescriptionSanitizer.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+namespace PoshMcp.Server.PowerShell;
+
+/// <summary>
+/// Spec 010 FR-540 description-text normalizer. Pure helper; no I/O, no allocations beyond
+/// the returned string.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Applied to description text from any source (Get-Help synopsis, Get-Help description body,
+/// Get-Help parameter description, etc.) before that text is surfaced to MCP clients.
+/// Sanitization is what makes the path-parity guarantee in FR-520 deliverable across the
+/// in-process console host and the OOP subprocess host with redirected I/O — different
+/// hosts wrap and pad text differently, and this normalizer absorbs those differences.
+/// </para>
+/// <para>
+/// The sequence applied (per FR-540) is:
+/// </para>
+/// <list type="number">
+///   <item><description>Trim leading and trailing whitespace from the overall string.</description></item>
+///   <item><description>Strip non-printable control characters (Unicode category <c>Cc</c>) other
+///   than the paragraph separator <c>\n\n</c> produced by FR-500 step 2.</description></item>
+///   <item><description>Within each paragraph (text between <c>\n\n</c> separators), collapse all
+///   runs of whitespace — spaces, tabs, single <c>\n</c>, <c>\r</c>, and <c>\r\n</c> — to a
+///   single space. Preserve the <c>\n\n</c> separators between paragraphs.</description></item>
+///   <item><description>Re-trim each paragraph after collapse.</description></item>
+/// </list>
+/// </remarks>
+public static class DescriptionSanitizer
+{
+    /// <summary>
+    /// The paragraph separator preserved by FR-540: two consecutive line-feeds. Producers
+    /// (Get-Help <c>.Description</c> body join, Get-Help parameter <c>description</c> join)
+    /// emit this exact sequence between paragraphs.
+    /// </summary>
+    public const string ParagraphSeparator = "\n\n";
+
+    /// <summary>
+    /// Normalizes <paramref name="value"/> per spec 010 FR-540. Returns <see cref="string.Empty"/>
+    /// when <paramref name="value"/> is <c>null</c>, empty, or contains only whitespace and
+    /// strippable control characters. Never throws.
+    /// </summary>
+    /// <param name="value">Raw description text from any precedence source.</param>
+    /// <returns>Normalized text safe for MCP serialization and byte-comparable across paths.</returns>
+    public static string Normalize(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        // FR-540 step 1: outer trim.
+        var trimmed = value!.Trim();
+        if (trimmed.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        // Split on the paragraph separator first so step 3 can run per-paragraph and
+        // preserve "\n\n" between them. Empty paragraphs (created by 3+ newlines or edge
+        // cases) collapse out of the result.
+        var paragraphs = trimmed.Split(new[] { ParagraphSeparator }, StringSplitOptions.None);
+        var normalizedParagraphs = new System.Collections.Generic.List<string>(paragraphs.Length);
+
+        foreach (var paragraph in paragraphs)
+        {
+            var normalized = NormalizeParagraph(paragraph);
+            if (normalized.Length > 0)
+            {
+                normalizedParagraphs.Add(normalized);
+            }
+        }
+
+        return string.Join(ParagraphSeparator, normalizedParagraphs);
+    }
+
+    /// <summary>
+    /// Truncates <paramref name="value"/> to at most <paramref name="maxLength"/> characters,
+    /// preferring a word boundary, and appends an ellipsis (<c>…</c>, U+2026) when truncation
+    /// occurred. Implements FR-541 / FR-542. The ellipsis counts toward the cap.
+    /// </summary>
+    /// <param name="value">Already-sanitized description text.</param>
+    /// <param name="maxLength">Maximum allowed length including the ellipsis. Must be at
+    /// least 1.</param>
+    /// <returns><paramref name="value"/> unchanged if it already fits; otherwise truncated
+    /// at the last whitespace at or before <c>maxLength - 1</c>, with <c>…</c> appended.</returns>
+    public static string TruncateAtWordBoundary(string value, int maxLength)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        if (maxLength < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxLength), "Must be at least 1.");
+        }
+
+        if (value.Length <= maxLength)
+        {
+            return value;
+        }
+
+        // Reserve one character for the ellipsis.
+        var cap = maxLength - 1;
+        if (cap <= 0)
+        {
+            return "\u2026";
+        }
+
+        // Walk back from cap to the last whitespace; if none, hard-cut at cap.
+        var cut = cap;
+        while (cut > 0 && !char.IsWhiteSpace(value[cut]))
+        {
+            cut--;
+        }
+
+        if (cut == 0)
+        {
+            cut = cap; // No whitespace found; fall back to a hard cut.
+        }
+
+        return value.Substring(0, cut).TrimEnd() + "\u2026";
+    }
+
+    private static string NormalizeParagraph(string paragraph)
+    {
+        if (string.IsNullOrEmpty(paragraph))
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(paragraph.Length);
+        var inWhitespaceRun = false;
+
+        foreach (var ch in paragraph)
+        {
+            // FR-540 step 2: strip Unicode category Cc (control characters). Whitespace
+            // characters that are also category Cc (\t, \n, \r, etc.) are converted into
+            // the single-space whitespace run handled below.
+            if (CharUnicodeInfo.GetUnicodeCategory(ch) == UnicodeCategory.Control)
+            {
+                if (IsWhitespaceControl(ch))
+                {
+                    if (!inWhitespaceRun && builder.Length > 0)
+                    {
+                        builder.Append(' ');
+                    }
+                    inWhitespaceRun = true;
+                }
+                // Non-whitespace control character: drop entirely.
+                continue;
+            }
+
+            // FR-540 step 3: collapse non-control whitespace (spaces, NBSP-equivalents
+            // PowerShell hosts sometimes inject) into a single ASCII space.
+            if (char.IsWhiteSpace(ch))
+            {
+                if (!inWhitespaceRun && builder.Length > 0)
+                {
+                    builder.Append(' ');
+                }
+                inWhitespaceRun = true;
+                continue;
+            }
+
+            builder.Append(ch);
+            inWhitespaceRun = false;
+        }
+
+        // FR-540 step 4: trim trailing whitespace introduced by the collapse pass.
+        while (builder.Length > 0 && builder[builder.Length - 1] == ' ')
+        {
+            builder.Length--;
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool IsWhitespaceControl(char ch)
+    {
+        // ASCII whitespace control characters that should collapse into a space rather
+        // than be stripped: HT, LF, VT, FF, CR.
+        return ch == '\t' || ch == '\n' || ch == '\v' || ch == '\f' || ch == '\r';
+    }
+}

--- a/PoshMcp.Server/PowerShell/HelpAwareToolMetadataSource.cs
+++ b/PoshMcp.Server/PowerShell/HelpAwareToolMetadataSource.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+
+namespace PoshMcp.Server.PowerShell;
+
+/// <summary>
+/// Spec 010 implementation of <see cref="IToolMetadataSource"/> that applies the full
+/// FR-500 / FR-510 precedence chains and FR-540 sanitization. Pure resolver — does NOT
+/// invoke PowerShell. Callers (<see cref="PoshMcp.McpToolFactoryV2"/> for the in-process
+/// path, the OOP host for the out-of-process path) are responsible for pre-resolving
+/// Get-Help inputs and supplying them via the request records.
+/// </summary>
+/// <remarks>
+/// Length caps from FR-541 (1024 for tool descriptions) and FR-542 (512 for parameter
+/// descriptions) are applied at this layer so both execution paths produce byte-identical
+/// output (FR-520).
+/// </remarks>
+public sealed class HelpAwareToolMetadataSource : IToolMetadataSource
+{
+    /// <summary>FR-541 cap applied to tool descriptions.</summary>
+    public const int ToolDescriptionMaxLength = 1024;
+
+    /// <summary>FR-542 cap applied to parameter descriptions.</summary>
+    public const int ParameterDescriptionMaxLength = 512;
+
+    /// <inheritdoc />
+    public ToolDescriptionResult ResolveToolDescription(in ToolDescriptionRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.CommandName))
+        {
+            throw new ArgumentException(
+                $"{nameof(ToolDescriptionRequest.CommandName)} must not be null or whitespace.",
+                nameof(request));
+        }
+
+        // FR-500 step 1: Get-Help .Synopsis when present, non-empty, and not equal to the command name.
+        if (!string.IsNullOrWhiteSpace(request.Synopsis))
+        {
+            var synopsis = DescriptionSanitizer.Normalize(request.Synopsis);
+            if (synopsis.Length > 0
+                && !string.Equals(synopsis, request.CommandName, StringComparison.Ordinal))
+            {
+                return new ToolDescriptionResult(
+                    DescriptionSanitizer.TruncateAtWordBoundary(synopsis, ToolDescriptionMaxLength),
+                    ToolDescriptionSource.Synopsis);
+            }
+        }
+
+        // FR-500 step 2: Get-Help .Description body, paragraph-joined and sanitized.
+        if (!string.IsNullOrWhiteSpace(request.LongDescription))
+        {
+            var longDesc = DescriptionSanitizer.Normalize(request.LongDescription);
+            if (longDesc.Length > 0)
+            {
+                return new ToolDescriptionResult(
+                    DescriptionSanitizer.TruncateAtWordBoundary(longDesc, ToolDescriptionMaxLength),
+                    ToolDescriptionSource.Description);
+            }
+        }
+
+        // FR-500 step 3: "{CommandName} {ParameterSetSyntax}".
+        if (!string.IsNullOrWhiteSpace(request.ParameterSetSyntax))
+        {
+            var combined = $"{request.CommandName} {request.ParameterSetSyntax}";
+            return new ToolDescriptionResult(
+                DescriptionSanitizer.TruncateAtWordBoundary(combined, ToolDescriptionMaxLength),
+                ToolDescriptionSource.Syntax);
+        }
+
+        // FR-500 step 4: bare command name.
+        return new ToolDescriptionResult(request.CommandName, ToolDescriptionSource.Name);
+    }
+
+    /// <inheritdoc />
+    public ParameterDescriptionResult ResolveParameterDescription(in ParameterDescriptionRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.ParameterName))
+        {
+            throw new ArgumentException(
+                $"{nameof(ParameterDescriptionRequest.ParameterName)} must not be null or whitespace.",
+                nameof(request));
+        }
+
+        // FR-510 step 1: Get-Help parameter description.
+        if (!string.IsNullOrWhiteSpace(request.HelpParameterDescription))
+        {
+            var helpParam = DescriptionSanitizer.Normalize(request.HelpParameterDescription);
+            if (helpParam.Length > 0)
+            {
+                return new ParameterDescriptionResult(
+                    DescriptionSanitizer.TruncateAtWordBoundary(helpParam, ParameterDescriptionMaxLength),
+                    ParameterDescriptionSource.HelpParameter);
+            }
+        }
+
+        // FR-510 step 2: ParameterAttribute.HelpMessage.
+        if (!string.IsNullOrWhiteSpace(request.HelpMessage))
+        {
+            var helpMessage = DescriptionSanitizer.Normalize(request.HelpMessage);
+            if (helpMessage.Length > 0)
+            {
+                return new ParameterDescriptionResult(
+                    DescriptionSanitizer.TruncateAtWordBoundary(helpMessage, ParameterDescriptionMaxLength),
+                    ParameterDescriptionSource.HelpMessage);
+            }
+        }
+
+        // FR-510 step 3: ValidateSet phrasing — singleton vs. array element.
+        if (request.ValidateSetValues is { Count: > 0 } values)
+        {
+            var prefix = request.ValidateSetAppliesToArrayElement ? "Each item is one of: " : "One of: ";
+            var rendered = prefix + string.Join(", ", values);
+            return new ParameterDescriptionResult(
+                DescriptionSanitizer.TruncateAtWordBoundary(rendered, ParameterDescriptionMaxLength),
+                ParameterDescriptionSource.ValidateSet);
+        }
+
+        // FR-510 step 4: type fallback (preserves pre-spec-010 behavior).
+        var typeName = string.IsNullOrWhiteSpace(request.ParameterTypeName)
+            ? "Object"
+            : request.ParameterTypeName;
+        return new ParameterDescriptionResult(
+            $"Parameter of type {typeName}",
+            ParameterDescriptionSource.TypeFallback);
+    }
+}

--- a/PoshMcp.Server/PowerShell/PowerShellAssemblyGenerator.cs
+++ b/PoshMcp.Server/PowerShell/PowerShellAssemblyGenerator.cs
@@ -26,6 +26,21 @@ public class PowerShellAssemblyGenerator
     private const string MaxResultsParameterName = "_MaxResults";
     private const string RequestedPropertiesParameterName = "_RequestedProperties";
 
+    private static readonly ConstructorInfo s_descriptionAttributeCtor =
+        typeof(System.ComponentModel.DescriptionAttribute).GetConstructor(new[] { typeof(string) })
+        ?? throw new InvalidOperationException("System.ComponentModel.DescriptionAttribute(string) constructor not found.");
+
+    private static IReadOnlyDictionary<string, string>? ResolveParameterDescriptions(
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>>? parameterDescriptions,
+        string commandName)
+    {
+        if (parameterDescriptions == null)
+        {
+            return null;
+        }
+        return parameterDescriptions.TryGetValue(commandName, out var perParameter) ? perParameter : null;
+    }
+
     public Assembly? GeneratedAssembly => _generatedAssembly;
 
     /// <summary>
@@ -158,12 +173,35 @@ public class PowerShellAssemblyGenerator
     }
 
     /// <summary>
-    /// Generates or retrieves the cached in-memory assembly containing PowerShell command methods
+    /// Generates or retrieves the cached in-memory assembly containing PowerShell command methods.
     /// </summary>
     /// <param name="commands">List of PowerShell commands to generate methods for</param>
     /// <param name="logger">Logger instance</param>
     /// <returns>The generated assembly</returns>
+    /// <remarks>
+    /// Convenience overload for callers that have not pre-computed parameter descriptions
+    /// (notably the in-tree functional tests). Spec 010 in-process callers MUST use the
+    /// overload that accepts a parameter-description map so the generated method parameters
+    /// receive <see cref="System.ComponentModel.DescriptionAttribute"/> instances and the
+    /// MCP SDK auto-schema surfaces them as <c>inputSchema.properties.&lt;name&gt;.description</c>.
+    /// </remarks>
     public Assembly GenerateAssembly(IEnumerable<CommandInfo> commands, ILogger logger)
+        => GenerateAssembly(commands, parameterDescriptions: null, logger);
+
+    /// <summary>
+    /// Generates or retrieves the cached in-memory assembly containing PowerShell command methods,
+    /// applying per-parameter descriptions resolved by spec 010's <see cref="HelpAwareToolMetadataSource"/>.
+    /// </summary>
+    /// <param name="commands">List of PowerShell commands to generate methods for.</param>
+    /// <param name="parameterDescriptions">Map keyed by command name; each value is a map from
+    /// parameter name to the resolved description text. May be <c>null</c> or empty (legacy
+    /// behavior preserved). When supplied, each generated method parameter receives a
+    /// <see cref="System.ComponentModel.DescriptionAttribute"/>.</param>
+    /// <param name="logger">Logger instance.</param>
+    public Assembly GenerateAssembly(
+        IEnumerable<CommandInfo> commands,
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>>? parameterDescriptions,
+        ILogger logger)
     {
         lock (_lock)
         {
@@ -215,7 +253,7 @@ public class PowerShellAssemblyGenerator
                     {
                         try
                         {
-                            var generated = GenerateMethodForCommand(typeBuilder, command, loggerField, runspaceField, logger, parameterSet);
+                            var generated = GenerateMethodForCommand(typeBuilder, command, loggerField, runspaceField, logger, parameterSet, ResolveParameterDescriptions(parameterDescriptions, command.Name));
                             if (generated)
                                 anyParameterSetGenerated = true;
                         }
@@ -355,7 +393,7 @@ public class PowerShellAssemblyGenerator
     /// <c>true</c> if the method was generated; <c>false</c> if the parameter set was skipped
     /// because one or more mandatory parameters have unserializable types.
     /// </returns>
-    private static bool GenerateMethodForCommand(TypeBuilder typeBuilder, CommandInfo commandInfo, FieldBuilder loggerField, FieldBuilder runspaceField, ILogger logger, CommandParameterSetInfo parameterSet)
+    private static bool GenerateMethodForCommand(TypeBuilder typeBuilder, CommandInfo commandInfo, FieldBuilder loggerField, FieldBuilder runspaceField, ILogger logger, CommandParameterSetInfo parameterSet, IReadOnlyDictionary<string, string>? parameterDescriptions)
     {
         // Get command parameters for this specific parameter set (excluding common parameters) and order by position.
         //
@@ -570,6 +608,24 @@ public class PowerShellAssemblyGenerator
             {
                 // Mandatory parameter
                 paramBuilder = methodBuilder.DefineParameter(i + 1, ParameterAttributes.None, parameterNames[i]);
+            }
+
+            // Spec 010 FR-510: attach [Description] to PowerShell-derived parameters so the
+            // MCP SDK auto-schema surfaces them as inputSchema.properties.<name>.description.
+            // Framework parameters (_AllProperties, _MaxResults, _RequestedProperties) and
+            // CancellationToken are skipped — they have framework-level documentation that
+            // lives elsewhere.
+            if (parameterDescriptions != null && i < parameters.Count)
+            {
+                var originalName = parameters[i].Key;
+                if (parameterDescriptions.TryGetValue(originalName, out var description)
+                    && !string.IsNullOrWhiteSpace(description))
+                {
+                    var attrBuilder = new CustomAttributeBuilder(
+                        s_descriptionAttributeCtor,
+                        new object[] { description });
+                    paramBuilder.SetCustomAttribute(attrBuilder);
+                }
             }
         }
 

--- a/PoshMcp.Server/PowerShell/PowerShellHelpResolver.cs
+++ b/PoshMcp.Server/PowerShell/PowerShellHelpResolver.cs
@@ -1,0 +1,282 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using PSPowerShell = System.Management.Automation.PowerShell;
+
+namespace PoshMcp.Server.PowerShell;
+
+/// <summary>
+/// Resolves <c>Get-Help</c>-derived metadata for in-process PowerShell command discovery,
+/// implementing the lookup half of spec 010 (the precedence chain logic itself lives in
+/// <see cref="HelpAwareToolMetadataSource"/>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// FR-570 / FR-571: <c>Get-Help</c> is invoked at most once per command and the result is
+/// cached for the lifetime of this resolver instance (and therefore for the lifetime of the
+/// owning <see cref="IPowerShellRunspace"/>). Per-parameter <c>Get-Help</c> calls are
+/// forbidden — parameter help is read from the per-command result.
+/// </para>
+/// <para>
+/// FR-502 / FR-580 / FR-581: any failure (null result, exception, missing MAML) is treated
+/// as "no value" and recorded as an empty cache entry. Discovery never fails because help
+/// cannot be resolved.
+/// </para>
+/// </remarks>
+public sealed class PowerShellHelpResolver
+{
+    private readonly ConcurrentDictionary<string, CommandHelpInfo> _cache =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Returns a structured snapshot of <c>Get-Help</c> output for <paramref name="commandName"/>.
+    /// First call per command name invokes <c>Get-Help</c>; subsequent calls return the cached
+    /// result. Never throws — failures yield an empty <see cref="CommandHelpInfo"/>.
+    /// </summary>
+    /// <param name="commandName">PowerShell command name (e.g., <c>Get-Process</c>).</param>
+    /// <param name="powerShell">A live PSPowerShell instance from the discovery runspace.</param>
+    /// <param name="logger">Diagnostic logger for help-resolution failures.</param>
+    public CommandHelpInfo Resolve(string commandName, PSPowerShell powerShell, ILogger logger)
+    {
+        if (string.IsNullOrWhiteSpace(commandName))
+        {
+            return CommandHelpInfo.Empty;
+        }
+
+        return _cache.GetOrAdd(commandName, name => ResolveCore(name, powerShell, logger));
+    }
+
+    /// <summary>Drops all cached help entries.</summary>
+    public void ClearCache() => _cache.Clear();
+
+    private static CommandHelpInfo ResolveCore(string commandName, PSPowerShell powerShell, ILogger logger)
+    {
+        try
+        {
+            powerShell.Commands.Clear();
+            powerShell.Streams.ClearStreams();
+            powerShell.AddCommand("Get-Help")
+                .AddParameter("Name", commandName)
+                .AddParameter("Full")
+                .AddParameter("ErrorAction", "SilentlyContinue");
+
+            var results = powerShell.Invoke();
+            powerShell.Commands.Clear();
+
+            if (results == null || results.Count == 0 || results[0] == null)
+            {
+                return CommandHelpInfo.Empty;
+            }
+
+            return BuildFromHelpObject(results[0], commandName);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Get-Help failed for {Command}; treating as no help available.", commandName);
+            try { powerShell.Commands.Clear(); } catch { /* best-effort cleanup */ }
+            return CommandHelpInfo.Empty;
+        }
+    }
+
+    private static CommandHelpInfo BuildFromHelpObject(PSObject help, string commandName)
+    {
+        var synopsisRaw = SafeGetString(help, "Synopsis");
+        var synopsis = string.Equals(synopsisRaw?.Trim(), commandName, StringComparison.Ordinal)
+            ? null // FR-500 step 1: synopsis equal to command name = auto-generated, treat as missing.
+            : synopsisRaw;
+
+        var longDescription = ExtractDescriptionBody(help);
+        var parameters = ExtractParameterDescriptions(help);
+
+        return new CommandHelpInfo(synopsis, longDescription, parameters);
+    }
+
+    private static string? ExtractDescriptionBody(PSObject help)
+    {
+        var descriptionProperty = help.Properties["description"];
+        if (descriptionProperty?.Value is null)
+        {
+            return null;
+        }
+
+        return JoinMamlParagraphs(descriptionProperty.Value);
+    }
+
+    private static IReadOnlyDictionary<string, string> ExtractParameterDescriptions(PSObject help)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        var parametersProperty = help.Properties["parameters"];
+        if (parametersProperty?.Value is null)
+        {
+            return result;
+        }
+
+        // .parameters is a PSCustomObject with a .parameter array (or single parameter object).
+        var parameterEntries = ResolveParameterArray(parametersProperty.Value);
+        if (parameterEntries == null)
+        {
+            return result;
+        }
+
+        foreach (var entry in parameterEntries)
+        {
+            if (entry == null) continue;
+            var psEntry = entry as PSObject ?? new PSObject(entry);
+            var name = SafeGetString(psEntry, "name");
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                continue;
+            }
+
+            var descriptionValue = psEntry.Properties["description"]?.Value;
+            if (descriptionValue == null)
+            {
+                continue;
+            }
+
+            var joined = JoinMamlParagraphs(descriptionValue);
+            if (!string.IsNullOrWhiteSpace(joined))
+            {
+                result[name!] = joined!;
+            }
+        }
+
+        return result;
+    }
+
+    private static IEnumerable<object?>? ResolveParameterArray(object value)
+    {
+        var unwrapped = value is PSObject pso ? pso.BaseObject ?? pso : value;
+        var holder = unwrapped as PSObject ?? new PSObject(unwrapped);
+
+        var parameterMember = holder.Properties["parameter"]?.Value;
+        if (parameterMember == null)
+        {
+            // Some shapes pass the parameter array directly.
+            return value as IEnumerable<object?>
+                   ?? (value as System.Collections.IEnumerable)?.Cast<object?>();
+        }
+
+        if (parameterMember is System.Collections.IEnumerable enumerable && parameterMember is not string)
+        {
+            return enumerable.Cast<object?>();
+        }
+
+        return new[] { (object?)parameterMember };
+    }
+
+    private static string? JoinMamlParagraphs(object? value)
+    {
+        if (value == null)
+        {
+            return null;
+        }
+
+        var unwrapped = value is PSObject pso ? pso.BaseObject ?? pso : value;
+
+        // MAML paragraphs come back as either a string, a single PSObject with a `Text`
+        // property, or an array of those.
+        if (unwrapped is string s)
+        {
+            return s;
+        }
+
+        if (unwrapped is System.Collections.IEnumerable enumerable && unwrapped is not string)
+        {
+            var paragraphs = new List<string>();
+            foreach (var item in enumerable)
+            {
+                var text = ExtractParaText(item);
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    paragraphs.Add(text!);
+                }
+            }
+            return paragraphs.Count == 0
+                ? null
+                : string.Join(DescriptionSanitizer.ParagraphSeparator, paragraphs);
+        }
+
+        return ExtractParaText(unwrapped);
+    }
+
+    private static string? ExtractParaText(object? item)
+    {
+        if (item == null)
+        {
+            return null;
+        }
+        if (item is string s)
+        {
+            return s;
+        }
+
+        var pso = item as PSObject ?? new PSObject(item);
+        var textProperty = pso.Properties["Text"]?.Value;
+        if (textProperty != null)
+        {
+            return textProperty.ToString();
+        }
+
+        return pso.ToString();
+    }
+
+    private static string? SafeGetString(PSObject obj, string propertyName)
+    {
+        var prop = obj.Properties[propertyName];
+        if (prop?.Value == null)
+        {
+            return null;
+        }
+
+        // Synopsis can come back wrapped in PSObject, plain string, or even a
+        // ParamTextSpan-style array. Stringify defensively.
+        var raw = prop.Value;
+        if (raw is string s)
+        {
+            return s;
+        }
+
+        if (raw is System.Collections.IEnumerable enumerable && raw is not PSObject)
+        {
+            var sb = new StringBuilder();
+            foreach (var item in enumerable)
+            {
+                if (item == null) continue;
+                if (sb.Length > 0) sb.Append(' ');
+                sb.Append(item);
+            }
+            return sb.ToString();
+        }
+
+        return raw.ToString();
+    }
+}
+
+/// <summary>
+/// Snapshot of <c>Get-Help</c> output for a single command, in the shape
+/// <see cref="HelpAwareToolMetadataSource"/> consumes.
+/// </summary>
+/// <param name="Synopsis">Raw <c>.Synopsis</c> text, already filtered for the
+/// auto-generated case (equal to command name → <c>null</c>). Sanitization is the
+/// metadata source's responsibility, not this record's.</param>
+/// <param name="LongDescription">Raw <c>.Description</c> body with paragraphs joined by
+/// <see cref="DescriptionSanitizer.ParagraphSeparator"/>.</param>
+/// <param name="ParameterDescriptions">Map from parameter name to raw paragraph-joined
+/// description text. Empty when no per-parameter help is present.</param>
+public sealed record CommandHelpInfo(
+    string? Synopsis,
+    string? LongDescription,
+    IReadOnlyDictionary<string, string> ParameterDescriptions)
+{
+    /// <summary>The "no help available" sentinel; returned for any resolution failure.</summary>
+    public static CommandHelpInfo Empty { get; } = new(
+        Synopsis: null,
+        LongDescription: null,
+        ParameterDescriptions: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+}

--- a/PoshMcp.Server/PowerShell/PowerShellSchemaGenerator.cs
+++ b/PoshMcp.Server/PowerShell/PowerShellSchemaGenerator.cs
@@ -6,19 +6,31 @@ using System.Management.Automation;
 namespace PoshMcp.Server.PowerShell;
 
 /// <summary>
-/// Utility class for generating JSON schemas for PowerShell parameters
+/// Utility class for generating JSON schemas for PowerShell parameters.
 /// </summary>
+/// <remarks>
+/// Spec 010: parameter descriptions emitted by this generator are now resolved through an
+/// <see cref="IToolMetadataSource"/> so they apply the same FR-510 precedence chain
+/// (Get-Help parameter → ParameterAttribute.HelpMessage → ValidateSet phrasing → typed
+/// fallback) used by the in-process and out-of-process tool factory paths. Callers that
+/// don't supply a source receive the type-fallback string for every parameter (preserves
+/// pre-spec-010 output).
+/// </remarks>
 public static class PowerShellSchemaGenerator
 {
     /// <summary>
-    /// Generates a JSON schema object for the command parameters (for documentation purposes)
+    /// Generates a JSON schema object for the command parameters (for documentation purposes).
     /// </summary>
-    /// <param name="commandInfo">The PowerShell command information</param>
-    /// <returns>A schema object representing the command parameters</returns>
-    public static object GenerateParameterSchema(CommandInfo commandInfo)
+    /// <param name="commandInfo">The PowerShell command information.</param>
+    /// <param name="metadataSource">Optional metadata source used to resolve per-parameter
+    /// descriptions per spec 010 FR-510. Defaults to <see cref="DefaultToolMetadataSource"/>
+    /// when omitted, which preserves pre-spec-010 output.</param>
+    /// <returns>A schema object representing the command parameters.</returns>
+    public static object GenerateParameterSchema(CommandInfo commandInfo, IToolMetadataSource? metadataSource = null)
     {
         var properties = new Dictionary<string, object>();
         var required = new List<string>();
+        var source = metadataSource ?? new DefaultToolMetadataSource();
 
         foreach (var parameterKvp in commandInfo.Parameters)
         {
@@ -29,7 +41,7 @@ public static class PowerShellSchemaGenerator
             if (PowerShellParameterUtils.IsCommonParameter(parameterName))
                 continue;
 
-            var parameterSchema = CreateParameterSchema(parameterMetadata);
+            var parameterSchema = CreateParameterSchema(parameterMetadata, commandInfo.Name, parameterName, source);
             properties[parameterName] = parameterSchema;
 
             // Check if parameter is mandatory
@@ -48,12 +60,30 @@ public static class PowerShellSchemaGenerator
     }
 
     /// <summary>
-    /// Creates a JSON schema for a single parameter
+    /// Creates a JSON schema for a single parameter.
     /// </summary>
-    /// <param name="parameterMetadata">The parameter metadata</param>
-    /// <returns>A schema object for the parameter</returns>
+    /// <param name="parameterMetadata">The parameter metadata.</param>
+    /// <returns>A schema object for the parameter.</returns>
     public static object CreateParameterSchema(ParameterMetadata parameterMetadata)
+        => CreateParameterSchema(parameterMetadata, commandName: string.Empty, parameterName: parameterMetadata?.Name ?? string.Empty, metadataSource: null);
+
+    /// <summary>
+    /// Creates a JSON schema for a single parameter, applying the spec 010 FR-510 precedence
+    /// chain to the parameter description when <paramref name="metadataSource"/> is supplied.
+    /// </summary>
+    /// <param name="parameterMetadata">The parameter metadata.</param>
+    /// <param name="commandName">Owning command name (used for diagnostics in resolver
+    /// implementations); empty string is acceptable when not available.</param>
+    /// <param name="parameterName">Parameter name without leading dash.</param>
+    /// <param name="metadataSource">Description resolver. <c>null</c> selects the type fallback.</param>
+    public static object CreateParameterSchema(
+        ParameterMetadata parameterMetadata,
+        string commandName,
+        string parameterName,
+        IToolMetadataSource? metadataSource)
     {
+        if (parameterMetadata == null) throw new ArgumentNullException(nameof(parameterMetadata));
+
         var schema = new Dictionary<string, object>();
         var parameterType = parameterMetadata.ParameterType;
 
@@ -94,8 +124,29 @@ public static class PowerShellSchemaGenerator
             schema["type"] = "string"; // Default to string for complex types
         }
 
-        // Add description from parameter name and type
-        schema["description"] = $"Parameter of type {parameterType.Name}";
+        // Resolve description through the spec 010 precedence chain. Pull the same inputs
+        // the in-process call site collects (Get-Help text isn't available here, so the
+        // chain naturally degrades to HelpMessage / ValidateSet / typed fallback).
+        var source = metadataSource ?? new DefaultToolMetadataSource();
+        var helpMessage = parameterMetadata.Attributes.OfType<ParameterAttribute>()
+            .Select(a => a.HelpMessage)
+            .FirstOrDefault(m => !string.IsNullOrWhiteSpace(m));
+        var validateSet = parameterMetadata.Attributes.OfType<ValidateSetAttribute>().FirstOrDefault();
+        IReadOnlyList<string>? validateValues = validateSet?.ValidValues != null
+            ? validateSet.ValidValues.ToArray()
+            : null;
+        var appliesToArrayElement = validateValues != null && parameterType.IsArray;
+
+        var request = new ParameterDescriptionRequest(
+            CommandName: string.IsNullOrEmpty(commandName) ? parameterName : commandName,
+            ParameterName: string.IsNullOrEmpty(parameterName) ? "_param" : parameterName,
+            ParameterTypeName: parameterType.Name,
+            HelpParameterDescription: null,
+            HelpMessage: helpMessage,
+            ValidateSetValues: validateValues,
+            ValidateSetAppliesToArrayElement: appliesToArrayElement);
+
+        schema["description"] = source.ResolveParameterDescription(in request).Description;
 
         return schema;
     }

--- a/PoshMcp.Server/Server/HttpServerHost.cs
+++ b/PoshMcp.Server/Server/HttpServerHost.cs
@@ -280,10 +280,11 @@ internal static class HttpServerHost
     {
         builder.Services.AddSingleton<McpMetrics>();
 
-        // Spec 010 seam: shared MCP tool/parameter description sourcing. The default impl
-        // preserves pre-spec-010 behavior; #226 / #227 replace this registration with an
-        // implementation that consults Get-Help.
-        builder.Services.TryAddSingleton<IToolMetadataSource, DefaultToolMetadataSource>();
+        // Spec 010 seam: shared MCP tool/parameter description sourcing. The Help-aware
+        // implementation applies the FR-500/FR-510 precedence chain (Get-Help synopsis →
+        // long description → syntax → name for tools; Get-Help parameter → HelpMessage →
+        // ValidateSet phrasing → typed fallback for parameters) and the FR-540 sanitizer.
+        builder.Services.TryAddSingleton<IToolMetadataSource, HelpAwareToolMetadataSource>();
 
         builder.Services.AddOpenTelemetry()
             .WithTracing(tracingBuilder =>

--- a/PoshMcp.Server/Server/StdioServerHost.cs
+++ b/PoshMcp.Server/Server/StdioServerHost.cs
@@ -141,10 +141,11 @@ internal static class StdioServerHost
         // Register and configure OpenTelemetry metrics
         builder.Services.AddSingleton<McpMetrics>();
 
-        // Spec 010 seam: shared MCP tool/parameter description sourcing. The default impl
-        // preserves pre-spec-010 behavior; #226 / #227 replace this registration with an
-        // implementation that consults Get-Help.
-        builder.Services.TryAddSingleton<IToolMetadataSource, DefaultToolMetadataSource>();
+        // Spec 010 seam: shared MCP tool/parameter description sourcing. The Help-aware
+        // implementation applies the FR-500/FR-510 precedence chain (Get-Help synopsis →
+        // long description → syntax → name for tools; Get-Help parameter → HelpMessage →
+        // ValidateSet phrasing → typed fallback for parameters) and the FR-540 sanitizer.
+        builder.Services.TryAddSingleton<IToolMetadataSource, HelpAwareToolMetadataSource>();
 
         builder.Services.AddOpenTelemetry()
             .WithTracing(tracingBuilder =>

--- a/PoshMcp.Tests/Unit/DescriptionSanitizerTests.cs
+++ b/PoshMcp.Tests/Unit/DescriptionSanitizerTests.cs
@@ -1,0 +1,157 @@
+using PoshMcp.Server.PowerShell;
+using Xunit;
+
+namespace PoshMcp.Tests.Unit;
+
+/// <summary>
+/// Unit tests for <see cref="DescriptionSanitizer"/>, the FR-540 normalizer used by the
+/// in-process and out-of-process metadata pipelines. These tests pin behavior that the
+/// FR-520 byte-equivalence guarantee depends on: any change here must hold across both
+/// execution paths.
+/// </summary>
+public class DescriptionSanitizerTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t\t\t")]
+    [InlineData("\r\n\r\n")]
+    public void Normalize_NullOrWhitespaceInput_ReturnsEmpty(string? input)
+    {
+        Assert.Equal(string.Empty, DescriptionSanitizer.Normalize(input));
+    }
+
+    [Fact]
+    public void Normalize_OuterWhitespace_IsTrimmed()
+    {
+        Assert.Equal("hello", DescriptionSanitizer.Normalize("   hello   "));
+    }
+
+    [Fact]
+    public void Normalize_TabsBetweenWords_CollapseToSingleSpace()
+    {
+        Assert.Equal("hello world", DescriptionSanitizer.Normalize("hello\t\tworld"));
+    }
+
+    [Fact]
+    public void Normalize_MultipleSpacesBetweenWords_CollapseToSingleSpace()
+    {
+        Assert.Equal("hello world", DescriptionSanitizer.Normalize("hello     world"));
+    }
+
+    [Fact]
+    public void Normalize_MixedTabsAndSpaces_CollapseToSingleSpace()
+    {
+        Assert.Equal("a b c", DescriptionSanitizer.Normalize("a \t  b\t \t c"));
+    }
+
+    [Fact]
+    public void Normalize_ParagraphBreak_IsPreserved()
+    {
+        var input = "First paragraph.\n\nSecond paragraph.";
+        Assert.Equal("First paragraph.\n\nSecond paragraph.", DescriptionSanitizer.Normalize(input));
+    }
+
+    [Fact]
+    public void Normalize_MultipleBlankLines_StillSeparateParagraphsByDoubleNewline()
+    {
+        // Three or more newlines still represent a paragraph boundary; the normalizer
+        // must collapse them to exactly one blank line so parity with the OOP host holds.
+        var input = "First.\n\n\n\nSecond.";
+        Assert.Equal("First.\n\nSecond.", DescriptionSanitizer.Normalize(input));
+    }
+
+    [Fact]
+    public void Normalize_WhitespaceWithinParagraph_IsCollapsed_WithoutDestroyingParagraphBreak()
+    {
+        var input = "First   \tparagraph.\n\nSecond\tparagraph.";
+        Assert.Equal("First paragraph.\n\nSecond paragraph.", DescriptionSanitizer.Normalize(input));
+    }
+
+    [Fact]
+    public void Normalize_Cc_ControlCharacters_AreStripped()
+    {
+        // \u0001 and \u001F are Cc control characters that must be removed entirely
+        // (whitespace categories like \t, \r, \n collapse instead — covered above).
+        var input = "alpha\u0001beta\u001Fgamma";
+        Assert.Equal("alphabetagamma", DescriptionSanitizer.Normalize(input));
+    }
+
+    [Fact]
+    public void Normalize_BellCharacter_IsStripped()
+    {
+        Assert.Equal("warning", DescriptionSanitizer.Normalize("warning\u0007"));
+    }
+
+    [Fact]
+    public void Normalize_PrintableUnicode_IsPreserved()
+    {
+        // Smart quotes, en-dash, accented characters must survive normalization.
+        var input = "café — résumé “quoted”";
+        Assert.Equal("café — résumé “quoted”", DescriptionSanitizer.Normalize(input));
+    }
+
+    [Fact]
+    public void TruncateAtWordBoundary_ShorterThanMax_ReturnsAsIs()
+    {
+        Assert.Equal("hello", DescriptionSanitizer.TruncateAtWordBoundary("hello", 100));
+    }
+
+    [Fact]
+    public void TruncateAtWordBoundary_AppendsEllipsisCharacter()
+    {
+        var result = DescriptionSanitizer.TruncateAtWordBoundary("hello world from poshmcp", 12);
+        Assert.EndsWith("\u2026", result);
+        Assert.True(result.Length <= 12);
+    }
+
+    [Fact]
+    public void TruncateAtWordBoundary_PrefersWordBoundary_OverHardCut()
+    {
+        // "hello world from poshmcp" — at maxLength 17 a word boundary exists at
+        // "hello world from " (length 17 incl. trailing space). The truncator should
+        // back up to a boundary and append the ellipsis instead of slicing inside "from".
+        var result = DescriptionSanitizer.TruncateAtWordBoundary("hello world from poshmcp", 18);
+        Assert.EndsWith("\u2026", result);
+        // Either "hello world from\u2026" (16 chars + ellipsis) or "hello world\u2026" — both are
+        // valid word-boundary truncations. What matters is that we did NOT cut mid-word
+        // (the trailing word "poshmcp" must not appear partially).
+        Assert.DoesNotContain("poshmc", result);
+        Assert.True(result == "hello world from\u2026" || result == "hello world\u2026");
+    }
+
+    [Fact]
+    public void TruncateAtWordBoundary_NoWordBoundaryAvailable_FallsBackToHardCut()
+    {
+        // A single long token longer than the limit must still be truncated; the only
+        // available behavior is a hard cut + ellipsis. The result is allowed to consume
+        // all of `maxLength` minus the ellipsis character.
+        var result = DescriptionSanitizer.TruncateAtWordBoundary("supercalifragilistic", 10);
+        Assert.EndsWith("\u2026", result);
+        Assert.True(result.Length <= 10);
+    }
+
+    [Fact]
+    public void TruncateAtWordBoundary_MaxLengthOne_ReturnsSingleEllipsis()
+    {
+        Assert.Equal("\u2026", DescriptionSanitizer.TruncateAtWordBoundary("anything at all", 1));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void TruncateAtWordBoundary_NullOrEmpty_ReturnsEmpty(string? input)
+    {
+        Assert.Equal(string.Empty, DescriptionSanitizer.TruncateAtWordBoundary(input ?? string.Empty, 50));
+    }
+
+    [Fact]
+    public void Normalize_ParagraphSeparatorConstant_MatchesDoubleNewline()
+    {
+        // The FR-540 contract names this the "paragraph separator". Pin it so callers
+        // building structured help (PowerShellHelpResolver.JoinMamlParagraphs) cannot
+        // diverge from the sanitizer's expectation.
+        Assert.Equal("\n\n", DescriptionSanitizer.ParagraphSeparator);
+    }
+}


### PR DESCRIPTION
Closes #226

Implements FR-500/FR-510/FR-540 in the in-process path via a new HelpAwareToolMetadataSource consuming the IToolMetadataSource seam from #225/#238. Includes DescriptionSanitizer with unit tests. OOP path unchanged in this PR.

Reviewers: Farnsworth + Cubert (squad).