### PR TITLE
fix(metadata): wire parameter descriptions through to MCP inputSchema (#242)

### DIFF
--- a/.squad/agents/bender/history.md
+++ b/.squad/agents/bender/history.md
@@ -705,3 +705,23 @@ should update to their own path (removed the repo-internal `examples/appsettings
 **#242 observation (FR-510 parameter descriptions not reaching MCP `inputSchema`):** Looked but did not deeply audit. The PR will note this is a separate concern. Hypothesis: `BuildParameterDescriptionMap` does record into the description map, but the description map may not be flowing into the JSON Schema property definition emitted to MCP. Worth its own investigation — different code path from doctor output (which now reads the tracker, not the schema).
 
 **Test coverage (12 unit tests):** all 4 tool sources + all 4 parameter sources via real `HelpAwareToolMetadataSource` resolution + tracker first-wins semantics + JSON round-trip + vocabulary mapping (both enums) + `BuildToolDescriptionEntries` empty/populated paths. 521 unit tests now passing.
+
+## Learnings — 2026-05-13 (Issue #242)
+
+**PowerShell SDK: PSObject wrapper vs BaseObject for Get-Help.parameters**
+
+Get-Help returns .parameters as a PSObject whose BaseObject is a marker PSCustomObject with no public members. The synthesized .parameter[] collection only exists on the **wrapper**, NOT on BaseObject. Calling .BaseObject first dereferences to the marker and silently drops the array.
+
+Rule: when working with PowerShell adapted/synthesized members (especially Get-Help output, format data, custom property sets), access `Properties["name"]` on the PSObject wrapper directly. Only fall back to BaseObject when the wrapper does not expose the member you need. Never reflexively unwrap.
+
+This bug shipped silently because the resolver returned the right strings for parameters it could find, but the array itself was empty — so callers got "no parameters in help" rather than an exception.
+
+## Learnings — 2026-05-13 (Issue #242)
+
+**PowerShell SDK: PSObject wrapper vs BaseObject for Get-Help.parameters**
+
+Get-Help returns .parameters as a PSObject whose BaseObject is a marker PSCustomObject with no public members. The synthesized .parameter[] collection only exists on the **wrapper**, NOT on BaseObject. Calling .BaseObject first dereferences to the marker and silently drops the array.
+
+Rule: when working with PowerShell adapted/synthesized members (especially Get-Help output, format data, custom property sets), access `Properties["name"]` on the PSObject wrapper directly. Only fall back to BaseObject when the wrapper does not expose the member you need. Never reflexively unwrap.
+
+This bug shipped silently because the resolver returned the right strings for parameters it could find, but the array itself was empty — so callers got "no parameters in help" rather than an exception.

--- a/PoshMcp.Server/McpToolFactoryV2.cs
+++ b/PoshMcp.Server/McpToolFactoryV2.cs
@@ -139,7 +139,7 @@ public class McpToolFactoryV2
     public McpToolFactoryV2(IToolMetadataSource? metadataSource, IToolDescriptionSourceTracker? descriptionSourceTracker)
     {
         _assemblyGenerator = new PowerShellAssemblyGenerator(new SingletonPowerShellRunspace());
-        _toolMetadataSource = metadataSource ?? new DefaultToolMetadataSource();
+        _toolMetadataSource = metadataSource ?? new HelpAwareToolMetadataSource();
         _descriptionSourceTracker = descriptionSourceTracker;
     }
 
@@ -172,7 +172,7 @@ public class McpToolFactoryV2
     public McpToolFactoryV2(IPowerShellRunspace runspace, IToolMetadataSource? metadataSource, IToolDescriptionSourceTracker? descriptionSourceTracker)
     {
         _assemblyGenerator = new PowerShellAssemblyGenerator(runspace);
-        _toolMetadataSource = metadataSource ?? new DefaultToolMetadataSource();
+        _toolMetadataSource = metadataSource ?? new HelpAwareToolMetadataSource();
         _descriptionSourceTracker = descriptionSourceTracker;
     }
 
@@ -202,7 +202,7 @@ public class McpToolFactoryV2
     {
         _commandExecutor = commandExecutor ?? throw new ArgumentNullException(nameof(commandExecutor));
         _outOfProcessAssemblyGenerator = new OutOfProcessToolAssemblyGenerator(commandExecutor);
-        _toolMetadataSource = metadataSource ?? new DefaultToolMetadataSource();
+        _toolMetadataSource = metadataSource ?? new HelpAwareToolMetadataSource();
         _descriptionSourceTracker = descriptionSourceTracker;
     }
 

--- a/PoshMcp.Server/PowerShell/PowerShellHelpResolver.cs
+++ b/PoshMcp.Server/PowerShell/PowerShellHelpResolver.cs
@@ -151,10 +151,20 @@ public sealed class PowerShellHelpResolver
 
     private static IEnumerable<object?>? ResolveParameterArray(object value)
     {
-        var unwrapped = value is PSObject pso ? pso.BaseObject ?? pso : value;
-        var holder = unwrapped as PSObject ?? new PSObject(unwrapped);
-
+        // Get-Help returns .parameters as a PSObject wrapping a PSCustomObject. The
+        // synthesized .parameter[] member lives on the PSObject wrapper — calling
+        // .BaseObject would dereference to the PSCustomObject marker type, which has
+        // no public members, dropping the parameter array on the floor (issue #242).
+        // Access Properties directly on the wrapper, only falling back to BaseObject
+        // unwrapping if the wrapper does not expose .parameter.
+        var holder = value as PSObject ?? new PSObject(value);
         var parameterMember = holder.Properties["parameter"]?.Value;
+        if (parameterMember == null && value is PSObject pso && pso.BaseObject is { } baseObj && !ReferenceEquals(baseObj, pso))
+        {
+            var baseHolder = baseObj as PSObject ?? new PSObject(baseObj);
+            parameterMember = baseHolder.Properties["parameter"]?.Value;
+        }
+
         if (parameterMember == null)
         {
             // Some shapes pass the parameter array directly.

--- a/PoshMcp.Tests/Integration/ToolDescriptionParityTests.cs
+++ b/PoshMcp.Tests/Integration/ToolDescriptionParityTests.cs
@@ -210,7 +210,7 @@ public sealed class ToolDescriptionParityTests : PowerShellTestBase, IAsyncLifet
     /// <item>Get-FixtureValidateSetArray.Directions → FR-510 step 3 (array).</item>
     /// </list>
     /// </remarks>
-    [Theory(Skip = "Tracking issue #242 — FR-510 wiring gap: inputSchema parameter descriptions are empty in both modes. Resolver returns the right strings but they don't reach inputSchema.properties.<name>.description. Un-skip when #242 is fixed.")]
+    [Theory]
     [InlineData("Get-FixtureFullHelp", "Message")]
     [InlineData("Get-FixtureFullHelp", "Count")]
     [InlineData("Get-FixtureHelpMessageOnly", "UserId")]
@@ -255,7 +255,7 @@ public sealed class ToolDescriptionParityTests : PowerShellTestBase, IAsyncLifet
     /// OutOfProcess path so the gap is surfaced in BOTH runtimes when present.
     /// Skipped when pwsh is not on PATH.
     /// </summary>
-    [Theory(Skip = "Tracking issue #242 — FR-510 wiring gap: inputSchema parameter descriptions are empty in both modes. Resolver returns the right strings but they don't reach inputSchema.properties.<name>.description. Un-skip when #242 is fixed.")]
+    [PwshAvailableTheory]
     [InlineData("Get-FixtureFullHelp", "Message")]
     [InlineData("Get-FixtureFullHelp", "Count")]
     [InlineData("Get-FixtureHelpMessageOnly", "UserId")]


### PR DESCRIPTION
## Summary

Fixes #242 — FR-510 wiring gap where MCP `inputSchema.properties.<name>.description` was empty in both in-process and out-of-process modes.

## Root Cause

`PowerShellHelpResolver.ResolveParameterArray` was calling `.BaseObject` on the `Get-Help` `.parameters` PSObject. The PSObject is a wrapper around a `PSCustomObject` marker type with **no public members** — the synthesized `.parameter[]` collection lives on the **wrapper**, not on `BaseObject`. Unwrapping first dereferenced to the empty marker and silently returned no parameters, so every MCP tool's `inputSchema` shipped with empty parameter descriptions.

The resolver had been returning the right strings for help text it could see; the array enumeration step was just dropping the input on the floor before any string lookups happened.

## Fix

```csharp
// Before:
var unwrapped = value is PSObject pso ? pso.BaseObject ?? pso : value;
var holder = unwrapped as PSObject ?? new PSObject(unwrapped);

// After: read on the wrapper first, fall back to BaseObject only if absent.
var holder = value as PSObject ?? new PSObject(value);
var parameterMember = holder.Properties["parameter"]?.Value;
if (parameterMember == null && value is PSObject pso && pso.BaseObject is { } baseObj && !ReferenceEquals(baseObj, pso))
{
    var baseHolder = baseObj as PSObject ?? new PSObject(baseObj);
    parameterMember = baseHolder.Properties["parameter"]?.Value;
}
```

## Secondary Change — `McpToolFactoryV2` Default Source

Three `McpToolFactoryV2` constructors null-coalesced `IToolMetadataSource` to `DefaultToolMetadataSource` (a no-op that returns nothing). In production, `HttpServerHost`/`StdioServerHost` register `HelpAwareToolMetadataSource` via DI, so this default never fired in real runtime. But CLI bootstrappers and any test path that constructs `McpToolFactoryV2` without supplying a metadata source were silently running with help-blind metadata.

Switched all three defaults to `HelpAwareToolMetadataSource` so the contract matches production wiring. **No DI registration changed** — this only affects callers that pass `null` and want sensible defaults, which is what they almost certainly intended.

## Verification

- **`ParameterDescription_IsNonEmpty_*` regression gate (the 10 tests Fry left skipped on #242):** **10/10 passing** — 5 in-process + 5 out-of-process.
- **Broader description surface** (`ToolDescription`, `ParameterSet`, `DoctorDescription`, `DescriptionSource`): **70/70 passing.**
- **Full unit suite:** **532/532 passing**, 0 skipped.

## Files

- `PoshMcp.Server/PowerShell/PowerShellHelpResolver.cs` — root-cause fix
- `PoshMcp.Server/McpToolFactoryV2.cs` — default-source swap (3 ctors)
- `PoshMcp.Tests/Integration/ToolDescriptionParityTests.cs` — un-skipped 10 `[Theory(Skip="…#242…")]` rows; one became `[PwshAvailableTheory]` for the OOP variant

Closes #242.
