### PR TITLE
docs(exposing-tools): document description precedence chains (#234)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ PoshMcp automatically:
 - **Zero Boilerplate**: Existing scripts work without modification
 - **State Preservation**: Variables and custom functions persist between calls
 - **Pattern-Based Filtering**: Include/exclude commands via configuration
-- **Rich Metadata**: Automatic extraction from `Get-Help` and `Get-Command`
+- **Rich Metadata**: Automatic extraction from `Get-Help` and `Get-Command` ([description precedence](docs/articles/exposing-tools.md#description-precedence))
 - **MCP Resources**: Expose files and live system state as readable resources
 - **MCP Prompts**: Define reusable prompt templates with dynamic arguments
 

--- a/docs/articles/exposing-tools.md
+++ b/docs/articles/exposing-tools.md
@@ -124,3 +124,187 @@ PoshMcp provides utility tools for working with command output:
 3. AI calls: filter-last-command-output -FilterExpression "$_.Status -eq 'Running'"
    Result: Only running services
 ```
+
+## Description Precedence
+
+PoshMcp populates two fields in every MCP `tools/list` response:
+
+- **Tool description** — `tools[].description`
+- **Parameter description** — `tools[].inputSchema.properties.<name>.description`
+
+Each field is resolved by a fixed precedence chain. PoshMcp tries each step in order and stops at the first that produces a non-empty value. The same chain runs in both the in-process and out-of-process execution paths and produces byte-identical output.
+
+### Tool description chain
+
+| Step | Source | Notes |
+| ---- | ------ | ----- |
+| 1 | `Get-Help <command>` `.Synopsis` | Used when present, non-empty, and not equal to the command name. |
+| 2 | `Get-Help <command>` `.Description` body | Paragraph entries are joined by a blank line (`\n\n`). |
+| 3 | `"{CommandName} {ParameterSetSyntax}"` | The syntax line from `CommandParameterSetInfo.ToString()` prefixed by the command name. |
+| 4 | The bare command name | Final fallback — guaranteed non-empty. |
+
+The chain is applied **per command**, not per parameter set. All parameter sets of a given command share the same tool description text.
+
+**Authoring example.** A function that supplies only `.SYNOPSIS` lands at step 1:
+
+```powershell
+function Get-FixtureSynopsisOnly {
+    <#
+    .SYNOPSIS
+    Returns a fixed sentinel string used by the help parity fixture.
+    #>
+    [CmdletBinding()]
+    param()
+    'synopsis-only'
+}
+```
+
+A function that supplies both `.SYNOPSIS` and `.DESCRIPTION` still lands at step 1 — the synopsis wins because it appears first in the chain. To surface the long-form description, omit the synopsis (or set it equal to the command name, which is filtered out by step 1).
+
+A function with no comment-based help and a single parameter set falls through to step 3:
+
+```
+Description: "Get-FixtureBare [[-Anything] <string>] [<CommonParameters>]"
+```
+
+A function with no comment-based help and no resolvable syntax falls through to step 4 (bare command name).
+
+### Parameter description chain
+
+| Step | Source | Notes |
+| ---- | ------ | ----- |
+| 1 | `Get-Help <command>` `.Parameters.parameter[].description` | Matched by parameter name; paragraph join identical to step 2 of the tool chain. |
+| 2 | `[Parameter(HelpMessage = "...")]` | Only the `HelpMessage` named argument; ignored when empty. |
+| 3 | `[ValidateSet(...)]` allowed values | Singleton: `"One of: A, B, C"`. Array element type: `"Each item is one of: A, B, C"`. Element ordering matches the declaration. |
+| 4 | `"Parameter of type <TypeName>"` | Final fallback. `<TypeName>` is the .NET type name (e.g. `System.String`). |
+
+The chain is applied **per parameter**. The same parameter appearing in multiple parameter sets receives the same description text.
+
+**Authoring example.** A `.PARAMETER` block lands at step 1:
+
+```powershell
+function Get-FixtureFullHelp {
+    <#
+    .PARAMETER Message
+    The text to echo back to the caller.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Message
+    )
+    $Message
+}
+```
+
+A `[Parameter(HelpMessage = ...)]` lands at step 2 when there is no `.PARAMETER` block:
+
+```powershell
+function Get-FixtureHelpMessageOnly {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, HelpMessage = 'The user identifier to look up.')]
+        [string]$UserId
+    )
+    [pscustomobject]@{ UserId = $UserId }
+}
+```
+
+A `[ValidateSet]` with no other help lands at step 3:
+
+```powershell
+function Get-FixtureValidateSetScalar {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Red', 'Green', 'Blue')]
+        [string]$Color
+    )
+    $Color
+}
+```
+
+The resulting parameter description is `"One of: Red, Green, Blue"`. If the parameter were typed `[string[]]` instead of `[string]`, the description would be `"Each item is one of: Red, Green, Blue"`.
+
+A bare parameter with no help, no `HelpMessage`, and no `ValidateSet` falls through to step 4: `"Parameter of type System.String"`.
+
+> **Known issue.** Parameter descriptions resolved through this chain are not yet surfaced into `inputSchema.properties.<name>.description` in every MCP response. The resolver returns the correct value and doctor reports the correct source, but plumbing into the published schema is tracked by [issue #242](https://github.com/usepowershell/poshmcp/issues/242). Module authors who want their parameter help to reach clients today should still add the help — it will appear automatically once #242 ships, with no module change required.
+
+### Sanitization and length caps
+
+All description text from any source is normalized before it leaves PoshMcp:
+
+1. Leading and trailing whitespace are trimmed from the overall string.
+2. Non-printable control characters (Unicode category `Cc`) are stripped, except for the paragraph separator `\n\n` produced by step 2 of the tool chain.
+3. Within each paragraph, runs of whitespace — spaces, tabs, single `\n`, `\r`, `\r\n` — collapse to a single space. The `\n\n` separators between paragraphs are preserved.
+4. Each paragraph is re-trimmed.
+
+Tool descriptions are then capped at **1024 characters** and parameter descriptions at **512 characters**. Truncation lands on a word boundary and appends a single ellipsis (`…`, U+2026).
+
+Sanitization is what makes the in-process path and the out-of-process subprocess produce identical text — `Get-Help` paragraph wrapping varies with `$Host.UI.RawUI.BufferSize`, which differs between an attached console host and a subprocess with redirected stdin/stdout. The collapse step absorbs that difference.
+
+## Inspecting the resolved source
+
+PoshMcp exposes the precedence step that produced each description so operators can verify what their MCP clients will see without connecting one.
+
+### Doctor output
+
+The `poshmcp doctor` command reports the resolved source per command and per parameter via a `descriptionSource` JSON field:
+
+| Scope | JSON path | Allowed values |
+| ----- | --------- | -------------- |
+| Tool | `tools[].descriptionSource` | `synopsis`, `description`, `syntax`, `name` |
+| Parameter | `tools[].parameters[].descriptionSource` | `helpParameter`, `helpMessage`, `validateSet`, `typeFallback` |
+
+Operators looking at impoverished tool metadata can use this field to identify which commands fall through to the syntax or bare-name fallback and add `.SYNOPSIS` blocks to fix it.
+
+### OpenTelemetry counters
+
+PoshMcp emits one OTel counter per chain, incremented once per command (or per parameter) per discovery cycle:
+
+- `poshmcp.tool_description.source` — tag `step` ∈ `{synopsis, description, syntax, name}`
+- `poshmcp.parameter_description.source` — tag `step` ∈ `{helpParameter, helpMessage, validateSet, typeFallback}`
+
+Tag values match the `descriptionSource` literals exactly. A dashboard that breaks either counter down by the `step` tag shows at a glance how many tools land on each rung of the chain.
+
+## Worked example
+
+A function with full comment-based help:
+
+```powershell
+function Get-WidgetReport {
+    <#
+    .SYNOPSIS
+    Generate a status report for one widget.
+
+    .DESCRIPTION
+    Reads the widget identified by -WidgetId and returns a structured
+    report containing health, last-seen timestamp, and pending alerts.
+
+    .PARAMETER WidgetId
+    The widget identifier. Sourced from the upstream inventory system.
+
+    .PARAMETER Format
+    Output format. Defaults to Json.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$WidgetId,
+
+        [ValidateSet('Json', 'Yaml', 'Text')]
+        [string]$Format = 'Json'
+    )
+    # ...
+}
+```
+
+Resolved fields in the MCP `tools/list` response (after sanitization, before length capping):
+
+- `tools[].description` → `"Generate a status report for one widget."` (tool chain step 1, source `synopsis`)
+- `tools[].inputSchema.properties.WidgetId.description` → `"The widget identifier. Sourced from the upstream inventory system."` (parameter chain step 1, source `helpParameter`)
+- `tools[].inputSchema.properties.Format.description` → `"Output format. Defaults to Json."` (parameter chain step 1, source `helpParameter`)
+
+Removing the `.PARAMETER Format` block would change the `Format` parameter to step 3 (`"One of: Json, Yaml, Text"`, source `validateSet`). Removing the `[ValidateSet]` as well would land at step 4 (`"Parameter of type System.String"`, source `typeFallback`).
+
+The `HelpParityFixture` module under `PoshMcp.Tests/Fixtures/Modules/HelpParityFixture/` exercises every rung of both chains and is a good reference for additional shapes.


### PR DESCRIPTION
Closes #234. Spec 010 sequencing step 11.

## Summary

Documents the FR-500 (tool description) and FR-510 (parameter description) precedence chains in `docs/articles/exposing-tools.md` so module authors can predict which Get-Help element produces which MCP field.

## Sections added

- **Description Precedence** — both chains as tables, with PowerShell authoring examples drawn from `HelpParityFixture`.
- **Sanitization and length caps** — FR-540 normalization, FR-541 (1024) and FR-542 (512) caps, and the in-proc/OOP parity rationale.
- **Inspecting the resolved source** — `descriptionSource` field in doctor output (FR-582 / FR-583) and the `poshmcp.tool_description.source` / `poshmcp.parameter_description.source` OpenTelemetry counters (FR-590).
- **Worked example** — full comment-based help walkthrough showing what each field becomes.

Cross-link added from README "Rich Metadata" bullet to the new section.

## FRs covered

- FR-500 — tool description precedence (synopsis -> description -> syntax -> name)
- FR-510 — parameter description precedence (helpParameter -> helpMessage -> validateSet -> typeFallback)
- FR-540 — sanitization rules
- FR-541 / FR-542 — length caps
- FR-582 / FR-583 — doctor `descriptionSource`
- FR-590 — OTel counters

## Issue #242 footnote

A "Known issue" callout was added under the parameter-description section pointing to #242. Today the resolver returns the correct parameter description and doctor reports the correct source, but plumbing into `inputSchema.properties.<name>.description` is incomplete in the MCP response. The footnote is honest about this so authors aren't surprised when their `.PARAMETER` blocks don't appear in clients yet, and it makes clear that no module change will be required once #242 ships.

## Verification

- Edits limited to `README.md` (one cross-link) and `docs/articles/exposing-tools.md` (new sections appended after existing content; no existing prose modified).
- Plain technical voice; no Squad personas in the doc or commit.
- Branch off `main` at `eecf81a` (spec 010 waves 1-9 complete).

Draft PR — opening for review.
