### PR TITLE
ci(009): run tests as category-scoped phases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    # Job-level env. HAS_AZURE_CREDS is evaluated once at job start by checking
+    # whether AZURE_CLIENT_ID secret is non-empty. GitHub Actions does not allow
+    # `secrets.X != ''` directly inside step-level `if:` expressions outside of
+    # environment contexts, so we project it into env here and gate steps on env.
+    env:
+      HAS_AZURE_CREDS: ${{ secrets.AZURE_CLIENT_ID != '' }}
+
     steps:
     - uses: actions/checkout@v4
 
@@ -45,11 +52,52 @@ jobs:
     - name: Build
       run: dotnet build --configuration Release --no-restore
 
+    # ---------------------------------------------------------------------------
+    # Phased test execution per spec 009 (issue #215).
+    #
+    # Each phase runs as its own step so a failure is attributable to exactly
+    # one category in the CI UI, with its own duration and pass/fail summary.
+    # `continue-on-error` is left at the default (false) so a phase failure
+    # halts subsequent phases — matches today's serial-suite behavior.
+    #
+    # Filter strategy: `--filter "Category=X"` matches xUnit
+    # `[Trait("Category", "X")]`. While issue #212 (trait rollout) is in flight,
+    # tests without a Category trait fall into the default bucket and are
+    # excluded from category-scoped phases — those phases will run honestly
+    # against whatever is currently labeled. As traits land, each phase
+    # automatically picks up its newly-tagged tests.
+    # ---------------------------------------------------------------------------
+
     - name: Test (Unit)
-      run: dotnet test --no-build --configuration Release --filter "FullyQualifiedName~Unit" --logger "trx;LogFileName=unit-tests.trx" --results-directory ./TestResults
+      run: dotnet test --no-build --configuration Release --filter "Category=Unit" --logger "trx;LogFileName=phase-unit.trx" --results-directory ./TestResults
+
+    - name: Test (Integration)
+      run: dotnet test --no-build --configuration Release --filter "Category=Integration" --logger "trx;LogFileName=phase-integration.trx" --results-directory ./TestResults
+
+    - name: Test (OutOfProcess)
+      run: dotnet test --no-build --configuration Release --filter "Category=OutOfProcess" --logger "trx;LogFileName=phase-outofprocess.trx" --results-directory ./TestResults
+
+    - name: Test (Http)
+      run: dotnet test --no-build --configuration Release --filter "Category=Http" --logger "trx;LogFileName=phase-http.trx" --results-directory ./TestResults
 
     - name: Test (Functional)
-      run: dotnet test --blame --no-build --configuration Release --filter "FullyQualifiedName~Functional" --logger "trx;LogFileName=functional-tests.trx" --results-directory ./TestResults
+      run: dotnet test --blame --no-build --configuration Release --filter "Category=Functional" --logger "trx;LogFileName=phase-functional.trx" --results-directory ./TestResults
+
+    # Azure phase: skipped (not failed) when credentials absent. PR builds from
+    # forks and any environment without AZURE_CLIENT_ID configured will see this
+    # step as "skipped" in the CI UI rather than a hard failure. Credentialed
+    # CI for the Azure phase is deferred per spec 009.
+    - name: Test (Azure)
+      if: ${{ env.HAS_AZURE_CREDS == 'true' }}
+      env:
+        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      run: dotnet test --no-build --configuration Release --filter "Category=Azure" --logger "trx;LogFileName=phase-azure.trx" --results-directory ./TestResults
+
+    - name: Test (Azure) — skipped (no credentials)
+      if: ${{ env.HAS_AZURE_CREDS != 'true' }}
+      run: echo "Azure phase skipped — AZURE_CLIENT_ID secret is not configured for this build."
 
     - name: Upload Test Results
       if: always()


### PR DESCRIPTION
## Summary

Replaces the single Unit + Functional test job in `.github/workflows/ci.yml` with a sequence of **category-scoped phases** per spec 009, so a CI failure is attributable to exactly one category in the UI.

**Phase order (each is its own step with its own duration / pass-fail summary):**

| Phase          | Filter expression          | TRX log                  |
| -------------- | -------------------------- | ------------------------ |
| Unit           | `Category=Unit`            | `phase-unit.trx`         |
| Integration    | `Category=Integration`     | `phase-integration.trx`  |
| OutOfProcess   | `Category=OutOfProcess`    | `phase-outofprocess.trx` |
| Http           | `Category=Http`            | `phase-http.trx`         |
| Functional     | `Category=Functional`      | `phase-functional.trx`   |
| Azure          | `Category=Azure`           | `phase-azure.trx`        |

`continue-on-error` is left at its default (`false`), so a phase failure halts subsequent phases — matches today's serial-suite behavior.

## Azure skip mechanism

The Azure phase is **skipped (not failed)** when `AZURE_CLIENT_ID` is absent:

- A job-level env `HAS_AZURE_CREDS: ${{ secrets.AZURE_CLIENT_ID != '' }}` projects secret presence into an evaluable expression (GitHub Actions does not allow direct `secrets.X != ''` in step-level `if:` outside environment contexts).
- The Azure step runs only when `env.HAS_AZURE_CREDS == 'true'`.
- A companion "skipped — no credentials" step echoes a message when the secret is absent, so the UI shows an explicit "skipped" status rather than a missing step.

Credentialed Azure CI is deferred per spec 009.

## Dependency note — issue #212 (Fry, in flight)

This workflow uses `--filter "Category=X"` filters. Issue #212 is rolling out the actual `[Trait("Category", ...)]` attributes across the test suite in parallel. Until those land:

- Tests **with** the trait route to the right phase.
- Tests **without** the trait fall into the default bucket and are excluded from category-scoped phases — those phases still run honestly against whatever is currently labeled.
- As traits land, each phase automatically picks up its newly-tagged tests.

This branch does **not** block on #212.

## Acceptance (spec 009 §FR-409, SC-104, SC-106, FR-413)

- ✅ Distinct phase summaries with separate durations (each phase = own step in CI UI)
- ✅ A failed phase produces a CI status whose failure message identifies the category (`Test (OutOfProcess)`)
- ✅ Total wall-clock comparable to or better than current ~6-min serial run — same `dotnet test` invocations, no parallelism added, only metadata routing
- ✅ Azure phase skipped (not failed) when credentials absent

## Files changed

- `.github/workflows/ci.yml` — replaced 2 test steps with 7 (6 phases + skip placeholder)

Closes #215.
