### PR TITLE
test(009): centralize pwsh subprocess teardown

### DIFF
--- a/PoshMcp.Tests/Integration/ApplicationInsightsIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/ApplicationInsightsIntegrationTests.cs
@@ -380,19 +380,8 @@ internal sealed class AppInsightsTestHttpServer : IDisposable
     {
         if (_serverProcess == null) return;
 
-        try
-        {
-            if (!_serverProcess.HasExited)
-            {
-                _serverProcess.Kill(entireProcessTree: true);
-                _serverProcess.WaitForExit(5000);
-            }
-        }
-        finally
-        {
-            TestProcessRegistry.Unregister(_serverProcess);
-            _serverProcess.Dispose();
-            _serverProcess = null;
-        }
+        // Spec 009 FR-412 — centralized teardown.
+        SubprocessTeardown.Teardown(_serverProcess);
+        _serverProcess = null;
     }
 }

--- a/PoshMcp.Tests/Integration/AzureDeploymentIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/AzureDeploymentIntegrationTests.cs
@@ -431,7 +431,9 @@ public class AzureDeploymentIntegrationTests : IAsyncLifetime
         var outputBuilder = new StringBuilder();
         var errorBuilder = new StringBuilder();
 
-        using var process = new Process { StartInfo = processStartInfo };
+        // Spec 009 FR-412 — wrap in try/finally so SubprocessTeardown runs
+        // even if WaitForExitAsync throws or is cancelled.
+        var process = new Process { StartInfo = processStartInfo };
 
         process.OutputDataReceived += (sender, e) =>
         {
@@ -449,13 +451,22 @@ public class AzureDeploymentIntegrationTests : IAsyncLifetime
             }
         };
 
-        process.Start();
-        process.BeginOutputReadLine();
-        process.BeginErrorReadLine();
+        int exitCode;
+        try
+        {
+            process.Start();
+            TestProcessRegistry.Register(process);
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
 
-        await process.WaitForExitAsync();
+            await process.WaitForExitAsync();
+            exitCode = process.ExitCode;
+        }
+        finally
+        {
+            await SubprocessTeardown.TeardownAsync(process);
+        }
 
-        var exitCode = process.ExitCode;
         var output = outputBuilder.ToString();
         var error = errorBuilder.ToString();
 

--- a/PoshMcp.Tests/Integration/DeployScriptConfigurationPrecedenceTests.cs
+++ b/PoshMcp.Tests/Integration/DeployScriptConfigurationPrecedenceTests.cs
@@ -156,7 +156,9 @@ function Invoke-WebRequest {{
         var outputBuilder = new StringBuilder();
         var errorBuilder = new StringBuilder();
 
-        using var process = new Process { StartInfo = startInfo };
+        // Spec 009 FR-412 — local pwsh spawn wrapped in try/finally so a hung
+        // child still routes through SubprocessTeardown (kill tree + handle poll).
+        var process = new Process { StartInfo = startInfo };
         process.OutputDataReceived += (_, e) =>
         {
             if (!string.IsNullOrEmpty(e.Data))
@@ -172,15 +174,25 @@ function Invoke-WebRequest {{
             }
         };
 
-        process.Start();
-        process.BeginOutputReadLine();
-        process.BeginErrorReadLine();
-        await process.WaitForExitAsync();
+        int exitCode;
+        try
+        {
+            process.Start();
+            TestProcessRegistry.Register(process);
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+            await process.WaitForExitAsync();
+            exitCode = process.ExitCode;
+        }
+        finally
+        {
+            await SubprocessTeardown.TeardownAsync(process);
+        }
 
         var combined = outputBuilder.ToString() + Environment.NewLine + errorBuilder.ToString();
         _output.WriteLine(combined);
 
-        return (process.ExitCode, combined);
+        return (exitCode, combined);
     }
 
     private static string EscapeSingleQuoted(string value)

--- a/PoshMcp.Tests/Integration/McpServerIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/McpServerIntegrationTests.cs
@@ -431,24 +431,10 @@ public class InProcessMcpServer : IDisposable
             return;
         }
 
-        try
-        {
-            if (!_serverProcess.HasExited)
-            {
-                _serverProcess.Kill(entireProcessTree: true);
-                _serverProcess.WaitForExit(5000);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to stop stdio server process cleanly");
-        }
-        finally
-        {
-            TestProcessRegistry.Unregister(_serverProcess);
-            _serverProcess.Dispose();
-            _serverProcess = null;
-        }
+        // Centralized teardown: kill tree + WaitForExit + Windows handle-release poll.
+        // Spec 009 FR-412 — see PoshMcp.Tests/Shared/SubprocessTeardown.cs.
+        SubprocessTeardown.Teardown(_serverProcess, _logger);
+        _serverProcess = null;
     }
 }
 

--- a/PoshMcp.Tests/Integration/SubprocessTeardownTests.cs
+++ b/PoshMcp.Tests/Integration/SubprocessTeardownTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PoshMcp.Tests.Integration;
+
+/// <summary>
+/// Smoke test for the centralized subprocess teardown contract introduced by
+/// spec 009 FR-412 / GitHub #218. Spawns a real <c>pwsh</c> child, tears it
+/// down via <see cref="SubprocessTeardown"/>, and asserts that no new
+/// <c>pwsh</c> processes remain attributable to this test runner.
+///
+/// Lives in the <c>Integration</c> category because it spawns <c>pwsh</c>
+/// (FR-401 forbids that under <c>Unit</c>).
+/// </summary>
+[Trait("Category", "Integration")]
+public class SubprocessTeardownTests : PowerShellTestBase
+{
+    public SubprocessTeardownTests(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    [PwshAvailableFact]
+    public async Task TeardownAsync_AfterShortLivedPwsh_LeavesNoOrphans()
+    {
+        var auditor = new OrphanProcessAuditor("pwsh");
+
+        var process = StartShortLivedPwsh();
+
+        try
+        {
+            // Let the child finish naturally on its own short script.
+            await process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(15));
+            Assert.True(process.HasExited, "Pwsh child did not exit within 15s.");
+        }
+        finally
+        {
+            await SubprocessTeardown.TeardownAsync(process, Logger);
+        }
+
+        var newPids = auditor.NewLivingPids();
+        Assert.True(
+            newPids.Count == 0,
+            $"Expected zero new living pwsh processes after teardown, found {newPids.Count}: " +
+            $"{string.Join(",", newPids)}");
+    }
+
+    [PwshAvailableFact]
+    public async Task TeardownAsync_AfterHungPwsh_KillsTreeAndLeavesNoOrphans()
+    {
+        var auditor = new OrphanProcessAuditor("pwsh");
+
+        var process = StartHungPwsh();
+
+        try
+        {
+            // Confirm the child is still alive — teardown must kill it.
+            await Task.Delay(250);
+            Assert.False(process.HasExited, "Hung pwsh exited prematurely; test setup is wrong.");
+        }
+        finally
+        {
+            await SubprocessTeardown.TeardownAsync(process, Logger);
+        }
+
+        var newPids = auditor.NewLivingPids();
+        Assert.True(
+            newPids.Count == 0,
+            $"Expected kill-tree teardown to leave zero new living pwsh processes, found {newPids.Count}: " +
+            $"{string.Join(",", newPids)}");
+    }
+
+    private static Process StartShortLivedPwsh()
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "pwsh",
+            Arguments = "-NoProfile -NonInteractive -Command \"exit 0\"",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+
+        var process = new Process { StartInfo = psi };
+        process.Start();
+        TestProcessRegistry.Register(process);
+        return process;
+    }
+
+    private static Process StartHungPwsh()
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "pwsh",
+            Arguments = "-NoProfile -NonInteractive -Command \"Start-Sleep -Seconds 120\"",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+
+        var process = new Process { StartInfo = psi };
+        process.Start();
+        TestProcessRegistry.Register(process);
+        return process;
+    }
+}

--- a/PoshMcp.Tests/Integration/UnifiedHttpTransportIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/UnifiedHttpTransportIntegrationTests.cs
@@ -441,19 +441,8 @@ internal sealed class InProcessUnifiedHttpServer : IDisposable
             return;
         }
 
-        try
-        {
-            if (!_serverProcess.HasExited)
-            {
-                _serverProcess.Kill(entireProcessTree: true);
-                _serverProcess.WaitForExit(5000);
-            }
-        }
-        finally
-        {
-            TestProcessRegistry.Unregister(_serverProcess);
-            _serverProcess.Dispose();
-            _serverProcess = null;
-        }
+        // Spec 009 FR-412 — centralized teardown.
+        SubprocessTeardown.Teardown(_serverProcess);
+        _serverProcess = null;
     }
 }

--- a/PoshMcp.Tests/Shared/OrphanProcessAuditor.cs
+++ b/PoshMcp.Tests/Shared/OrphanProcessAuditor.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace PoshMcp.Tests;
+
+/// <summary>
+/// Snapshots running <c>pwsh</c> processes at construction and reports any new
+/// <c>pwsh</c> instances still alive at audit time. Used to verify spec 009
+/// FR-412 acceptance: a post-test process audit confirms zero orphan
+/// <c>pwsh</c> processes attributable to the test runner.
+///
+/// Diff-based rather than absolute count so a developer with unrelated
+/// <c>pwsh</c> sessions on the box does not produce false positives.
+/// </summary>
+internal sealed class OrphanProcessAuditor
+{
+    private readonly HashSet<int> _baseline;
+    private readonly string _processName;
+
+    public OrphanProcessAuditor(string processName = "pwsh")
+    {
+        _processName = processName;
+        _baseline = SnapshotPids(processName);
+    }
+
+    /// <summary>
+    /// Pids that match the audited process name, are still alive, and were
+    /// NOT present at construction time.
+    /// </summary>
+    public IReadOnlyCollection<int> NewLivingPids()
+    {
+        var current = SnapshotPids(_processName);
+        current.ExceptWith(_baseline);
+        return current;
+    }
+
+    /// <summary>
+    /// Convenience wrapper around <see cref="NewLivingPids"/>.
+    /// </summary>
+    public int CountNewLiving() => NewLivingPids().Count;
+
+    private static HashSet<int> SnapshotPids(string processName)
+    {
+        var result = new HashSet<int>();
+        Process[] processes;
+
+        try
+        {
+            processes = Process.GetProcessesByName(processName);
+        }
+        catch
+        {
+            return result;
+        }
+
+        foreach (var p in processes)
+        {
+            try
+            {
+                if (!p.HasExited)
+                {
+                    result.Add(p.Id);
+                }
+            }
+            catch
+            {
+                // Skip races where the process exits between enumeration and inspection.
+            }
+            finally
+            {
+                p.Dispose();
+            }
+        }
+
+        return result;
+    }
+}

--- a/PoshMcp.Tests/Shared/SubprocessTeardown.cs
+++ b/PoshMcp.Tests/Shared/SubprocessTeardown.cs
@@ -1,0 +1,283 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace PoshMcp.Tests;
+
+/// <summary>
+/// Centralized subprocess teardown for the test suite. Implements the contract
+/// required by spec 009 FR-410/FR-412: kill the entire process tree, wait for
+/// full process exit, and on Windows poll for handle release before declaring
+/// teardown complete.
+///
+/// Every <see cref="Process"/> spawned by tests (directly or via helper/fixture)
+/// MUST be torn down through this helper so the algorithm stays in one place.
+/// All methods are exception-safe and never throw — they are designed to be
+/// called from <c>finally</c> and <c>Dispose</c> paths.
+/// </summary>
+internal static class SubprocessTeardown
+{
+    /// <summary>
+    /// Default time to wait for a killed process to exit before logging a warning
+    /// and proceeding to the handle-release poll. Generous enough to absorb a
+    /// loaded CI host yet bounded so a hung child cannot block the whole run.
+    /// </summary>
+    public static readonly TimeSpan DefaultGracefulTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Default time to wait on Windows for the OS to release the process handle
+    /// after <see cref="Process.WaitForExitAsync"/> returns. On Windows, file and
+    /// pipe handles owned by the child can outlive process exit by a short window
+    /// and cause subsequent tests to fail with locked-file or port-in-use errors.
+    /// </summary>
+    public static readonly TimeSpan DefaultHandleReleasePollTimeout = TimeSpan.FromSeconds(2);
+
+    private const int HandleReleasePollIntervalMs = 50;
+
+    /// <summary>
+    /// Asynchronously tear down a subprocess: kill its tree, wait for full exit,
+    /// poll for handle release on Windows, unregister from
+    /// <see cref="TestProcessRegistry"/>, and dispose the <see cref="Process"/>.
+    /// Safe to call with a null process or one that has already exited.
+    /// Never throws — diagnostic detail is logged when <paramref name="logger"/>
+    /// is supplied.
+    /// </summary>
+    public static async Task TeardownAsync(
+        Process? process,
+        ILogger? logger = null,
+        TimeSpan? gracefulTimeout = null,
+        TimeSpan? handleReleasePollTimeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (process is null)
+        {
+            return;
+        }
+
+        var graceful = gracefulTimeout ?? DefaultGracefulTimeout;
+        var handlePoll = handleReleasePollTimeout ?? DefaultHandleReleasePollTimeout;
+
+        var capturedPid = TryCapturePid(process);
+
+        try
+        {
+            if (!HasExitedSafe(process))
+            {
+                TryKillTree(process, logger, capturedPid);
+
+                try
+                {
+                    using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    cts.CancelAfter(graceful);
+                    await process.WaitForExitAsync(cts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    logger?.LogWarning(
+                        "Subprocess pid {Pid} did not exit within {Timeout}; proceeding to handle-release poll.",
+                        capturedPid, graceful);
+                }
+                catch (Exception ex)
+                {
+                    logger?.LogWarning(ex, "WaitForExitAsync failed for pid {Pid}.", capturedPid);
+                }
+            }
+
+            if (capturedPid.HasValue && OperatingSystem.IsWindows())
+            {
+                await WaitForHandleReleaseAsync(capturedPid.Value, handlePoll, logger, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            SafeUnregisterAndDispose(process);
+        }
+    }
+
+    /// <summary>
+    /// Synchronous teardown for code paths that cannot be async (e.g. existing
+    /// <see cref="IDisposable.Dispose"/> implementations). Mirrors the algorithm
+    /// of <see cref="TeardownAsync"/> using blocking calls. Never throws.
+    /// </summary>
+    public static void Teardown(
+        Process? process,
+        ILogger? logger = null,
+        TimeSpan? gracefulTimeout = null,
+        TimeSpan? handleReleasePollTimeout = null)
+    {
+        if (process is null)
+        {
+            return;
+        }
+
+        var graceful = gracefulTimeout ?? DefaultGracefulTimeout;
+        var handlePoll = handleReleasePollTimeout ?? DefaultHandleReleasePollTimeout;
+
+        var capturedPid = TryCapturePid(process);
+
+        try
+        {
+            if (!HasExitedSafe(process))
+            {
+                TryKillTree(process, logger, capturedPid);
+
+                try
+                {
+                    process.WaitForExit((int)graceful.TotalMilliseconds);
+                }
+                catch (Exception ex)
+                {
+                    logger?.LogWarning(ex, "WaitForExit failed for pid {Pid}.", capturedPid);
+                }
+            }
+
+            if (capturedPid.HasValue && OperatingSystem.IsWindows())
+            {
+                WaitForHandleReleaseSync(capturedPid.Value, handlePoll, logger);
+            }
+        }
+        finally
+        {
+            SafeUnregisterAndDispose(process);
+        }
+    }
+
+    private static int? TryCapturePid(Process process)
+    {
+        try
+        {
+            return process.Id;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static bool HasExitedSafe(Process process)
+    {
+        try
+        {
+            return process.HasExited;
+        }
+        catch
+        {
+            return true;
+        }
+    }
+
+    private static void TryKillTree(Process process, ILogger? logger, int? capturedPid)
+    {
+        try
+        {
+            process.Kill(entireProcessTree: true);
+        }
+        catch (InvalidOperationException)
+        {
+            // Already exited between HasExited check and Kill — benign race.
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex, "Process.Kill(entireProcessTree:true) failed for pid {Pid}.", capturedPid);
+        }
+    }
+
+    private static async Task WaitForHandleReleaseAsync(
+        int pid,
+        TimeSpan timeout,
+        ILogger? logger,
+        CancellationToken cancellationToken)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (!ProcessHandleStillResolvable(pid))
+            {
+                return;
+            }
+
+            try
+            {
+                await Task.Delay(HandleReleasePollIntervalMs, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
+
+        logger?.LogWarning(
+            "Subprocess pid {Pid} handle still resolvable after {Timeout}; continuing.",
+            pid, timeout);
+    }
+
+    private static void WaitForHandleReleaseSync(int pid, TimeSpan timeout, ILogger? logger)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (!ProcessHandleStillResolvable(pid))
+            {
+                return;
+            }
+
+            Thread.Sleep(HandleReleasePollIntervalMs);
+        }
+
+        logger?.LogWarning(
+            "Subprocess pid {Pid} handle still resolvable after {Timeout}; continuing.",
+            pid, timeout);
+    }
+
+    private static bool ProcessHandleStillResolvable(int pid)
+    {
+        try
+        {
+            using var probe = Process.GetProcessById(pid);
+            // On Windows, GetProcessById succeeds while the kernel object lingers
+            // even after process exit. Treat HasExited as "released enough" for
+            // teardown purposes — the file/pipe handles drain alongside it.
+            return !probe.HasExited;
+        }
+        catch (ArgumentException)
+        {
+            // Process no longer exists — fully released.
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+        catch
+        {
+            // Any other failure: assume released so we do not stall teardown.
+            return false;
+        }
+    }
+
+    private static void SafeUnregisterAndDispose(Process process)
+    {
+        try
+        {
+            TestProcessRegistry.Unregister(process);
+        }
+        catch
+        {
+            // Tolerate races during AppDomain shutdown.
+        }
+
+        try
+        {
+            process.Dispose();
+        }
+        catch
+        {
+            // Tolerate double dispose.
+        }
+    }
+}


### PR DESCRIPTION
Closes #218.

## Summary
Implements spec 009 FR-412 — every test that spawns `pwsh` (directly or via helper/fixture) now goes through a single centralized teardown contract that:

1. Calls `Process.Kill(entireProcessTree: true)` (catches `InvalidOperationException` for already-exited race).
2. Awaits `WaitForExitAsync` (or `WaitForExit`) bounded by a configurable graceful timeout (default 5s).
3. On Windows, polls `Process.GetProcessById(pid).HasExited` until the kernel object is released or the poll timeout elapses (default 2s, 50ms interval). `ArgumentException` from `GetProcessById` is treated as "released".
4. Unregisters from `TestProcessRegistry` and disposes the `Process` instance.

Helper never throws — failures are swallowed (with optional `ILogger` warnings) so teardown always completes.

## Helpers added
- `PoshMcp.Tests/Shared/SubprocessTeardown.cs` — canonical teardown contract (`TeardownAsync` + sync `Teardown`).
- `PoshMcp.Tests/Shared/OrphanProcessAuditor.cs` — diff-based audit of `pwsh` (or arbitrary process name) PIDs around a region of test code; powers the FR-412 acceptance smoke test.
- `PoshMcp.Tests/Integration/SubprocessTeardownTests.cs` — two `[PwshAvailableFact]` smoke tests asserting zero new orphan `pwsh` after both short-lived and hung spawns.

## Spawn sites audited & refactored
| File | Spawn | Refactor |
|------|-------|----------|
| `PoshMcp.Tests/Integration/McpServerIntegrationTests.cs` | `InProcessMcpServer.StopServerProcess()` | Replaced bespoke try/catch + Kill + WaitForExit + Unregister + Dispose with `SubprocessTeardown.Teardown(_serverProcess, _logger)`. |
| `PoshMcp.Tests/Integration/ApplicationInsightsIntegrationTests.cs` | `AppInsightsTestHttpServer.Dispose()` | Replaced inline teardown with `SubprocessTeardown.Teardown(_serverProcess)`. |
| `PoshMcp.Tests/Integration/UnifiedHttpTransportIntegrationTests.cs` | Anonymous server helper `Dispose()` | Same refactor as above. |
| `PoshMcp.Tests/Integration/DeployScriptConfigurationPrecedenceTests.cs` | Inline `Process.Start` / `WaitForExitAsync` | Wrapped in `try/finally` calling `SubprocessTeardown.TeardownAsync(process)`; registered with `TestProcessRegistry` after `Start()`. |
| `PoshMcp.Tests/Integration/AzureDeploymentIntegrationTests.cs` | `RunCommandAsync` | Same `try/finally` + `TestProcessRegistry` pattern. |

Fixtures that compose `InProcessMcpServer` (e.g. `HelpParityFixtureSession`) inherit the new teardown for free — no per-test duplication.

`PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessHost.cs` (production code) was already calling `Kill(entireProcessTree: true)` + `WaitForExitAsync` and is intentionally outside the scope of this test refactor.

## Verification
- Build: `dotnet build PoshMcp.Tests/PoshMcp.Tests.csproj -c Debug --no-incremental` — succeeded (1 NU1510 warning, pre-existing).
- New smoke tests: `dotnet test --filter "FullyQualifiedName~SubprocessTeardownTests"` — **2/2 passed** (short-lived + hung pwsh, zero orphans).
- Impacted integration suites: `--filter "FullyQualifiedName~McpServerIntegrationTests|ApplicationInsightsIntegrationTests|UnifiedHttpTransportIntegrationTests"` — **8/8 passed**.

## Audit result
Orphan-process audit (`OrphanProcessAuditor("pwsh")`) reports **0 new living `pwsh` PIDs** after teardown across both smoke scenarios. Centralized helper in place; no duplicated kill/wait/poll code remains in tests.
