### PR TITLE
feat(oop): wire OOP through IToolMetadataSource seam (#228)

### DIFF
--- a/PoshMcp.Server/McpToolFactoryV2.cs
+++ b/PoshMcp.Server/McpToolFactoryV2.cs
@@ -396,7 +396,8 @@ public class McpToolFactoryV2
             return new List<McpServerTool>();
         }
 
-        _outOfProcessAssemblyGenerator.GenerateAssembly(schemas, logger);
+        var remoteParameterDescriptions = BuildRemoteParameterDescriptionMap(schemas, _toolMetadataSource);
+        _outOfProcessAssemblyGenerator.GenerateAssembly(schemas, remoteParameterDescriptions, logger);
         var generatedInstance = _outOfProcessAssemblyGenerator.GetGeneratedInstance(logger);
         var generatedMethods = _outOfProcessAssemblyGenerator.GetGeneratedMethods();
         var methodToCommandMap = CreateRemoteCommandMetadataMapping(schemas, _toolMetadataSource);
@@ -571,8 +572,8 @@ public class McpToolFactoryV2
                 CommandName: schema.Name,
                 ParameterSetName: schema.ParameterSetName,
                 Synopsis: string.IsNullOrWhiteSpace(schema.Description) ? null : schema.Description,
-                LongDescription: null,
-                ParameterSetSyntax: null);
+                LongDescription: string.IsNullOrWhiteSpace(schema.FullDescription) ? null : schema.FullDescription,
+                ParameterSetSyntax: BuildRemoteParameterSetSyntax(schema));
             var result = metadataSource.ResolveToolDescription(in request);
             var metadata = new PowerShellCommandMetadata
             {
@@ -602,6 +603,123 @@ public class McpToolFactoryV2
         }
 
         return methodToCommandMap;
+    }
+
+    /// <summary>
+    /// Spec 010 FR-510 / FR-520: builds the per-parameter description map for the OOP path
+    /// by feeding each <see cref="RemoteParameterSchema"/>'s help-derived fields through the
+    /// shared <see cref="IToolMetadataSource"/> seam. This is the OOP analogue of
+    /// <see cref="BuildParameterDescriptionMap"/>; the result feeds
+    /// <see cref="OutOfProcessToolAssemblyGenerator.GenerateAssembly(IReadOnlyList{RemoteToolSchema}, IReadOnlyDictionary{string, IReadOnlyDictionary{string, string}}?, ILogger)"/>
+    /// so OOP-emitted parameters carry the same <c>[Description]</c> attributes that the
+    /// in-process path emits.
+    /// </summary>
+    private static IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> BuildRemoteParameterDescriptionMap(
+        IReadOnlyList<RemoteToolSchema> schemas,
+        IToolMetadataSource metadataSource)
+    {
+        var result = new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var schema in schemas)
+        {
+            if (result.ContainsKey(schema.Name))
+            {
+                continue;
+            }
+
+            var perParameter = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var param in schema.Parameters)
+            {
+                if (PowerShellParameterUtils.IsCommonParameter(param.Name))
+                {
+                    continue;
+                }
+
+                IReadOnlyList<string>? validateValues = param.ValidateSetValues != null && param.ValidateSetValues.Length > 0
+                    ? param.ValidateSetValues
+                    : null;
+                var appliesToArrayElement = validateValues != null && IsArrayLikeTypeName(param.TypeName);
+
+                var request = new ParameterDescriptionRequest(
+                    CommandName: schema.Name,
+                    ParameterName: param.Name,
+                    ParameterTypeName: param.TypeName,
+                    HelpParameterDescription: param.HelpDescription,
+                    HelpMessage: param.HelpMessage,
+                    ValidateSetValues: validateValues,
+                    ValidateSetAppliesToArrayElement: appliesToArrayElement);
+
+                var resolved = metadataSource.ResolveParameterDescription(in request);
+                if (resolved.Source != ParameterDescriptionSource.TypeFallback
+                    && !string.IsNullOrWhiteSpace(resolved.Description))
+                {
+                    perParameter[param.Name] = resolved.Description;
+                }
+            }
+
+            if (perParameter.Count > 0)
+            {
+                result[schema.Name] = perParameter;
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Synthesizes a parameter-set-syntax string for the OOP tool-description fallback
+    /// (FR-500 step 3). The OOP host script does not carry <c>CommandParameterSetInfo.ToString()</c>
+    /// across the wire; this best-effort renderer mirrors its conventional shape:
+    /// <c>[-Param &lt;Type&gt;]</c> for optional, <c>-Param &lt;Type&gt;</c> for mandatory.
+    /// Returns <c>null</c> when the schema has no parameters so the resolver falls through
+    /// to the bare command name.
+    /// </summary>
+    private static string? BuildRemoteParameterSetSyntax(RemoteToolSchema schema)
+    {
+        if (schema.Parameters == null || schema.Parameters.Count == 0)
+        {
+            return null;
+        }
+
+        var parts = new List<string>(schema.Parameters.Count);
+        foreach (var param in schema.Parameters)
+        {
+            if (PowerShellParameterUtils.IsCommonParameter(param.Name))
+            {
+                continue;
+            }
+
+            var typeDisplay = ShortTypeName(param.TypeName);
+            var fragment = string.Equals(param.TypeName, "System.Management.Automation.SwitchParameter", StringComparison.Ordinal)
+                ? $"-{param.Name}"
+                : $"-{param.Name} <{typeDisplay}>";
+
+            parts.Add(param.IsMandatory ? fragment : $"[{fragment}]");
+        }
+
+        return parts.Count == 0 ? null : string.Join(" ", parts);
+    }
+
+    private static bool IsArrayLikeTypeName(string? typeName)
+    {
+        if (string.IsNullOrEmpty(typeName))
+        {
+            return false;
+        }
+        return typeName.EndsWith("[]", StringComparison.Ordinal);
+    }
+
+    private static string ShortTypeName(string? typeName)
+    {
+        if (string.IsNullOrWhiteSpace(typeName))
+        {
+            return "Object";
+        }
+        var lastDot = typeName!.LastIndexOf('.');
+        return lastDot >= 0 && lastDot < typeName.Length - 1
+            ? typeName.Substring(lastDot + 1)
+            : typeName;
     }
 
     private void MapParameterSetsToMetadata(CommandInfo command, PSPowerShell powerShell, CommandHelpInfo help, Dictionary<string, PowerShellCommandMetadata> methodToCommandMap, ILogger logger)

--- a/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessToolAssemblyGenerator.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessToolAssemblyGenerator.cs
@@ -20,6 +20,10 @@ public class OutOfProcessToolAssemblyGenerator
 {
     private const int FrameworkParameterCount = 3;
 
+    private static readonly ConstructorInfo s_descriptionAttributeCtor =
+        typeof(System.ComponentModel.DescriptionAttribute).GetConstructor(new[] { typeof(string) })
+        ?? throw new InvalidOperationException("System.ComponentModel.DescriptionAttribute(string) constructor not found.");
+
     private readonly ICommandExecutor _commandExecutor;
     private readonly object _lock = new object();
     private Type? _generatedType;
@@ -45,6 +49,27 @@ public class OutOfProcessToolAssemblyGenerator
     }
 
     public void GenerateAssembly(IReadOnlyList<RemoteToolSchema> schemas, ILogger logger)
+        => GenerateAssembly(schemas, parameterDescriptions: null, logger);
+
+    /// <summary>
+    /// Generates the OOP-backed dynamic assembly, optionally attaching
+    /// <see cref="System.ComponentModel.DescriptionAttribute"/> to each emitted
+    /// parameter so the MCP SDK auto-schema surfaces them as
+    /// <c>inputSchema.properties.&lt;name&gt;.description</c>. Spec 010 FR-520:
+    /// the supplied description map is the OOP path's equivalent of the in-process
+    /// map produced by <c>McpToolFactoryV2.BuildParameterDescriptionMap</c>, both
+    /// resolved through the same <see cref="IToolMetadataSource"/> seam.
+    /// </summary>
+    /// <param name="schemas">Discovered remote command schemas.</param>
+    /// <param name="parameterDescriptions">Map keyed by command name; each value is
+    /// a map from PowerShell parameter name to the resolved, sanitized description
+    /// text. <c>null</c> or empty preserves legacy behavior (no per-parameter
+    /// descriptions emitted).</param>
+    /// <param name="logger">Logger instance.</param>
+    public void GenerateAssembly(
+        IReadOnlyList<RemoteToolSchema> schemas,
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>>? parameterDescriptions,
+        ILogger logger)
     {
         lock (_lock)
         {
@@ -80,7 +105,11 @@ public class OutOfProcessToolAssemblyGenerator
             {
                 try
                 {
-                    GenerateMethodForSchema(typeBuilder, schema, executorField);
+                    var perParameter = parameterDescriptions != null
+                        && parameterDescriptions.TryGetValue(schema.Name, out var map)
+                            ? map
+                            : null;
+                    GenerateMethodForSchema(typeBuilder, schema, executorField, perParameter);
                 }
                 catch (Exception ex)
                 {
@@ -246,7 +275,8 @@ public class OutOfProcessToolAssemblyGenerator
     private static void GenerateMethodForSchema(
         TypeBuilder typeBuilder,
         RemoteToolSchema schema,
-        FieldBuilder executorField)
+        FieldBuilder executorField,
+        IReadOnlyDictionary<string, string>? parameterDescriptions = null)
     {
         var methodName = PowerShellAssemblyGenerator.SanitizeMethodName(schema.Name, schema.ParameterSetName);
 
@@ -298,10 +328,11 @@ public class OutOfProcessToolAssemblyGenerator
         // Set parameter names and default values
         for (int i = 0; i < paramCSharpNames.Count; i++)
         {
+            ParameterBuilder paramBuilder;
             if (!paramIsMandatory[i])
             {
                 var paramAttributes = ParameterAttributes.Optional | ParameterAttributes.HasDefault;
-                var paramBuilder = methodBuilder.DefineParameter(i + 1, paramAttributes, paramCSharpNames[i]);
+                paramBuilder = methodBuilder.DefineParameter(i + 1, paramAttributes, paramCSharpNames[i]);
 
                 try
                 {
@@ -342,7 +373,26 @@ public class OutOfProcessToolAssemblyGenerator
             }
             else
             {
-                methodBuilder.DefineParameter(i + 1, ParameterAttributes.None, paramCSharpNames[i]);
+                paramBuilder = methodBuilder.DefineParameter(i + 1, ParameterAttributes.None, paramCSharpNames[i]);
+            }
+
+            // Spec 010 FR-510 / FR-520: attach [Description] to PowerShell-derived
+            // parameters so the MCP SDK auto-schema surfaces them as
+            // inputSchema.properties.<name>.description. Framework parameters
+            // (_AllProperties, _MaxResults, _RequestedProperties) and
+            // CancellationToken are skipped — they have framework-level
+            // documentation that lives elsewhere.
+            if (parameterDescriptions != null && i < commandParamCount)
+            {
+                var originalName = paramOriginalNames[i];
+                if (parameterDescriptions.TryGetValue(originalName, out var description)
+                    && !string.IsNullOrWhiteSpace(description))
+                {
+                    var attrBuilder = new CustomAttributeBuilder(
+                        s_descriptionAttributeCtor,
+                        new object[] { description });
+                    paramBuilder.SetCustomAttribute(attrBuilder);
+                }
             }
         }
 


### PR DESCRIPTION
Closes #228

Routes OOP description resolution through the same `IToolMetadataSource` seam used by the in-process path, consuming the new `RemoteToolSchema` fields from #227. Establishes mode parity for tool/parameter descriptions per FR-520. Parity regression tests land in #229.

**Changes**

- `McpToolFactoryV2`
  - `CreateRemoteCommandMetadataMapping` now passes `schema.FullDescription` as `LongDescription` and a synthesized parameter-set syntax string as `ParameterSetSyntax`, so the OOP tool-description chain exercises FR-500 steps 1→4 identically to in-process (`SetParameterSetDescription`).
  - New `BuildRemoteParameterDescriptionMap` mirrors the in-process `BuildParameterDescriptionMap`: it iterates `RemoteParameterSchema` entries and resolves each through `_toolMetadataSource.ResolveParameterDescription` using the new `HelpDescription` / `HelpMessage` / `ValidateSetValues` fields. Output feeds the OOP assembly generator.
  - Helper `BuildRemoteParameterSetSyntax` synthesizes `[-Param <Type>]` / `-Param <Type>` from schema parameters so FR-500 step 3 works without round-tripping `CommandParameterSetInfo.ToString()` over the wire.
- `OutOfProcessToolAssemblyGenerator`
  - New `GenerateAssembly(schemas, parameterDescriptions, logger)` overload (legacy single-arg overload preserved). Per-command description map is forwarded to `GenerateMethodForSchema` and used to attach `[Description]` to each PowerShell-derived parameter — same pattern as `PowerShellAssemblyGenerator` so the MCP SDK auto-schema surfaces them as `inputSchema.properties.<name>.description`.
  - Framework parameters (`_AllProperties`, `_MaxResults`, `_RequestedProperties`) and `CancellationToken` are skipped, matching in-process.

No host-script changes: `oop-host.ps1` already emits the new fields raw per #239; the C# consumer now no longer depends on `Description` (Synopsis) being non-empty since the precedence chain handles fall-through.

**Verification**

- `dotnet build PoshMcp.sln -c Release` — clean (no new warnings).
- `dotnet test PoshMcp.Tests/PoshMcp.Tests.csproj -c Release --filter "Category!=Integration"` — 684 passed, 7 skipped, 0 failed.
- Local OOP `tools/list` snapshot via `specs/010-tool-self-documentation/baseline/capture-snapshots.ps1` — tool descriptions for `HelpParityFixture` commands now match in-process output (Synopsis-derived for `Get-FixtureFullHelp` / `Get-FixtureSynopsisOnly`, syntax fallback for the bare/help-message-only/validate-set fixtures). Parameter-description population for those fixtures matches in-process behavior — both paths emit equivalent inputSchema, achieving the FR-520 wiring parity goal at this layer. Baseline files were not modified.

Reviewers: Farnsworth + Cubert (squad).
