### PR TITLE
feat(metrics): OTel counters for description-source resolution (#231)

### DIFF
--- a/PoshMcp.Server/McpToolFactoryV2.cs
+++ b/PoshMcp.Server/McpToolFactoryV2.cs
@@ -55,6 +55,58 @@ public class McpToolFactoryV2
     }
 
     /// <summary>
+    /// Spec 010 FR-590 — emit a counter sample for a resolved tool description
+    /// source. Reuses <see cref="DescriptionSourceVocabulary.ToWireValue(ToolDescriptionSource)"/>
+    /// so the OTel tag stays byte-identical to the doctor report's FR-583 value.
+    /// Failure-isolated: per the metrics charter, instrumentation must never
+    /// crash the application, so any exception is swallowed.
+    /// </summary>
+    private static void RecordToolDescriptionSourceMetric(ToolDescriptionSource source)
+    {
+        var metrics = _metrics;
+        if (metrics is null)
+        {
+            return;
+        }
+
+        try
+        {
+            metrics.ToolDescriptionSourceCount.Add(
+                1,
+                new KeyValuePair<string, object?>("step", DescriptionSourceVocabulary.ToWireValue(source)));
+        }
+        catch
+        {
+            // Charter: metrics must never crash the application.
+        }
+    }
+
+    /// <summary>
+    /// Spec 010 FR-590 — emit a counter sample for a resolved parameter
+    /// description source. See <see cref="RecordToolDescriptionSourceMetric"/>
+    /// for the failure-isolation rationale.
+    /// </summary>
+    private static void RecordParameterDescriptionSourceMetric(ParameterDescriptionSource source)
+    {
+        var metrics = _metrics;
+        if (metrics is null)
+        {
+            return;
+        }
+
+        try
+        {
+            metrics.ParameterDescriptionSourceCount.Add(
+                1,
+                new KeyValuePair<string, object?>("step", DescriptionSourceVocabulary.ToWireValue(source)));
+        }
+        catch
+        {
+            // Charter: metrics must never crash the application.
+        }
+    }
+
+    /// <summary>
     /// Initializes a new instance of McpToolFactoryV2 with default runspace
     /// </summary>
     public McpToolFactoryV2()
@@ -214,6 +266,7 @@ public class McpToolFactoryV2
             var result = metadataSource.ResolveToolDescription(in request);
             metadata.Description = result.Description;
             descriptionSourceTracker?.RecordToolSource(commandInfo.Name, result.Source);
+            RecordToolDescriptionSourceMetric(result.Source);
             logger.LogDebug($"Resolved description for {commandInfo.Name} ({parameterSet.Name}) via {result.Source}: {metadata.Description}");
         }
         catch (Exception ex)
@@ -570,6 +623,7 @@ public class McpToolFactoryV2
 
                 var resolved = _toolMetadataSource.ResolveParameterDescription(in request);
                 _descriptionSourceTracker?.RecordParameterSource(command.Name, paramName, resolved.Source);
+                RecordParameterDescriptionSourceMetric(resolved.Source);
                 if (resolved.Source != ParameterDescriptionSource.TypeFallback
                     && !string.IsNullOrWhiteSpace(resolved.Description))
                 {
@@ -615,6 +669,7 @@ public class McpToolFactoryV2
                 ParameterSetSyntax: BuildRemoteParameterSetSyntax(schema));
             var result = metadataSource.ResolveToolDescription(in request);
             descriptionSourceTracker?.RecordToolSource(schema.Name, result.Source);
+            RecordToolDescriptionSourceMetric(result.Source);
             var metadata = new PowerShellCommandMetadata
             {
                 CommandName = schema.Name,
@@ -693,6 +748,7 @@ public class McpToolFactoryV2
 
                 var resolved = metadataSource.ResolveParameterDescription(in request);
                 descriptionSourceTracker?.RecordParameterSource(schema.Name, param.Name, resolved.Source);
+                RecordParameterDescriptionSourceMetric(resolved.Source);
                 if (resolved.Source != ParameterDescriptionSource.TypeFallback
                     && !string.IsNullOrWhiteSpace(resolved.Description))
                 {

--- a/PoshMcp.Server/Metrics/McpMetrics.cs
+++ b/PoshMcp.Server/Metrics/McpMetrics.cs
@@ -46,6 +46,12 @@ public class McpMetrics
     public Counter<long> AgentInvocationTotal { get; }
     public Histogram<double> AgentToolDiversity { get; }
 
+    // Spec 010 FR-590 — description-source resolution counters. Tag values are
+    // emitted via DescriptionSourceVocabulary.ToWireValue so the strings stay
+    // byte-identical to the doctor report's FR-583 vocabulary.
+    public Counter<long> ToolDescriptionSourceCount { get; }
+    public Counter<long> ParameterDescriptionSourceCount { get; }
+
     public McpMetrics()
     {
         _meter = new Meter(MeterName, MeterVersion);
@@ -128,6 +134,18 @@ public class McpMetrics
         AgentToolDiversity = _meter.CreateHistogram<double>(
             "mcp_agent_tool_diversity",
             description: "Number of unique tools used per agent over time");
+
+        // Spec 010 FR-590 — emitted on every tool/parameter description
+        // resolution (in-process and out-of-process paths). Tag `step` carries
+        // the FR-583 wire value (synopsis|description|syntax|name for tools;
+        // helpParameter|helpMessage|validateSet|typeFallback for parameters).
+        ToolDescriptionSourceCount = _meter.CreateCounter<long>(
+            "poshmcp.tool_description.source",
+            description: "Count of tool description resolutions, tagged by precedence step that supplied the description");
+
+        ParameterDescriptionSourceCount = _meter.CreateCounter<long>(
+            "poshmcp.parameter_description.source",
+            description: "Count of parameter description resolutions, tagged by precedence step that supplied the description");
     }
 
     public void Dispose()

--- a/PoshMcp.Tests/Unit/DescriptionSourceMetricsTests.cs
+++ b/PoshMcp.Tests/Unit/DescriptionSourceMetricsTests.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using System.Reflection;
+using PoshMcp.Server.Metrics;
+using PoshMcp.Server.PowerShell;
+using Xunit;
+
+namespace PoshMcp.Tests.Unit;
+
+/// <summary>
+/// Spec 010 FR-590 — verifies the OTel counters
+/// <c>poshmcp.tool_description.source</c> and
+/// <c>poshmcp.parameter_description.source</c> emit one sample per
+/// resolution with the FR-583 wire literal in the <c>step</c> tag.
+/// </summary>
+public class DescriptionSourceMetricsTests : IDisposable
+{
+    private readonly McpMetrics _metrics;
+    private readonly MeterListener _listener;
+    private readonly List<(Instrument Instrument, long Value, IReadOnlyDictionary<string, object?> Tags)> _samples =
+        new();
+
+    public DescriptionSourceMetricsTests()
+    {
+        _metrics = new McpMetrics();
+        SetFactoryMetrics(_metrics);
+
+        _listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == McpMetrics.MeterName &&
+                    (instrument.Name == "poshmcp.tool_description.source" ||
+                     instrument.Name == "poshmcp.parameter_description.source"))
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+        _listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+        {
+            var dict = new Dictionary<string, object?>(tags.Length);
+            foreach (var kvp in tags)
+            {
+                dict[kvp.Key] = kvp.Value;
+            }
+            lock (_samples)
+            {
+                _samples.Add((instrument, measurement, dict));
+            }
+        });
+        _listener.Start();
+    }
+
+    public void Dispose()
+    {
+        _listener.Dispose();
+        SetFactoryMetrics(null);
+        _metrics.Dispose();
+    }
+
+    [Theory]
+    [InlineData(ToolDescriptionSource.Synopsis, "synopsis")]
+    [InlineData(ToolDescriptionSource.Description, "description")]
+    [InlineData(ToolDescriptionSource.Syntax, "syntax")]
+    [InlineData(ToolDescriptionSource.Name, "name")]
+    public void ToolDescriptionSourceCounter_emits_FR583_wire_value_for_each_source(
+        ToolDescriptionSource source, string expectedTag)
+    {
+        InvokeRecordToolDescriptionSourceMetric(source);
+
+        var sample = SingleSampleFor("poshmcp.tool_description.source");
+        Assert.Equal(1L, sample.Value);
+        Assert.True(sample.Tags.TryGetValue("step", out var tag));
+        Assert.Equal(expectedTag, tag);
+    }
+
+    [Theory]
+    [InlineData(ParameterDescriptionSource.HelpParameter, "helpParameter")]
+    [InlineData(ParameterDescriptionSource.HelpMessage, "helpMessage")]
+    [InlineData(ParameterDescriptionSource.ValidateSet, "validateSet")]
+    [InlineData(ParameterDescriptionSource.TypeFallback, "typeFallback")]
+    public void ParameterDescriptionSourceCounter_emits_FR583_wire_value_for_each_source(
+        ParameterDescriptionSource source, string expectedTag)
+    {
+        InvokeRecordParameterDescriptionSourceMetric(source);
+
+        var sample = SingleSampleFor("poshmcp.parameter_description.source");
+        Assert.Equal(1L, sample.Value);
+        Assert.True(sample.Tags.TryGetValue("step", out var tag));
+        Assert.Equal(expectedTag, tag);
+    }
+
+    [Fact]
+    public void Counter_emission_is_noop_when_metrics_not_configured()
+    {
+        // Charter: metrics must never crash the application. With no McpMetrics
+        // wired, the helpers must silently skip emission.
+        SetFactoryMetrics(null);
+
+        var ex = Record.Exception(() =>
+        {
+            InvokeRecordToolDescriptionSourceMetric(ToolDescriptionSource.Synopsis);
+            InvokeRecordParameterDescriptionSourceMetric(ParameterDescriptionSource.HelpParameter);
+        });
+
+        Assert.Null(ex);
+        Assert.Empty(_samples);
+    }
+
+    [Fact]
+    public void Counter_emission_swallows_unknown_enum_values()
+    {
+        // Vocabulary throws ArgumentOutOfRangeException for unknown enum values.
+        // The metrics helper must absorb that — emission failures must never
+        // propagate to callers (charter).
+        var ex = Record.Exception(() =>
+        {
+            InvokeRecordToolDescriptionSourceMetric((ToolDescriptionSource)999);
+            InvokeRecordParameterDescriptionSourceMetric((ParameterDescriptionSource)999);
+        });
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Multiple_emissions_each_record_a_sample()
+    {
+        InvokeRecordToolDescriptionSourceMetric(ToolDescriptionSource.Synopsis);
+        InvokeRecordToolDescriptionSourceMetric(ToolDescriptionSource.Description);
+        InvokeRecordParameterDescriptionSourceMetric(ParameterDescriptionSource.HelpMessage);
+
+        Assert.Equal(2, _samples.Count(s => s.Instrument.Name == "poshmcp.tool_description.source"));
+        Assert.Equal(1, _samples.Count(s => s.Instrument.Name == "poshmcp.parameter_description.source"));
+    }
+
+    private (Instrument Instrument, long Value, IReadOnlyDictionary<string, object?> Tags) SingleSampleFor(string name)
+    {
+        lock (_samples)
+        {
+            var matches = _samples.Where(s => s.Instrument.Name == name).ToList();
+            Assert.Single(matches);
+            return matches[0];
+        }
+    }
+
+    // The metric-emission helpers are private static methods on McpToolFactoryV2.
+    // Reflect into them so the tests exercise the exact code path used by the
+    // four production call sites (in-proc tool / in-proc param / OOP tool /
+    // OOP param) without having to spin up a full discovery cycle.
+    private static readonly MethodInfo s_recordToolMethod =
+        typeof(McpToolFactoryV2).GetMethod(
+            "RecordToolDescriptionSourceMetric",
+            BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("RecordToolDescriptionSourceMetric not found");
+
+    private static readonly MethodInfo s_recordParameterMethod =
+        typeof(McpToolFactoryV2).GetMethod(
+            "RecordParameterDescriptionSourceMetric",
+            BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("RecordParameterDescriptionSourceMetric not found");
+
+    private static readonly FieldInfo s_metricsField =
+        typeof(McpToolFactoryV2).GetField(
+            "_metrics",
+            BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("_metrics field not found");
+
+    private static void InvokeRecordToolDescriptionSourceMetric(ToolDescriptionSource source)
+    {
+        s_recordToolMethod.Invoke(null, new object[] { source });
+    }
+
+    private static void InvokeRecordParameterDescriptionSourceMetric(ParameterDescriptionSource source)
+    {
+        s_recordParameterMethod.Invoke(null, new object[] { source });
+    }
+
+    private static void SetFactoryMetrics(McpMetrics? metrics)
+    {
+        s_metricsField.SetValue(null, metrics);
+    }
+}


### PR DESCRIPTION
## Summary

Implements **spec 010 FR-590** (issue #231) — emits two OpenTelemetry counters on every tool/parameter description resolution.

| Counter | Tag | Values |
|---|---|---|
| `poshmcp.tool_description.source` | `step` | `synopsis` \| `description` \| `syntax` \| `name` |
| `poshmcp.parameter_description.source` | `step` | `helpParameter` \| `helpMessage` \| `validateSet` \| `typeFallback` |

Tag values are the **FR-583** wire literals — same vocabulary the doctor report (`descriptionSource` field) emits, sourced from a single helper.

## Builds on #244 (Bender's handoff)

PR #244 introduced two artifacts that this PR consumes:

1. **`DescriptionSourceVocabulary.ToWireValue(...)`** — single source of truth for FR-583 string literals. This PR calls it directly when populating the `step` tag, so the wire vocabulary stays in one place. Doctor JSON and OTel tags are byte-identical by construction.
2. **`IToolDescriptionSourceTracker`** — already records the resolved source at all four `Resolve*` sites (in-proc tool, in-proc parameter, OOP tool, OOP parameter). This PR co-locates counter emission with each tracker call so we never re-walk the precedence chain.

## Wiring choice — Option B (direct emission), not Option A (decorator)

The spawn brief preferred a decorator over `IToolDescriptionSourceTracker`. After reading the existing code I went with **Option B: emit alongside each tracker call inside `McpToolFactoryV2`**, for one architectural reason:

> The tracker is **optional** (`IToolDescriptionSourceTracker?`) and is only wired by the doctor command path. In normal HTTP/stdio operation, the tracker is `null`. A decorator over the tracker would only fire when the tracker is wired — which means counters would silently miss every production resolution.

FR-590 requires counters fire on **every** resolution. So emission must be independent of tracker presence. The cleanest expression of that — given the existing `private static McpMetrics? _metrics` pattern already used by `McpToolFactoryV2` for `ToolRegistrationTotal` — is two private static helpers (`RecordToolDescriptionSourceMetric`, `RecordParameterDescriptionSourceMetric`) called immediately after each tracker call. Single insertion-point per site, no duplication, mirrors the surrounding code style.

## In-process + OOP coverage

Both counters fire on every one of the four `Resolve*` call sites:

| Path | Site | Tracker call | Counter call |
|---|---|---|---|
| In-proc tool | `SetParameterSetDescription` | `RecordToolSource` | `RecordToolDescriptionSourceMetric` |
| In-proc param | `BuildParameterDescriptionMap` | `RecordParameterSource` | `RecordParameterDescriptionSourceMetric` |
| OOP tool | `CreateRemoteCommandMetadataMapping` | `RecordToolSource` | `RecordToolDescriptionSourceMetric` |
| OOP param | `BuildRemoteParameterDescriptionMap` | `RecordParameterSource` | `RecordParameterDescriptionSourceMetric` |

## Failure isolation

Per the metrics charter (*"metrics must never crash the application"*), both helpers wrap `Counter<long>.Add(...)` in `try { ... } catch { /* swallow */ }`. The vocabulary's `ArgumentOutOfRangeException` for unknown enum values is also swallowed. A unit test (`Counter_emission_swallows_unknown_enum_values`) exercises the failure path.

## Tests

11 new tests in `DescriptionSourceMetricsTests` use `MeterListener` to capture emissions:

- 4 tests verify each `ToolDescriptionSource` enum value emits the right `step` tag (`synopsis`, `description`, `syntax`, `name`)
- 4 tests verify each `ParameterDescriptionSource` enum value emits the right `step` tag (`helpParameter`, `helpMessage`, `validateSet`, `typeFallback`)
- 1 test verifies emission is a no-op when `McpMetrics` is not configured (failure isolation)
- 1 test verifies unknown enum values do not throw (failure isolation)
- 1 test verifies multiple emissions each record a separate sample

```
Total tests: 11
     Passed: 11
```

Full unit suite: **531 / 532 green** (one unrelated flake — `OutOfProcessHostTests.Lifecycle_Start_Ping_Setup_Shutdown_Restart` — STATUS_ACCESS_VIOLATION in the OOP child subprocess; passed cleanly on rerun).

## Closes

- Closes #231
- Builds on #244
- Spec: `specs/010-tool-self-documentation/spec.md` — FR-590, FR-583
