### PR TITLE
release: 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to this project will be documented here.
 
+## [0.13.0] - 2026-05-13
+
+Spec 010 — Tool self-documentation. PoshMcp now resolves a documented description for every command and parameter exposed over MCP, following a defined precedence chain (PowerShell `[Description]` attribute → comment-based help → `Get-Help` synopsis → fallback), and reports the resolved source through doctor and OpenTelemetry. Two adjacent correctness fixes ship in the same release: parameter descriptions now actually reach `inputSchema` on the wire, and `SwitchParameter` arguments round-trip correctly through MCP JSON.
+
+### Added
+- **Tool description precedence chain (FR-500/FR-510)** — In-process and out-of-process metadata sources now resolve command and parameter descriptions through a documented precedence chain, with FR-540 sanitization applied uniformly. (#225 #226 #227 #228 #238 #239 #240 #241)
+- **Doctor: per-command and per-parameter `descriptionSource`** — `poshmcp doctor` and the `get-configuration-troubleshooting` MCP tool now report which source each tool description was resolved from (Description attribute / comment-based help / Get-Help synopsis / fallback), per command and per parameter. (#230 #244)
+- **OpenTelemetry counters for description-source resolution** — Emits counters tagged by command and source so operators can see at a glance which surfaces are documented and which are falling through to the default. (#231 #245)
+- **Documentation: FR-500/FR-510 precedence chain** — `docs/articles/exposing-tools` now documents the description precedence chain end-to-end, including how to author `[Description]` attributes, comment-based help, and `Get-Help` synopses for tools exposed via PoshMcp. (#234 #247)
+
+### Fixed
+- **Parameter descriptions now reach MCP `inputSchema` (#242)** — `PowerShellSchemaGenerator` was bypassing the metadata source for parameter-level descriptions, so even when descriptions were resolved correctly server-side they did not appear in the schema delivered to clients. The cold-path generator now wires `HelpAwareToolMetadataSource` as its default `IToolMetadataSource`, so `tools/list` returns parameter descriptions consistent with what doctor reports. (#248 #250)
+- **`SwitchParameter` round-trips through MCP JSON (#222)** — Boolean MCP arguments targeting PowerShell `SwitchParameter` parameters now bind correctly to a switch (present/absent), instead of failing parameter binding or being dropped silently.
+
+### Changed
+- **Tool descriptions on the wire** — Tool and parameter descriptions exposed to MCP clients (`tools/list`) now reflect the FR-500/FR-510 precedence chain. Clients that rely on the previous (often empty or fallback) descriptions will see richer, sanitized text. This is intended and is the headline behavior change of the release.
+
+### Tests
+- **Description parity, regression, and parameter-set consistency tests (#229 #243)** — New cross-cutting tests assert that in-process and out-of-process metadata sources agree on resolved descriptions, that previously-snapshotted `tools/list` output stays stable for unchanged surfaces, and that parameter-set variants resolve consistently.
+- **`ParameterDescription_IsNonEmpty` regression gate** — Cubert's acceptance suite for the `inputSchema` wiring fix passes 10/10.
+- **Pre/post-spec010 `tools/list` snapshots (#224 #236)** — Snapshot baseline captured before spec 010 work and re-validated after, locking down the user-visible shape of the description rollout.
+- All 532/532 unit tests green.
+
+### Performance
+- **Cold-start regression well under the FR-572 50% gate.** Pre-spec010 baseline captured under `bench-runs/run-5-pre-spec010/` (#223 #237); post-spec010 measurement under `bench-runs/run-6-post-spec010/` (#232 #246). Run-6 vs run-5 cold-start delta: +10–12%, comfortably below the configured regression gate.
+
+### Behavior notes
+- MCP clients will see different (richer, sanitized) tool and parameter descriptions in `tools/list` results compared to v0.12.x. This is the intended outcome of spec 010 and the #242 wire-path fix. If a downstream client pinned strings from prior descriptions, expect to update those expectations.
+- `descriptionSource` and the new OTel counters are additive — no existing field changed shape.
+
+### Merged PRs since v0.12.3
+- Spec 010 wave 1: #235 #236 #237 #238 #239 #240 #241
+- Spec 010 wave 2: #243 #244 #245 #246 #247
+- Adjacent fixes: #222 (SwitchParameter), #248 (FR-510 wiring for #242), #250 (cold-path schema generator wiring for #249)
+
 ## [0.12.3] - 2026-05-12
 
 ### Fixed

--- a/PoshMcp.Server/PoshMcp.csproj
+++ b/PoshMcp.Server/PoshMcp.csproj
@@ -9,7 +9,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>poshmcp</ToolCommandName>
     <PackageId>poshmcp</PackageId>
-    <Version>0.12.3</Version>
+    <Version>0.13.0</Version>
     <Authors>Steven Murawski</Authors>
     <Description>A Model Context Protocol (MCP) server that exposes PowerShell commands and modules as AI-consumable tools.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/docs/release-notes/0.13.0.md
+++ b/docs/release-notes/0.13.0.md
@@ -1,0 +1,89 @@
+# Release v0.13.0
+
+**Release Date:** May 13, 2026
+
+## Summary
+
+Minor release. Spec 010 — **tool self-documentation** — lands end-to-end. PoshMcp now resolves a documented description for every command and parameter it exposes over MCP, following a defined precedence chain (PowerShell `[Description]` attribute → comment-based help → `Get-Help` synopsis → fallback), and reports the resolved source through `poshmcp doctor` and OpenTelemetry. Two adjacent correctness fixes ship in the same release: parameter descriptions now actually reach the `inputSchema` MCP clients receive, and `SwitchParameter` arguments round-trip correctly through MCP JSON.
+
+This is a meaningful change to what MCP clients see on the wire. It is intentionally a minor bump.
+
+## Highlights
+
+### Tool description precedence chain (FR-500 / FR-510)
+
+Both the in-process and out-of-process metadata paths now resolve descriptions via `IToolMetadataSource` with a documented precedence:
+
+1. PowerShell `[Description]` attribute on the command or parameter
+2. Comment-based help (`.SYNOPSIS`, `.PARAMETER`)
+3. `Get-Help` synopsis
+4. Fallback (typed name)
+
+FR-540 sanitization is applied uniformly across sources. The OOP path (`RemoteToolSchema`) was extended to carry full description and per-parameter metadata so OOP-hosted tools surface the same documentation as in-process tools.
+
+PRs: #225 #226 #227 #228 #238 #239 #240 #241
+
+### Doctor reports `descriptionSource` per command and per parameter
+
+`poshmcp doctor` and the `get-configuration-troubleshooting` MCP tool now report which source each description was resolved from, per command and per parameter. This lets operators see at a glance which tool surfaces are well-documented at the source and which are falling through to the fallback.
+
+PRs: #230 #244
+
+### OpenTelemetry counters for description-source resolution
+
+New counters tagged by command and source, suitable for dashboarding the documentation coverage of an MCP surface.
+
+PRs: #231 #245
+
+### Documentation
+
+`docs/articles/exposing-tools` now documents the FR-500/FR-510 chain end-to-end, including how to author `[Description]` attributes, comment-based help, and `Get-Help` synopses so they flow through to MCP clients.
+
+PRs: #234 #247
+
+## Fixes (correctness, ship in this release)
+
+### Parameter descriptions now reach MCP `inputSchema` (#242 → #248, #250)
+
+`PowerShellSchemaGenerator` was bypassing the metadata source for parameter-level descriptions. Even when descriptions resolved correctly server-side, they did not appear in the schema delivered to clients in `tools/list`. The cold-path generator now wires `HelpAwareToolMetadataSource` as its default `IToolMetadataSource`, so what doctor reports and what clients see are consistent.
+
+If you've been relying on `tools/list` to drive client-side help text and noticed that parameter descriptions were empty in v0.12.x, this is the fix.
+
+### `SwitchParameter` round-trips through MCP JSON (#222)
+
+Boolean MCP arguments targeting PowerShell `SwitchParameter` parameters now bind correctly to a switch. Previously, JSON `true` could be silently dropped or fail parameter binding depending on the path.
+
+## Behavior notes
+
+- **Tool descriptions over the wire have changed.** This is the intended outcome of spec 010 and the #242 fix. MCP clients will see richer, sanitized descriptions on commands and parameters in `tools/list` compared to v0.12.x. If a downstream client pinned strings from prior descriptions, update those expectations.
+- `descriptionSource` and the new OTel counters are additive — no existing field changed shape.
+
+## Tests
+
+- **Cross-source parity, regression, and parameter-set consistency tests** — assert in-process and OOP paths agree on resolved descriptions; assert previously-snapshotted `tools/list` output stays stable for unchanged surfaces. (#229, #243)
+- **`ParameterDescription_IsNonEmpty` acceptance suite** — passes 10/10. This is the regression gate for the #242 wire-path fix.
+- **Pre/post-spec010 `tools/list` snapshots** — baseline captured before the work, re-validated after, so the user-visible shape of the description rollout is locked down. (#224 → #236)
+- **All 532/532 unit tests pass.**
+
+## Performance
+
+Cold-start regression is well under the FR-572 50% gate.
+
+- Pre-spec010 baseline: `bench-runs/run-5-pre-spec010/` (#223 → #237)
+- Post-spec010 measurement: `bench-runs/run-6-post-spec010/` (#232 → #246)
+- Run-6 vs run-5 cold-start delta: +10–12%, comfortably below the configured regression gate.
+
+## Upgrade path
+
+Drop-in minor release. No configuration changes required.
+
+- **Binary / direct install:** Replace the build, restart the server.
+- **Container users:** Rebuild your derived image from `poshmcp:latest` (or pull the updated tag). No changes to `appsettings.json`, `Dockerfile`, or startup script are required.
+
+Review any client expectations on `tools/list` description strings — they are now richer.
+
+## Merged PRs since v0.12.3
+
+- Spec 010 wave 1: #235, #236, #237, #238, #239, #240, #241
+- Spec 010 wave 2: #243, #244, #245, #246, #247
+- Adjacent fixes: #222 (SwitchParameter), #248 (FR-510 wiring for #242), #250 (cold-path schema generator wiring for #249)

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -57,6 +57,8 @@
 
 - name: Release Notes
   items:
+  - name: v0.13.0
+    href: release-notes/0.13.0.md
   - name: v0.12.3
     href: release-notes/0.12.3.md
   - name: v0.12.2


### PR DESCRIPTION
## Release v0.13.0

Minor bump: **0.12.3 → 0.13.0**.

This release lands spec 010 (tool self-documentation) end-to-end plus two adjacent correctness fixes that change what MCP clients see on the wire. Worth a minor bump.

---

### Headline

- **Tool description precedence chain (FR-500/FR-510)** — In-process and OOP metadata sources both resolve descriptions through `IToolMetadataSource` with a documented chain (`[Description]` attribute → comment-based help → `Get-Help` synopsis → fallback), with FR-540 sanitization applied uniformly.
- **Doctor reports `descriptionSource`** per command and per parameter so operators can see which surfaces are well-documented.
- **OpenTelemetry counters** for description-source resolution, tagged by command and source.
- **Parameter descriptions now reach `inputSchema` on the wire (#242)** — `PowerShellSchemaGenerator` was bypassing the metadata source. Cold-path generator now wires `HelpAwareToolMetadataSource` as default, so `tools/list` matches what doctor reports.
- **`SwitchParameter` round-trips through MCP JSON (#222)** — boolean MCP arguments now bind correctly to switches.

---

### Behavior change worth flagging

MCP clients will see different (richer, sanitized) tool and parameter descriptions in `tools/list` results compared to v0.12.x. This is the intended outcome of spec 010 and the #242 wire-path fix. If a downstream client pinned strings from prior descriptions, those expectations need to be updated.

`descriptionSource` and the new OTel counters are additive — no existing field changed shape.

---

### 13 PRs merged since v0.12.3

**Spec 010 wave 1**
- #235 docs: fix misleading RemoteToolSchema XML doc
- #236 test: capture pre-spec010 tools/list snapshots (#224)
- #237 bench: capture pre-spec010 cold-start baseline (#223)
- #238 feat(metadata): extract IToolMetadataSource seam (#225)
- #239 feat(oop): extend RemoteToolSchema with full description + per-parameter metadata (#227)
- #240 feat(metadata): in-process Help-aware precedence + FR-540 sanitization (#226)
- #241 feat(oop): wire OOP through IToolMetadataSource seam (#228)

**Spec 010 wave 2**
- #243 test(parity): add tool description parity, regression, and parameter-set consistency tests (#229)
- #244 feat(doctor): report resolved descriptionSource per command and parameter (#230)
- #245 feat(metrics): emit OTel counters for description-source resolution (#231)
- #246 bench: capture post-spec010 cold-start, gate on <50% regression vs run-5 (#232)
- #247 docs(exposing-tools): document FR-500/FR-510 description precedence chains (#234)

**Adjacent fixes**
- #222 fix: SwitchParameter round-trips through MCP JSON arguments
- #248 fix(metadata): wire parameter descriptions through to MCP inputSchema (#242)
- #250 fix(schema): wire HelpAwareToolMetadataSource as default in PowerShellSchemaGenerator (#249)

(That's 15 commits in `git log v0.12.3..HEAD`; spec-task numbering reflects the 13 PR work items called out in the release plan.)

---

### Validation

- Build: `dotnet build -c Release` → green (warnings only, no errors).
- Tests: `dotnet test --filter "FullyQualifiedName~PoshMcp.Tests.Unit" -c Release` → **532 passed, 0 failed, 0 skipped**.
- Cubert's `ParameterDescription_IsNonEmpty` regression suite: 10/10.
- Cold-start: `bench-runs/run-6-post-spec010` vs `bench-runs/run-5-pre-spec010` → +10–12%, well under the FR-572 50% gate.

---

### Files changed

- `PoshMcp.Server/PoshMcp.csproj` — `<Version>0.12.3</Version>` → `0.13.0`
- `CHANGELOG.md` — new `## [0.13.0] - 2026-05-13` section prepended
- `docs/release-notes/0.13.0.md` — new release notes file
- `docs/toc.yml` — v0.13.0 entry added above v0.12.3

---

### Changelog (verbatim)

```markdown
## [0.13.0] - 2026-05-13

Spec 010 — Tool self-documentation. PoshMcp now resolves a documented description for every command and parameter exposed over MCP, following a defined precedence chain (PowerShell `[Description]` attribute → comment-based help → `Get-Help` synopsis → fallback), and reports the resolved source through doctor and OpenTelemetry. Two adjacent correctness fixes ship in the same release: parameter descriptions now actually reach `inputSchema` on the wire, and `SwitchParameter` arguments round-trip correctly through MCP JSON.

### Added
- **Tool description precedence chain (FR-500/FR-510)** — In-process and out-of-process metadata sources now resolve command and parameter descriptions through a documented precedence chain, with FR-540 sanitization applied uniformly. (#225 #226 #227 #228 #238 #239 #240 #241)
- **Doctor: per-command and per-parameter `descriptionSource`** — `poshmcp doctor` and the `get-configuration-troubleshooting` MCP tool now report which source each tool description was resolved from (Description attribute / comment-based help / Get-Help synopsis / fallback), per command and per parameter. (#230 #244)
- **OpenTelemetry counters for description-source resolution** — Emits counters tagged by command and source so operators can see at a glance which surfaces are documented and which are falling through to the default. (#231 #245)
- **Documentation: FR-500/FR-510 precedence chain** — `docs/articles/exposing-tools` now documents the description precedence chain end-to-end, including how to author `[Description]` attributes, comment-based help, and `Get-Help` synopses for tools exposed via PoshMcp. (#234 #247)

### Fixed
- **Parameter descriptions now reach MCP `inputSchema` (#242)** — `PowerShellSchemaGenerator` was bypassing the metadata source for parameter-level descriptions, so even when descriptions were resolved correctly server-side they did not appear in the schema delivered to clients. The cold-path generator now wires `HelpAwareToolMetadataSource` as its default `IToolMetadataSource`, so `tools/list` returns parameter descriptions consistent with what doctor reports. (#248 #250)
- **`SwitchParameter` round-trips through MCP JSON (#222)** — Boolean MCP arguments targeting PowerShell `SwitchParameter` parameters now bind correctly to a switch (present/absent), instead of failing parameter binding or being dropped silently.

### Changed
- **Tool descriptions on the wire** — Tool and parameter descriptions exposed to MCP clients (`tools/list`) now reflect the FR-500/FR-510 precedence chain. Clients that rely on the previous (often empty or fallback) descriptions will see richer, sanitized text. This is intended and is the headline behavior change of the release.

### Tests
- **Description parity, regression, and parameter-set consistency tests (#229 #243)** — New cross-cutting tests assert that in-process and out-of-process metadata sources agree on resolved descriptions, that previously-snapshotted `tools/list` output stays stable for unchanged surfaces, and that parameter-set variants resolve consistently.
- **`ParameterDescription_IsNonEmpty` regression gate** — Cubert's acceptance suite for the `inputSchema` wiring fix passes 10/10.
- **Pre/post-spec010 `tools/list` snapshots (#224 #236)** — Snapshot baseline captured before spec 010 work and re-validated after, locking down the user-visible shape of the description rollout.
- All 532/532 unit tests green.

### Performance
- **Cold-start regression well under the FR-572 50% gate.** Pre-spec010 baseline captured under `bench-runs/run-5-pre-spec010/` (#223 #237); post-spec010 measurement under `bench-runs/run-6-post-spec010/` (#232 #246). Run-6 vs run-5 cold-start delta: +10–12%, comfortably below the configured regression gate.

### Behavior notes
- MCP clients will see different (richer, sanitized) tool and parameter descriptions in `tools/list` results compared to v0.12.x. This is the intended outcome of spec 010 and the #242 wire-path fix. If a downstream client pinned strings from prior descriptions, expect to update those expectations.
- `descriptionSource` and the new OTel counters are additive — no existing field changed shape.

### Merged PRs since v0.12.3
- Spec 010 wave 1: #235 #236 #237 #238 #239 #240 #241
- Spec 010 wave 2: #243 #244 #245 #246 #247
- Adjacent fixes: #222 (SwitchParameter), #248 (FR-510 wiring for #242), #250 (cold-path schema generator wiring for #249)
```

---

### ⚠️ Holding line per release process

This PR is intentionally left for Steven's review. **No tag pushed, no GitHub release published, no container images pushed.** Steven gives the green light; Amy finishes the merge + tag + publish.
