### PR TITLE
test(009): bind to dynamic ports in test fixtures

### DIFF
--- a/PoshMcp.Tests/Integration/ApplicationInsightsIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/ApplicationInsightsIntegrationTests.cs
@@ -245,7 +245,10 @@ internal sealed class AppInsightsTestHttpServer : IDisposable
         Dictionary<string, string>? environmentOverrides = null,
         int port = 0)
     {
-        _port = port == 0 ? Random.Shared.Next(6100, 6900) : port;
+        // FR-411: bind on a kernel-allocated free port (probe TcpListener on
+        // port 0, read .Port, release). Replaces a Random.Shared.Next(6100,
+        // 6900) range-picker that produced collisions across concurrent runs.
+        _port = port == 0 ? PoshMcp.Tests.Shared.DynamicPort.Allocate() : port;
         _environmentOverrides = environmentOverrides ?? new Dictionary<string, string>();
     }
 

--- a/PoshMcp.Tests/Integration/UnifiedHttpTransportIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/UnifiedHttpTransportIntegrationTests.cs
@@ -314,7 +314,10 @@ internal sealed class InProcessUnifiedHttpServer : IDisposable
 
     public InProcessUnifiedHttpServer(int port = 0)
     {
-        _port = port == 0 ? Random.Shared.Next(6100, 6900) : port;
+        // FR-411: bind on a kernel-allocated free port (probe TcpListener on
+        // port 0, read .Port, release). Replaces a Random.Shared.Next(6100,
+        // 6900) range-picker that produced collisions across concurrent runs.
+        _port = port == 0 ? PoshMcp.Tests.Shared.DynamicPort.Allocate() : port;
     }
 
     public async Task StartAsync()

--- a/PoshMcp.Tests/Shared/DynamicPort.cs
+++ b/PoshMcp.Tests/Shared/DynamicPort.cs
@@ -1,0 +1,55 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace PoshMcp.Tests.Shared;
+
+/// <summary>
+/// Helper for allocating a TCP port the OS considers free, for use by test
+/// fixtures that must hand a numeric port to a child process before the
+/// child's HTTP server has bound (e.g. <c>dotnet run -- serve --url
+/// http://localhost:N</c>). Mirrors the canonical port-0 + read-back pattern
+/// already used by <c>LoopbackHttpServer</c> in
+/// <c>OutOfProcessHostConcurrencyTests</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementation: bind a <see cref="TcpListener"/> on
+/// <see cref="IPAddress.Loopback"/> port 0, read the kernel-assigned port,
+/// then stop the probe so the child can bind it. This satisfies FR-411 in
+/// spec 009 (resource-heavy tests that bind a port must use a dynamically
+/// allocated port — port 0 + read back actual port — not a hard-coded port
+/// from a small range).
+/// </para>
+/// <para>
+/// There is a small race window between probe close and child bind: another
+/// process on the host could grab the same port. In practice this is far
+/// more reliable than picking from a hand-picked range (the previous
+/// pattern used <c>Random.Shared.Next(6100, 6900)</c>, an 800-port range
+/// shared across all concurrent test runs on the machine, which produced
+/// observable collisions). When a fixture owns the listener directly (e.g.
+/// in-process <see cref="HttpListener"/> or <see cref="TcpListener"/>),
+/// prefer to bind to port 0 in-place and read the bound endpoint —
+/// <see cref="Allocate"/> is only required when the port number must be
+/// passed by argument before the listener exists.
+/// </para>
+/// </remarks>
+internal static class DynamicPort
+{
+    /// <summary>
+    /// Returns a TCP port number the kernel selected as free, then released
+    /// the probe socket so a caller (typically a child process) can bind it.
+    /// </summary>
+    public static int Allocate()
+    {
+        var probe = new TcpListener(IPAddress.Loopback, 0);
+        probe.Start();
+        try
+        {
+            return ((IPEndPoint)probe.LocalEndpoint).Port;
+        }
+        finally
+        {
+            probe.Stop();
+        }
+    }
+}


### PR DESCRIPTION
Closes #217. Implements **FR-411** for [spec 009](../tree/main/specs/009-test-suite-consistency/spec.md): every test that binds a TCP port must use a dynamically allocated port (port 0 + read back actual port), not a hard-coded port from a small range.

## Audit

Scanned `PoshMcp.Tests/` for `HttpListener|TcpListener|UseUrls|ListenLocalhost|UseKestrel|ConfigureKestrel|WebApplication.Create|UseHttpSys|Kestrel|ListenAnyIP|builder.WebHost`, plus port-literal patterns (`:5000`, `:8080`, `localhost:N`, `127.0.0.1:N`) and range allocators (`Random.Shared.Next`, `new Random()`).

| File | Pattern found | Action |
| --- | --- | --- |
| `Unit/OutOfProcess/OutOfProcessHostConcurrencyTests.cs` (`LoopbackHttpServer`) | HttpListener bound via `TcpListener` probe on port 0 → URL `http://127.0.0.1:{port}/` | None — already canonical |
| `Integration/ApplicationInsightsIntegrationTests.cs` (`AppInsightsTestHttpServer`) | `_port = port == 0 ? Random.Shared.Next(6100, 6900) : port;` | **Replaced** with `DynamicPort.Allocate()` |
| `Integration/UnifiedHttpTransportIntegrationTests.cs` (`InProcessUnifiedHttpServer`) | Same `Random.Shared.Next(6100, 6900)` pattern | **Replaced** with `DynamicPort.Allocate()` |
| `Fixtures/ProxyTestFixtures.cs` (`http://localhost:5985/wsman`) and `Unit/WinPsCompatProxyTests.cs` (`http://localhost:1234/wsman`) | Port literals in WSMan URL strings used as test description data | False positive — not bind sites, left alone |

## Changes

**New helper — `PoshMcp.Tests/Shared/DynamicPort.cs`:** single `Allocate()` method that binds a `TcpListener` on `IPAddress.Loopback` port 0, reads the kernel-assigned port, and releases the probe so the caller's child process can bind it. Lifted from the `LoopbackHttpServer` pattern that was already correct.

**Why a probe-and-release helper instead of binding port 0 in-place.** Both modified fixtures spawn a child `dotnet run -- serve --transport http --url http://localhost:N` process and pass the URL by argument — the parent needs the numeric port BEFORE the child has bound. The `LoopbackHttpServer` fixture already used this exact pattern; this PR lifts it into shared code instead of producing a third copy.

**Consumer changes.** `ServerUrl` properties were already `$"http://localhost:{_port}"` in both fixtures, so consumers (test clients, child-process arg construction) needed no changes — the field they read is now populated by the OS instead of by a range-picker.

## Validation

- **Build:** `dotnet build PoshMcp.Tests` — 0 errors, 20 warnings (all pre-existing in untouched files).
- **Tests passed (impacted scope only):**
  - `UnifiedHttpTransportIntegrationTests` — 4/4 (covers `InProcessUnifiedHttpServer`)
  - `ApplicationInsightsIntegrationTests` — 4/4 (covers `AppInsightsTestHttpServer`)
  - `MultiUserIsolationTests` — 1/1 (also uses `InProcessUnifiedHttpServer`)
  - **Total: 9/9 impacted tests pass.**
- The unchanged `LoopbackHttpServer` (in `OutOfProcessHostConcurrencyTests`) was not re-validated locally — its baseline applies.

## Notes for reviewers

- The probe-and-release helper has a small race window between probe close and child bind; in practice this is materially more reliable than the previous 800-port range shared across all concurrent test runs on the host (which produced observable collisions). If CI starts seeing collisions, the fix is retry-on-bind-failure inside the helper, NOT going back to a hand-picked range.
- Both fixtures still expose an optional `port` parameter (default 0). Auto-allocation only kicks in when `port == 0`; callers can still override for diagnosis.
