### PR TITLE
test(009): add Category traits to test classes

### DIFF
--- a/PoshMcp.Tests/AssemblyInfo.cs
+++ b/PoshMcp.Tests/AssemblyInfo.cs
@@ -3,3 +3,22 @@ using Xunit;
 // Many tests create PowerShell runspaces and child server processes.
 // Running tests in parallel can cause nondeterministic host aborts.
 [assembly: CollectionBehavior(DisableTestParallelization = true, MaxParallelThreads = 1)]
+
+// ─── Spec 009 — Test Category Policy ──────────────────────────────────────────
+//
+// Every test class in this assembly SHOULD carry exactly one
+// [Trait("Category", "<X>")] attribute, where <X> is one of:
+//
+//     Unit, Integration, OutOfProcess, Http, Azure, Functional
+//
+// Per FR-417, tests with no explicit Category trait fall back to the
+// "Integration" bucket (permissive default). The default-bucket fallback
+// MUST NOT be "Unit" — an untagged test must never silently appear in the
+// fast unit tier (which guarantees no subprocess, no port, no shared temp
+// per FR-401/FR-402/FR-403). Treating untagged tests as "Integration" keeps
+// them runnable but excludes them from the fast pre-commit tier until they
+// are explicitly tagged.
+//
+// See specs/009-test-suite-consistency/spec.md for the full category
+// definitions and FR list. Per-category run commands and the contributor
+// TESTING.md guide are tracked separately under issue #214.

--- a/PoshMcp.Tests/Functional/ConfigurationReload/ConfigurationReloadTests.cs
+++ b/PoshMcp.Tests/Functional/ConfigurationReload/ConfigurationReloadTests.cs
@@ -15,6 +15,7 @@ namespace PoshMcp.Tests.Functional.ConfigurationReload;
 /// <summary>
 /// Tests for PowerShell configuration reload functionality
 /// </summary>
+[Trait("Category", "Functional")]
 public class ConfigurationReloadTests : PowerShellTestBase
 {
     public ConfigurationReloadTests(ITestOutputHelper outputHelper) : base(outputHelper)

--- a/PoshMcp.Tests/Functional/ConfigurationReload/DynamicReloadToolsFeatureFlagTests.cs
+++ b/PoshMcp.Tests/Functional/ConfigurationReload/DynamicReloadToolsFeatureFlagTests.cs
@@ -12,6 +12,7 @@ namespace PoshMcp.Tests.Functional.ConfigurationReload;
 /// <summary>
 /// Tests for the EnableDynamicReloadTools feature flag functionality
 /// </summary>
+[Trait("Category", "Functional")]
 public class DynamicReloadToolsFeatureFlagTests : PowerShellTestBase
 {
     public DynamicReloadToolsFeatureFlagTests(ITestOutputHelper outputHelper) : base(outputHelper)

--- a/PoshMcp.Tests/Functional/ConfigurationReload/EndToEndDynamicReloadToolsTests.cs
+++ b/PoshMcp.Tests/Functional/ConfigurationReload/EndToEndDynamicReloadToolsTests.cs
@@ -11,6 +11,7 @@ namespace PoshMcp.Tests.Functional.ConfigurationReload;
 /// <summary>
 /// Test to verify the end-to-end behavior of the dynamic reload tools feature flag
 /// </summary>
+[Trait("Category", "Functional")]
 public class EndToEndDynamicReloadToolsTests : PowerShellTestBase
 {
     public EndToEndDynamicReloadToolsTests(ITestOutputHelper outputHelper) : base(outputHelper)

--- a/PoshMcp.Tests/Functional/CorrelationId/CorrelationIdGenerationTests.cs
+++ b/PoshMcp.Tests/Functional/CorrelationId/CorrelationIdGenerationTests.cs
@@ -18,6 +18,7 @@ namespace PoshMcp.Tests.Functional.CorrelationId;
 /// - IDs follow a consistent, parseable format
 /// - IDs can be set explicitly from request headers
 /// </summary>
+[Trait("Category", "Functional")]
 public class CorrelationIdGenerationTests : PowerShellTestBase
 {
     public CorrelationIdGenerationTests(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Functional/CorrelationId/CorrelationIdLoggingTests.cs
+++ b/PoshMcp.Tests/Functional/CorrelationId/CorrelationIdLoggingTests.cs
@@ -20,6 +20,7 @@ namespace PoshMcp.Tests.Functional.CorrelationId;
 /// - Structured logging captures correlation ID as a field
 /// - Log filtering by correlation ID is possible
 /// </summary>
+[Trait("Category", "Functional")]
 public class CorrelationIdLoggingTests : PowerShellTestBase
 {
     public CorrelationIdLoggingTests(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Functional/CorrelationId/CorrelationIdMiddlewareTests.cs
+++ b/PoshMcp.Tests/Functional/CorrelationId/CorrelationIdMiddlewareTests.cs
@@ -18,6 +18,7 @@ namespace PoshMcp.Tests.Functional.CorrelationId;
 /// Note: These are functional tests that may require integration test setup
 /// with actual HTTP requests once the middleware is implemented.
 /// </summary>
+[Trait("Category", "Functional")]
 public class CorrelationIdMiddlewareTests : PowerShellTestBase
 {
     public CorrelationIdMiddlewareTests(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Functional/CorrelationId/CorrelationIdPropagationTests.cs
+++ b/PoshMcp.Tests/Functional/CorrelationId/CorrelationIdPropagationTests.cs
@@ -19,6 +19,7 @@ namespace PoshMcp.Tests.Functional.CorrelationId;
 /// - IDs don't leak between unrelated operations
 /// - IDs survive across thread pool thread switches
 /// </summary>
+[Trait("Category", "Functional")]
 public class CorrelationIdPropagationTests : PowerShellTestBase
 {
     public CorrelationIdPropagationTests(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Functional/FilterLastCommandOutput/ShouldFilterCachedResultsTest.cs
+++ b/PoshMcp.Tests/Functional/FilterLastCommandOutput/ShouldFilterCachedResultsTest.cs
@@ -17,6 +17,7 @@ namespace PoshMcp.Tests.Functional.FilterLastCommandOutput;
 /// <summary>
 /// Test for filtering cached results
 /// </summary>
+[Trait("Category", "Functional")]
 public partial class FilterCachedResults : PowerShellTestBase
 {
     public FilterCachedResults(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Functional/GeneratedAssembly/UtilityMethodsShared.cs
+++ b/PoshMcp.Tests/Functional/GeneratedAssembly/UtilityMethodsShared.cs
@@ -12,6 +12,7 @@ namespace PoshMcp.Tests.Functional.GeneratedAssembly;
 /// <summary>
 /// Shared utilities for assembly generation tests
 /// </summary>
+[Trait("Category", "Functional")]
 public partial class GeneratedInstance : PowerShellTestBase
 {
     private void SetupTestPowerShellFunction()

--- a/PoshMcp.Tests/Functional/GetLastCommandOutput/ShouldReturnNullTest.cs
+++ b/PoshMcp.Tests/Functional/GetLastCommandOutput/ShouldReturnNullTest.cs
@@ -17,6 +17,7 @@ namespace PoshMcp.Tests.Functional.GetLastCommandOutput;
 /// <summary>
 /// Test for cache retrieval when no cache exists
 /// </summary>
+[Trait("Category", "Functional")]
 public class GetLastCommandResult : PowerShellTestBase
 {
     public GetLastCommandResult(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Functional/McpPromptsTests.cs
+++ b/PoshMcp.Tests/Functional/McpPromptsTests.cs
@@ -17,6 +17,7 @@ namespace PoshMcp.Tests.Functional;
 /// They document expected behavior and will be activated once WithListPromptsHandler and
 /// WithGetPromptHandler are registered in Program.cs (Spec 002 implementation PR).
 /// </summary>
+[Trait("Category", "Functional")]
 public class McpPromptsTests : PowerShellTestBase
 {
     public McpPromptsTests(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Functional/McpResourcesTests.cs
+++ b/PoshMcp.Tests/Functional/McpResourcesTests.cs
@@ -17,6 +17,7 @@ namespace PoshMcp.Tests.Functional;
 /// They document expected behavior and will be activated once WithListResourcesHandler and
 /// WithReadResourceHandler are registered in Program.cs (Spec 002 implementation PR).
 /// </summary>
+[Trait("Category", "Functional")]
 public class McpResourcesTests : PowerShellTestBase
 {
     public McpResourcesTests(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Functional/McpServerSetup/SetupTestsShared.cs
+++ b/PoshMcp.Tests/Functional/McpServerSetup/SetupTestsShared.cs
@@ -16,6 +16,7 @@ namespace PoshMcp.Tests.Functional.McpServerSetup;
 /// <summary>
 /// Shared setup for MCP server setup tests
 /// </summary>
+[Trait("Category", "Functional")]
 public partial class SetupTests : PowerShellTestBase
 {
     public SetupTests(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Functional/MethodExecution/ExecutionTestsShared.cs
+++ b/PoshMcp.Tests/Functional/MethodExecution/ExecutionTestsShared.cs
@@ -14,6 +14,7 @@ namespace PoshMcp.Tests.Functional.MethodExecution;
 /// <summary>
 /// Shared setup for method execution tests
 /// </summary>
+[Trait("Category", "Functional")]
 public partial class ExecutionTests : PowerShellTestBase
 {
     public ExecutionTests(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Functional/PowerShellCommandExecution/ShouldApplyPhase3PropertyFilteringTest.cs
+++ b/PoshMcp.Tests/Functional/PowerShellCommandExecution/ShouldApplyPhase3PropertyFilteringTest.cs
@@ -13,6 +13,7 @@ namespace PoshMcp.Tests.Functional.PowerShellCommandExecution;
 /// property filtering, _AllProperties override, _MaxResults composition,
 /// and fallback when no DefaultDisplayPropertySet exists.
 /// </summary>
+[Trait("Category", "Functional")]
 public class ShouldApplyPhase3PropertyFiltering : PowerShellTestBase
 {
     public ShouldApplyPhase3PropertyFiltering(ITestOutputHelper output) : base(output)

--- a/PoshMcp.Tests/Functional/PowerShellCommandExecution/ShouldCacheResultsTest.cs
+++ b/PoshMcp.Tests/Functional/PowerShellCommandExecution/ShouldCacheResultsTest.cs
@@ -18,6 +18,7 @@ namespace PoshMcp.Tests.Functional.PowerShellCommandExecution;
 /// Test for caching PowerShell command results and retrieval
 /// </summary>
 [Collection("CachingStateTests")]
+[Trait("Category", "Functional")]
 public class CacheResults : PowerShellTestBase
 {
     public CacheResults(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Functional/PowerShellCommandExecution/ShouldHandleGetProcessSerializationTest.cs
+++ b/PoshMcp.Tests/Functional/PowerShellCommandExecution/ShouldHandleGetProcessSerializationTest.cs
@@ -11,6 +11,7 @@ namespace PoshMcp.Tests.Functional.PowerShellCommandExecution;
 /// <summary>
 /// Regression test for serializing Get-Process output without traversing expensive live process graphs.
 /// </summary>
+[Trait("Category", "Functional")]
 public class HandleGetProcessSerialization : PowerShellTestBase
 {
     public HandleGetProcessSerialization(ITestOutputHelper output) : base(output)

--- a/PoshMcp.Tests/Functional/PowerShellCommandExecution/ShouldHandleInvalidCommandTest.cs
+++ b/PoshMcp.Tests/Functional/PowerShellCommandExecution/ShouldHandleInvalidCommandTest.cs
@@ -17,6 +17,7 @@ namespace PoshMcp.Tests.Functional.PowerShellCommandExecution;
 /// <summary>
 /// Test for handling invalid PowerShell commands
 /// </summary>
+[Trait("Category", "Functional")]
 public class InvalidCommand : PowerShellTestBase
 {
     public InvalidCommand(ITestOutputHelper output) : base(output)

--- a/PoshMcp.Tests/Functional/PowerShellCommandExecution/ShouldHandleValidCommandTest.cs
+++ b/PoshMcp.Tests/Functional/PowerShellCommandExecution/ShouldHandleValidCommandTest.cs
@@ -17,6 +17,7 @@ namespace PoshMcp.Tests.Functional.PowerShellCommandExecution;
 /// <summary>
 /// Test for handling valid PowerShell commands
 /// </summary>
+[Trait("Category", "Functional")]
 public class ValidCommand : PowerShellTestBase
 {
     public ValidCommand(ITestOutputHelper output) : base(output)

--- a/PoshMcp.Tests/Functional/PowerShellCommandExecution/ShouldOverwritePreviousCacheTest.cs
+++ b/PoshMcp.Tests/Functional/PowerShellCommandExecution/ShouldOverwritePreviousCacheTest.cs
@@ -18,6 +18,7 @@ namespace PoshMcp.Tests.Functional.PowerShellCommandExecution;
 /// Test for cache overwriting behavior
 /// </summary>
 [Collection("CachingStateTests")]
+[Trait("Category", "Functional")]
 public class OverwriteCache : PowerShellTestBase
 {
 

--- a/PoshMcp.Tests/Functional/PowerShellCommandExecution/WithParametersTest.cs
+++ b/PoshMcp.Tests/Functional/PowerShellCommandExecution/WithParametersTest.cs
@@ -18,6 +18,7 @@ namespace PoshMcp.Tests.Functional.PowerShellCommandExecution;
 /// Test for parameterized command caching
 /// </summary>
 [Collection("CachingStateTests")]
+[Trait("Category", "Functional")]
 public class ExecutePowerShellCommandWithParameters : PowerShellTestBase
 {
     public ExecutePowerShellCommandWithParameters(ITestOutputHelper output) : base(output)

--- a/PoshMcp.Tests/Functional/ReturnType/TypeTestsShared.cs
+++ b/PoshMcp.Tests/Functional/ReturnType/TypeTestsShared.cs
@@ -15,6 +15,7 @@ namespace PoshMcp.Tests.Functional.ReturnType;
 /// <summary>
 /// Shared setup for return type tests
 /// </summary>
+[Trait("Category", "Functional")]
 public partial class GeneratedMethod : PowerShellTestBase
 {
     public GeneratedMethod(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Functional/SortLastCommandOutput/ShouldReturnNullTest.cs
+++ b/PoshMcp.Tests/Functional/SortLastCommandOutput/ShouldReturnNullTest.cs
@@ -3,12 +3,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Xunit.Abstractions;
+using Xunit;
 
 namespace PoshMcp.Tests.Functional.SortLastCommandOutput;
 
 /// <summary>
 /// Test for sort behavior when no cache exists
 /// </summary>
+[Trait("Category", "Functional")]
 public class ShouldReturnNullTest : PowerShellTestBase
 {
     public ShouldReturnNullTest(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Functional/SortLastCommandOutput/ShouldSortCachedResultsTest.cs
+++ b/PoshMcp.Tests/Functional/SortLastCommandOutput/ShouldSortCachedResultsTest.cs
@@ -18,6 +18,7 @@ namespace PoshMcp.Tests.Functional.SortLastCommand;
 /// Test for sorting cached results
 /// </summary>
 [Collection("CachingStateTests")]
+[Trait("Category", "Functional")]
 public class Output_Test : PowerShellTestBase
 {
     public Output_Test(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Functional/StdioLoggingTests.cs
+++ b/PoshMcp.Tests/Functional/StdioLoggingTests.cs
@@ -14,6 +14,7 @@ namespace PoshMcp.Tests.Functional;
 /// - No log output leaks to stderr in stdio mode without a log file configured.
 /// - When a log file is configured, logs are written to that file instead.
 /// </summary>
+[Trait("Category", "Integration")]
 public class StdioLoggingTests : PowerShellTestBase
 {
     // Matches Serilog template "[2024-01-01 12:00:00 INF]" and MEL console "info: " / "warn: " etc.

--- a/PoshMcp.Tests/Functional/SwitchParameterMcpRoundTripTests.cs
+++ b/PoshMcp.Tests/Functional/SwitchParameterMcpRoundTripTests.cs
@@ -38,6 +38,7 @@ namespace PoshMcp.Tests.Functional;
 /// flow correctly from MCP JSON input to bound CLR values, and that the
 /// advertised JSON schema accepts every shape an MCP client might emit.
 /// </summary>
+[Trait("Category", "Functional")]
 public class SwitchParameterMcpRoundTripTests : PowerShellTestBase
 {
     public SwitchParameterMcpRoundTripTests(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Functional/WinPsCompatProxyMethodGenerationTests.cs
+++ b/PoshMcp.Tests/Functional/WinPsCompatProxyMethodGenerationTests.cs
@@ -34,6 +34,7 @@ namespace PoshMcp.Tests.Functional;
 /// Integration test for proxy and high-parameter method generation through tool registration.
 /// Tests that PR #211 changes work correctly end-to-end with real PowerShell commands.
 /// </summary>
+[Trait("Category", "Functional")]
 public class WinPsCompatProxyMethodGenerationTests : PowerShellTestBase
 {
     public WinPsCompatProxyMethodGenerationTests(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Integration/AzureDeploymentIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/AzureDeploymentIntegrationTests.cs
@@ -34,6 +34,7 @@ namespace PoshMcp.Tests.Integration;
 /// 
 /// Priority: System environment > .env.test > .env.local > .env
 /// </remarks>
+[Trait("Category", "Azure")]
 public class AzureDeploymentIntegrationTests : IAsyncLifetime
 {
     private readonly ITestOutputHelper _output;

--- a/PoshMcp.Tests/Integration/CommandLineTests.cs
+++ b/PoshMcp.Tests/Integration/CommandLineTests.cs
@@ -8,6 +8,7 @@ namespace PoshMcp.Tests.Integration
     /// <summary>
     /// Tests for the command line argument parsing functionality
     /// </summary>
+    [Trait("Category", "Integration")]
     public class CommandLineTests
     {
         private readonly ITestOutputHelper _output;

--- a/PoshMcp.Tests/Integration/ConfigurationGuidanceIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/ConfigurationGuidanceIntegrationTests.cs
@@ -7,6 +7,7 @@ using Xunit.Abstractions;
 
 namespace PoshMcp.Tests.Integration;
 
+[Trait("Category", "Integration")]
 public class ConfigurationGuidanceIntegrationTests : PowerShellTestBase
 {
     public ConfigurationGuidanceIntegrationTests(ITestOutputHelper output) : base(output)

--- a/PoshMcp.Tests/Integration/DeployScriptConfigurationPrecedenceTests.cs
+++ b/PoshMcp.Tests/Integration/DeployScriptConfigurationPrecedenceTests.cs
@@ -9,6 +9,7 @@ using Xunit.Abstractions;
 
 namespace PoshMcp.Tests.Integration;
 
+[Trait("Category", "Integration")]
 public class DeployScriptConfigurationPrecedenceTests
 {
     private readonly ITestOutputHelper _output;

--- a/PoshMcp.Tests/Integration/IntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/IntegrationTests.cs
@@ -14,6 +14,7 @@ namespace PoshMcp.Tests.Integration;
 /// <summary>
 /// Integration tests for the complete PowerShell dynamic assembly workflow
 /// </summary>
+[Trait("Category", "Integration")]
 public class IntegrationTests : PowerShellTestBase
 {
     public IntegrationTests(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Integration/McpPromptsIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/McpPromptsIntegrationTests.cs
@@ -18,7 +18,7 @@ namespace PoshMcp.Tests.Integration;
 /// To run only these tests:
 ///   dotnet test --filter "Category=McpPrompts"
 /// </summary>
-[Trait("Category", "McpPrompts")]
+[Trait("Category", "Integration")]
 public class McpPromptsIntegrationTests : PowerShellTestBase, IAsyncLifetime
 {
     private InProcessMcpServer? _server;

--- a/PoshMcp.Tests/Integration/McpResourcesIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/McpResourcesIntegrationTests.cs
@@ -18,7 +18,7 @@ namespace PoshMcp.Tests.Integration;
 /// To run only these tests:
 ///   dotnet test --filter "Category=McpResources"
 /// </summary>
-[Trait("Category", "McpResources")]
+[Trait("Category", "Integration")]
 public class McpResourcesIntegrationTests : PowerShellTestBase, IAsyncLifetime
 {
     private InProcessMcpServer? _server;

--- a/PoshMcp.Tests/Integration/McpServerIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/McpServerIntegrationTests.cs
@@ -20,6 +20,7 @@ namespace PoshMcp.Tests.Integration;
 /// <summary>
 /// Integration tests that run the MCP server in-process and communicate with external clients
 /// </summary>
+[Trait("Category", "Integration")]
 public class ServerWithExternalClient : PowerShellTestBase, IAsyncLifetime
 {
     private InProcessMcpServer? _sharedServer;
@@ -224,6 +225,7 @@ public class ServerWithExternalClient : PowerShellTestBase, IAsyncLifetime
     #endregion
 }
 
+[Trait("Category", "Integration")]
 public class McpServerProcessLifecycleTests : PowerShellTestBase
 {
     public McpServerProcessLifecycleTests(ITestOutputHelper output) : base(output)

--- a/PoshMcp.Tests/Integration/MultiUserIsolationTests.cs
+++ b/PoshMcp.Tests/Integration/MultiUserIsolationTests.cs
@@ -12,6 +12,7 @@ namespace PoshMcp.Tests.Integration;
 /// <summary>
 /// Tests to verify that multiple users get isolated PowerShell runspaces in the web server
 /// </summary>
+[Trait("Category", "Integration")]
 public class MultiUserIsolationTests : PowerShellTestBase, IAsyncLifetime
 {
     private readonly ITestOutputHelper _output;

--- a/PoshMcp.Tests/Integration/OutOfProcessModuleTests.cs
+++ b/PoshMcp.Tests/Integration/OutOfProcessModuleTests.cs
@@ -17,7 +17,7 @@ namespace PoshMcp.Tests.Integration;
 /// Requires pwsh on PATH and vendored modules at integration/Modules/.
 /// Tests skip automatically via <see cref="AzModulesAvailableFactAttribute"/>.
 /// </summary>
-[Trait("Category", "OutOfProcessModules")]
+[Trait("Category", "OutOfProcess")]
 public class OutOfProcessModuleTests
 {
     private readonly ITestOutputHelper _output;

--- a/PoshMcp.Tests/Integration/UnifiedHttpTransportIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/UnifiedHttpTransportIntegrationTests.cs
@@ -12,6 +12,7 @@ using Xunit.Abstractions;
 
 namespace PoshMcp.Tests.Integration;
 
+[Trait("Category", "Http")]
 public class UnifiedHttpTransportIntegrationTests : PowerShellTestBase
 {
     public UnifiedHttpTransportIntegrationTests(ITestOutputHelper output) : base(output)

--- a/PoshMcp.Tests/Unit/AuthenticationConfigurationValidatorTests.cs
+++ b/PoshMcp.Tests/Unit/AuthenticationConfigurationValidatorTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace PoshMcp.Tests.Unit;
 
+[Trait("Category", "Unit")]
 public class AuthenticationConfigurationValidatorTests
 {
     private readonly AuthenticationConfigurationValidator _validator = new();

--- a/PoshMcp.Tests/Unit/AuthenticationServiceExtensionsTests.cs
+++ b/PoshMcp.Tests/Unit/AuthenticationServiceExtensionsTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace PoshMcp.Tests.Unit;
 
+[Trait("Category", "Unit")]
 public class AuthenticationServiceExtensionsTests
 {
     [Fact]

--- a/PoshMcp.Tests/Unit/AuthorizationHelpersTests.cs
+++ b/PoshMcp.Tests/Unit/AuthorizationHelpersTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace PoshMcp.Tests.Unit;
 
+[Trait("Category", "Unit")]
 public class AuthorizationHelpersTests
 {
     [Fact]

--- a/PoshMcp.Tests/Unit/ConfigurationGuidanceToolsTests.cs
+++ b/PoshMcp.Tests/Unit/ConfigurationGuidanceToolsTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace PoshMcp.Tests.Unit;
 
+[Trait("Category", "Unit")]
 public class ConfigurationGuidanceToolsTests
 {
     [Fact]

--- a/PoshMcp.Tests/Unit/ConfigurationHealthCheckTests.cs
+++ b/PoshMcp.Tests/Unit/ConfigurationHealthCheckTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace PoshMcp.Tests.Unit;
 
+[Trait("Category", "Unit")]
 public class ConfigurationHealthCheckTests
 {
     [Fact]

--- a/PoshMcp.Tests/Unit/ConfigureApplicationInsightsTests.cs
+++ b/PoshMcp.Tests/Unit/ConfigureApplicationInsightsTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace PoshMcp.Tests.Unit;
 
+[Trait("Category", "Unit")]
 public class ConfigureApplicationInsightsTests
 {
     private static readonly MethodInfo ConfigureMethod = typeof(PoshMcp.StdioServerHost)

--- a/PoshMcp.Tests/Unit/DescriptionSanitizerTests.cs
+++ b/PoshMcp.Tests/Unit/DescriptionSanitizerTests.cs
@@ -9,6 +9,7 @@ namespace PoshMcp.Tests.Unit;
 /// FR-520 byte-equivalence guarantee depends on: any change here must hold across both
 /// execution paths.
 /// </summary>
+[Trait("Category", "Unit")]
 public class DescriptionSanitizerTests
 {
     [Theory]

--- a/PoshMcp.Tests/Unit/DescriptionSourceMetricsTests.cs
+++ b/PoshMcp.Tests/Unit/DescriptionSourceMetricsTests.cs
@@ -15,6 +15,7 @@ namespace PoshMcp.Tests.Unit;
 /// <c>poshmcp.parameter_description.source</c> emit one sample per
 /// resolution with the FR-583 wire literal in the <c>step</c> tag.
 /// </summary>
+[Trait("Category", "Unit")]
 public class DescriptionSourceMetricsTests : IDisposable
 {
     private readonly McpMetrics _metrics;

--- a/PoshMcp.Tests/Unit/Diagnostics/DoctorDescriptionSourceTests.cs
+++ b/PoshMcp.Tests/Unit/Diagnostics/DoctorDescriptionSourceTests.cs
@@ -13,6 +13,7 @@ namespace PoshMcp.Tests.Unit.Diagnostics;
 /// FR-500 (tool descriptions) and FR-510 (parameter descriptions) MUST surface
 /// the matching <c>descriptionSource</c> wire literal in doctor JSON output.
 /// </summary>
+[Trait("Category", "Unit")]
 public class DoctorDescriptionSourceTests
 {
     private const string TestCommandName = "Get-Doctor";

--- a/PoshMcp.Tests/Unit/DockerRunnerTests.cs
+++ b/PoshMcp.Tests/Unit/DockerRunnerTests.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace PoshMcp.Tests.Unit;
 
+[Trait("Category", "Unit")]
 public class DockerRunnerTests
 {
     [Fact]

--- a/PoshMcp.Tests/Unit/DoctorReportTests.cs
+++ b/PoshMcp.Tests/Unit/DoctorReportTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace PoshMcp.Tests.Unit;
 
+[Trait("Category", "Unit")]
 public class DoctorReportTests
 {
     // ── ComputeStatus ────────────────────────────────────────────────────────

--- a/PoshMcp.Tests/Unit/DoctorTextRendererTests.cs
+++ b/PoshMcp.Tests/Unit/DoctorTextRendererTests.cs
@@ -3,6 +3,7 @@ using Xunit;
 
 namespace PoshMcp.Tests.Unit;
 
+[Trait("Category", "Unit")]
 public class DoctorTextRendererTests
 {
     // ── Banner ───────────────────────────────────────────────────────────────

--- a/PoshMcp.Tests/Unit/FunctionOverrideAuthPropertiesTests.cs
+++ b/PoshMcp.Tests/Unit/FunctionOverrideAuthPropertiesTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace PoshMcp.Tests.Unit;
 
+[Trait("Category", "Unit")]
 public class FunctionOverrideAuthPropertiesTests
 {
     [Fact]

--- a/PoshMcp.Tests/Unit/HealthChecksTests.cs
+++ b/PoshMcp.Tests/Unit/HealthChecksTests.cs
@@ -23,6 +23,7 @@ namespace PoshMcp.Tests.Unit;
 /// - Health checks complete within 500ms (suitable for K8s probes)
 /// - Health check results include meaningful diagnostic data
 /// </summary>
+[Trait("Category", "Unit")]
 public class HealthChecksTests : PowerShellTestBase
 {
     public HealthChecksTests(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Unit/HttpToolFactoryParityTests.cs
+++ b/PoshMcp.Tests/Unit/HttpToolFactoryParityTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace PoshMcp.Tests.Unit;
 
+[Trait("Category", "Unit")]
 public class HttpToolFactoryParityTests
 {
     [Fact]

--- a/PoshMcp.Tests/Unit/McpPrompts/McpPromptConfigurationBindingTests.cs
+++ b/PoshMcp.Tests/Unit/McpPrompts/McpPromptConfigurationBindingTests.cs
@@ -13,6 +13,7 @@ namespace PoshMcp.Tests.Unit.McpPrompts;
 /// These tests compile and pass today using stub POCOs in PoshMcp.Tests.Models.
 /// Once the server implementation PR lands, update to bind against the server-side types.
 /// </summary>
+[Trait("Category", "Unit")]
 public class McpPromptConfigurationBindingTests
 {
     private static IConfiguration BuildConfig(string json)

--- a/PoshMcp.Tests/Unit/McpPrompts/McpPromptsValidatorTests.cs
+++ b/PoshMcp.Tests/Unit/McpPrompts/McpPromptsValidatorTests.cs
@@ -9,6 +9,7 @@ namespace PoshMcp.Tests.Unit.McpPrompts;
 /// Unit tests for McpPromptsValidator — doctor validation checks from Spec 002 User Story 5
 /// (FR-026, FR-027, SC-012).
 /// </summary>
+[Trait("Category", "Unit")]
 public class McpPromptsValidatorTests
 {
     private static readonly string ExistingDir = Path.GetTempPath();

--- a/PoshMcp.Tests/Unit/McpResources/McpResourceConfigurationBindingTests.cs
+++ b/PoshMcp.Tests/Unit/McpResources/McpResourceConfigurationBindingTests.cs
@@ -13,6 +13,7 @@ namespace PoshMcp.Tests.Unit.McpResources;
 /// These tests compile and pass today using stub POCOs in PoshMcp.Tests.Models.
 /// Once the server implementation PR lands, update to bind against the server-side types.
 /// </summary>
+[Trait("Category", "Unit")]
 public class McpResourceConfigurationBindingTests
 {
     private static IConfiguration BuildConfig(string json)

--- a/PoshMcp.Tests/Unit/McpResources/McpResourcesValidatorTests.cs
+++ b/PoshMcp.Tests/Unit/McpResources/McpResourcesValidatorTests.cs
@@ -9,6 +9,7 @@ namespace PoshMcp.Tests.Unit.McpResources;
 /// Unit tests for McpResourcesValidator — doctor validation checks from Spec 002 User Story 5
 /// (FR-026, FR-027, SC-012).
 /// </summary>
+[Trait("Category", "Unit")]
 public class McpResourcesValidatorTests
 {
     private static readonly string ExistingDir = Path.GetTempPath();

--- a/PoshMcp.Tests/Unit/McpToolFactoryV2Tests.cs
+++ b/PoshMcp.Tests/Unit/McpToolFactoryV2Tests.cs
@@ -9,6 +9,7 @@ namespace PoshMcp.Tests.Unit;
 /// <summary>
 /// Unit tests for McpToolFactoryV2 class extracted methods
 /// </summary>
+[Trait("Category", "Unit")]
 public class McpToolFactoryV2Tests : PowerShellTestBase
 {
     public McpToolFactoryV2Tests(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Unit/MetricsTests.cs
+++ b/PoshMcp.Tests/Unit/MetricsTests.cs
@@ -7,6 +7,7 @@ using Xunit.Abstractions;
 
 namespace PoshMcp.Tests.Unit;
 
+[Trait("Category", "Unit")]
 public class MetricsTests
 {
     private readonly ITestOutputHelper _output;

--- a/PoshMcp.Tests/Unit/ModuleDiscoveryStartupOrderingTests.cs
+++ b/PoshMcp.Tests/Unit/ModuleDiscoveryStartupOrderingTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace PoshMcp.Tests.Unit;
 
+[Trait("Category", "Unit")]
 public sealed class ModuleDiscoveryStartupOrderingTests : IDisposable
 {
     private readonly ILoggerFactory _loggerFactory;

--- a/PoshMcp.Tests/Unit/OAuthProxyEndpointsTests.cs
+++ b/PoshMcp.Tests/Unit/OAuthProxyEndpointsTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace PoshMcp.Tests.Unit;
 
+[Trait("Category", "Unit")]
 public class OAuthProxyEndpointsTests
 {
     // ── OAuthProxyConfiguration binding ─────────────────────────────────────

--- a/PoshMcp.Tests/Unit/Observability/LogSanitizerTests.cs
+++ b/PoshMcp.Tests/Unit/Observability/LogSanitizerTests.cs
@@ -3,6 +3,7 @@ using Xunit;
 
 namespace PoshMcp.Tests.Unit.Observability;
 
+[Trait("Category", "Unit")]
 public class LogSanitizerTests
 {
     [Fact]

--- a/PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessCancellationTests.cs
+++ b/PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessCancellationTests.cs
@@ -20,6 +20,7 @@ namespace PoshMcp.Tests.Unit.OutOfProcess;
 /// stop within a bounded time, leave the host healthy for follow-up requests,
 /// and (in Pool/ProcessPool) not block parallel work.
 /// </summary>
+[Trait("Category", "OutOfProcess")]
 public class OutOfProcessCancellationTests
 {
     private static readonly TimeSpan ObservationTimeout = TimeSpan.FromSeconds(15);

--- a/PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessCommandExecutorTests.cs
+++ b/PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessCommandExecutorTests.cs
@@ -17,6 +17,7 @@ namespace PoshMcp.Tests.Unit.OutOfProcess;
 /// Tests construction, static helpers, stub methods (Phase 3/4),
 /// and lifecycle management.
 /// </summary>
+[Trait("Category", "OutOfProcess")]
 public class OutOfProcessCommandExecutorTests
 {
     private readonly ILogger<OutOfProcessCommandExecutor> _logger;

--- a/PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessHostConcurrencyTests.cs
+++ b/PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessHostConcurrencyTests.cs
@@ -22,6 +22,7 @@ namespace PoshMcp.Tests.Unit.OutOfProcess;
 /// serialization errors caused by objects whose CLR type shadows a base-class
 /// member of the same name (e.g. BasicHtmlWebResponseObject's 'Content').
 /// </summary>
+[Trait("Category", "OutOfProcess")]
 public class OutOfProcessHostConcurrencyTests
 {
     [Fact]

--- a/PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessHostTests.cs
+++ b/PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessHostTests.cs
@@ -18,6 +18,7 @@ namespace PoshMcp.Tests.Unit.OutOfProcess;
 /// gracefully no-op when the script cannot be resolved (CI without
 /// build artifacts copied).
 /// </summary>
+[Trait("Category", "OutOfProcess")]
 public class OutOfProcessHostTests
 {
     [Fact]

--- a/PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessSubprocessPoolTests.cs
+++ b/PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessSubprocessPoolTests.cs
@@ -14,6 +14,7 @@ namespace PoshMcp.Tests.Unit.OutOfProcess;
 /// before <c>StartAsync</c>, environment fingerprint stability, and the
 /// <see cref="SubprocessHostMode"/> string detection.
 /// </summary>
+[Trait("Category", "OutOfProcess")]
 public class OutOfProcessSubprocessPoolTests
 {
     [Fact]

--- a/PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessToolAssemblyGeneratorTests.cs
+++ b/PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessToolAssemblyGeneratorTests.cs
@@ -15,6 +15,7 @@ namespace PoshMcp.Tests.Unit.OutOfProcess;
 /// Unit tests for OutOfProcessToolAssemblyGenerator.
 /// Tests IL generation of dynamic methods that delegate to ICommandExecutor.
 /// </summary>
+[Trait("Category", "OutOfProcess")]
 public class OutOfProcessToolAssemblyGeneratorTests
 {
     private readonly Mock<ICommandExecutor> _mockExecutor;

--- a/PoshMcp.Tests/Unit/OutOfProcess/RemoteToolSchemaTests.cs
+++ b/PoshMcp.Tests/Unit/OutOfProcess/RemoteToolSchemaTests.cs
@@ -10,6 +10,7 @@ namespace PoshMcp.Tests.Unit.OutOfProcess;
 /// Unit tests for RemoteToolSchema and RemoteParameterSchema DTOs.
 /// Validates default values, construction, and JSON serialization round-trips.
 /// </summary>
+[Trait("Category", "OutOfProcess")]
 public class RemoteToolSchemaTests
 {
     #region RemoteToolSchema Defaults

--- a/PoshMcp.Tests/Unit/OutOfProcess/RuntimeModeTests.cs
+++ b/PoshMcp.Tests/Unit/OutOfProcess/RuntimeModeTests.cs
@@ -7,6 +7,7 @@ namespace PoshMcp.Tests.Unit.OutOfProcess;
 /// Unit tests for the RuntimeMode enum.
 /// Validates that all expected enum values exist and parsing round-trips correctly.
 /// </summary>
+[Trait("Category", "OutOfProcess")]
 public class RuntimeModeTests
 {
     [Fact]

--- a/PoshMcp.Tests/Unit/OutputTypeTests.cs
+++ b/PoshMcp.Tests/Unit/OutputTypeTests.cs
@@ -12,6 +12,7 @@ namespace PoshMcp.Tests.Unit;
 /// <summary>
 /// Tests for examining PowerShell command OutputType information
 /// </summary>
+[Trait("Category", "Unit")]
 public class OutputTypeTests : PowerShellTestBase
 {
     public OutputTypeTests(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Unit/ParameterSetConsistencyTests.cs
+++ b/PoshMcp.Tests/Unit/ParameterSetConsistencyTests.cs
@@ -32,6 +32,7 @@ namespace PoshMcp.Tests.Unit;
 /// branching on it) would break these tests.
 /// </summary>
 [Trait("Spec", "010")]
+[Trait("Category", "Unit")]
 public sealed class ParameterSetConsistencyTests : PowerShellTestBase
 {
     private readonly HelpAwareToolMetadataSource _resolver = new();

--- a/PoshMcp.Tests/Unit/ParameterTypeTests.cs
+++ b/PoshMcp.Tests/Unit/ParameterTypeTests.cs
@@ -13,6 +13,7 @@ namespace PoshMcp.Tests.Unit;
 /// <summary>
 /// Tests for PowerShell parameter type handling in dynamic assembly generation
 /// </summary>
+[Trait("Category", "Unit")]
 public class ParameterTypeTests : PowerShellTestBase
 {
     public ParameterTypeTests(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Unit/PerformanceConfigurationTests.cs
+++ b/PoshMcp.Tests/Unit/PerformanceConfigurationTests.cs
@@ -14,6 +14,7 @@ namespace PoshMcp.Tests.Unit;
 /// explicit property lists, and configuration validation.
 /// Spec reference: specs/large-result-performance.md sections 3.2, 4.3, 5.1, 5.2
 /// </summary>
+[Trait("Category", "Unit")]
 public class PerformanceConfigurationTests : PowerShellTestBase
 {
     public PerformanceConfigurationTests(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Unit/PowerShellJsonSerializationTests.cs
+++ b/PoshMcp.Tests/Unit/PowerShellJsonSerializationTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace PoshMcp.Tests.Unit;
 
+[Trait("Category", "Unit")]
 public class PowerShellJsonSerializationTests
 {
     [Fact]

--- a/PoshMcp.Tests/Unit/ProgramCliBuildCommandTests.cs
+++ b/PoshMcp.Tests/Unit/ProgramCliBuildCommandTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 namespace PoshMcp.Tests.Unit;
 
 [Collection("TransportSelectionTests")]
+[Trait("Category", "Unit")]
 public class ProgramCliBuildCommandTests
 {
     [Fact]

--- a/PoshMcp.Tests/Unit/ProgramCliConfigCommandsTests.cs
+++ b/PoshMcp.Tests/Unit/ProgramCliConfigCommandsTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 namespace PoshMcp.Tests.Unit;
 
 [Collection("TransportSelectionTests")]
+[Trait("Category", "Unit")]
 public class ProgramCliConfigCommandsTests
 {
     [Fact]

--- a/PoshMcp.Tests/Unit/ProgramCliScaffoldCommandTests.cs
+++ b/PoshMcp.Tests/Unit/ProgramCliScaffoldCommandTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 namespace PoshMcp.Tests.Unit;
 
 [Collection("TransportSelectionTests")]
+[Trait("Category", "Unit")]
 public class ProgramCliScaffoldCommandTests
 {
     [Fact]

--- a/PoshMcp.Tests/Unit/ProgramConfigurationGuidanceToolExposureTests.cs
+++ b/PoshMcp.Tests/Unit/ProgramConfigurationGuidanceToolExposureTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace PoshMcp.Tests.Unit;
 
 [Collection("TransportSelectionTests")]
+[Trait("Category", "Unit")]
 public class ProgramConfigurationGuidanceToolExposureTests
 {
     private const string TroubleshootingToolEnvVar = "POSHMCP_ENABLE_CONFIGURATION_TROUBLESHOOTING_TOOL";

--- a/PoshMcp.Tests/Unit/ProgramDoctorConfigCoverageTests.cs
+++ b/PoshMcp.Tests/Unit/ProgramDoctorConfigCoverageTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace PoshMcp.Tests.Unit;
 
 [Collection("TransportSelectionTests")]
+[Trait("Category", "Unit")]
 public class ProgramDoctorConfigCoverageTests
 {
     [Fact]

--- a/PoshMcp.Tests/Unit/ProgramDoctorToolExposureTests.cs
+++ b/PoshMcp.Tests/Unit/ProgramDoctorToolExposureTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace PoshMcp.Tests.Unit;
 
 [Collection("TransportSelectionTests")]
+[Trait("Category", "Unit")]
 public class ProgramDoctorToolExposureTests
 {
     private const string TroubleshootingToolEnvVar = "POSHMCP_ENABLE_CONFIGURATION_TROUBLESHOOTING_TOOL";

--- a/PoshMcp.Tests/Unit/ProgramTests.cs
+++ b/PoshMcp.Tests/Unit/ProgramTests.cs
@@ -14,6 +14,7 @@ namespace PoshMcp.Tests.Unit;
 /// <summary>
 /// Unit tests for Program class extracted methods
 /// </summary>
+[Trait("Category", "Unit")]
 public class ProgramTests : PowerShellTestBase
 {
     public ProgramTests(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Unit/ProgramTransportSelectionTests.cs
+++ b/PoshMcp.Tests/Unit/ProgramTransportSelectionTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace PoshMcp.Tests.Unit;
 
 [Collection("TransportSelectionTests")]
+[Trait("Category", "Unit")]
 public class ProgramTransportSelectionTests
 {
     private const string TransportEnvVar = "POSHMCP_TRANSPORT";

--- a/PoshMcp.Tests/Unit/RuntimeCachingStateTests.cs
+++ b/PoshMcp.Tests/Unit/RuntimeCachingStateTests.cs
@@ -15,6 +15,7 @@ namespace PoshMcp.Tests.Unit;
 /// for result caching, set via the set-result-caching MCP tool.
 /// Spec reference: specs/large-result-performance.md section 3.6
 /// </summary>
+[Trait("Category", "Unit")]
 public class RuntimeCachingStateTests : PowerShellTestBase
 {
     public RuntimeCachingStateTests(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Unit/ServerSessionAwarePowerShellRunspaceTests.cs
+++ b/PoshMcp.Tests/Unit/ServerSessionAwarePowerShellRunspaceTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace PoshMcp.Tests.Unit;
 
+[Trait("Category", "Unit")]
 public class ServerSessionAwarePowerShellRunspaceTests : IDisposable
 {
     private readonly Mock<IHttpContextAccessor> _mockHttpContextAccessor;

--- a/PoshMcp.Tests/Unit/SimpleAssemblyTests.cs
+++ b/PoshMcp.Tests/Unit/SimpleAssemblyTests.cs
@@ -7,6 +7,7 @@ namespace PoshMcp.Tests.Unit;
 /// <summary>
 /// Simple tests for PowerShell dynamic assembly generation
 /// </summary>
+[Trait("Category", "Unit")]
 public class SimpleAssemblyTests : PowerShellTestBase
 {
     public SimpleAssemblyTests(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/Unit/StdioLoggingConfigurationTests.cs
+++ b/PoshMcp.Tests/Unit/StdioLoggingConfigurationTests.cs
@@ -9,6 +9,7 @@ namespace PoshMcp.Tests.Unit;
 /// <summary>
 /// Unit tests for ResolveLogFilePath — verifies CLI > env > config > null precedence.
 /// </summary>
+[Trait("Category", "Unit")]
 public class StdioLoggingConfigurationTests
 {
     private const string LogFileEnvVar = "POSHMCP_LOG_FILE";

--- a/PoshMcp.Tests/Unit/ToolNameMappingTests.cs
+++ b/PoshMcp.Tests/Unit/ToolNameMappingTests.cs
@@ -9,6 +9,7 @@ namespace PoshMcp.Tests.Unit;
 /// <summary>
 /// Unit tests for tool name to command name conversion
 /// </summary>
+[Trait("Category", "Unit")]
 public class ToolNameMappingTests
 {
     private readonly ITestOutputHelper _output;

--- a/PoshMcp.Tests/Unit/UnserializableTypeTests.cs
+++ b/PoshMcp.Tests/Unit/UnserializableTypeTests.cs
@@ -13,6 +13,7 @@ namespace PoshMcp.Tests.Unit;
 /// Unit tests for PowerShellParameterUtils.IsUnserializableType — verifies that the method
 /// correctly identifies types that cannot be meaningfully represented in a JSON schema.
 /// </summary>
+[Trait("Category", "Unit")]
 public class UnserializableTypeTests
 {
     private readonly ITestOutputHelper _output;

--- a/PoshMcp.Tests/Unit/WinPsCompatProxyTests.cs
+++ b/PoshMcp.Tests/Unit/WinPsCompatProxyTests.cs
@@ -24,6 +24,7 @@ using Xunit.Abstractions;
 
 namespace PoshMcp.Tests.Unit;
 
+[Trait("Category", "Unit")]
 public class WinPsCompatProxyTests
 {
     private readonly ITestOutputHelper _output;

--- a/scripts/add-category-traits.ps1
+++ b/scripts/add-category-traits.ps1
@@ -1,0 +1,293 @@
+# Spec 009 issue #212 — add Category traits to test classes.
+# Inserts [Trait("Category", "<X>")] immediately above each `public class *Tests` line.
+# Idempotent: skips classes that already carry a Category trait.
+# Adds `using Xunit;` to files that lack it.
+
+param(
+    [string]$Root = "$PSScriptRoot\..\PoshMcp.Tests"
+)
+
+$ErrorActionPreference = 'Stop'
+$Root = (Resolve-Path $Root).Path
+
+# Map of test class FullName/SimpleName -> Category.
+# Sourced from honest behavioral audit (see spec 009 FR-401..417).
+# Folder location is a hint, NOT authoritative.
+$catMap = @{
+    # ---------- Unit (no subprocess, no port, no shared temp) ----------
+    'AuthenticationConfigurationValidatorTests'        = 'Unit'
+    'AuthenticationServiceExtensionsTests'             = 'Unit'
+    'AuthorizationHelpersTests'                        = 'Unit'
+    'ConfigurationGuidanceToolsTests'                  = 'Unit'
+    'ConfigurationHealthCheckTests'                    = 'Unit'
+    'ConfigureApplicationInsightsTests'                = 'Unit'
+    'DescriptionSanitizerTests'                        = 'Unit'
+    'DescriptionSourceMetricsTests'                    = 'Unit'
+    'DockerRunnerTests'                                = 'Unit'
+    'DoctorReportTests'                                = 'Unit'
+    'DoctorTextRendererTests'                          = 'Unit'
+    'FunctionOverrideAuthPropertiesTests'              = 'Unit'
+    'HealthChecksTests'                                = 'Unit'
+    'HttpToolFactoryParityTests'                       = 'Unit'
+    'McpToolFactoryV2Tests'                            = 'Unit'
+    'MetricsTests'                                     = 'Unit'
+    'ModuleDiscoveryStartupOrderingTests'              = 'Unit'
+    'OAuthProxyEndpointsTests'                         = 'Unit'
+    'OutputTypeTests'                                  = 'Unit'
+    'ParameterSetConsistencyTests'                     = 'Unit'
+    'ParameterTypeTests'                               = 'Unit'
+    'PerformanceConfigurationTests'                    = 'Unit'
+    'PowerShellJsonSerializationTests'                 = 'Unit'
+    'ProgramCliBuildCommandTests'                      = 'Unit'
+    'ProgramCliConfigCommandsTests'                    = 'Unit'
+    'ProgramCliScaffoldCommandTests'                   = 'Unit'
+    'ProgramConfigurationGuidanceToolExposureTests'    = 'Unit'
+    'ProgramDoctorConfigCoverageTests'                 = 'Unit'
+    'ProgramDoctorToolExposureTests'                   = 'Unit'
+    'ProgramTests'                                     = 'Unit'
+    'ProgramTransportSelectionTests'                   = 'Unit'
+    'RuntimeCachingStateTests'                         = 'Unit'
+    'ServerSessionAwarePowerShellRunspaceTests'        = 'Unit'
+    'SimpleAssemblyTests'                              = 'Unit'
+    'StdioLoggingConfigurationTests'                   = 'Unit'
+    'ToolNameMappingTests'                             = 'Unit'
+    'UnserializableTypeTests'                          = 'Unit'
+    'WinPsCompatProxyTests'                            = 'Unit'
+    'DoctorDescriptionSourceTests'                     = 'Unit'
+    'McpPromptConfigurationBindingTests'               = 'Unit'
+    'McpPromptsValidatorTests'                         = 'Unit'
+    'McpResourceConfigurationBindingTests'             = 'Unit'
+    'McpResourcesValidatorTests'                       = 'Unit'
+    'LogSanitizerTests'                                = 'Unit'
+
+    # ---------- OutOfProcess (exercises pwsh subprocess via OOP host) ----------
+    'OutOfProcessCancellationTests'                    = 'OutOfProcess'
+    'OutOfProcessCommandExecutorTests'                 = 'OutOfProcess'
+    'OutOfProcessHostConcurrencyTests'                 = 'OutOfProcess'
+    'OutOfProcessHostTests'                            = 'OutOfProcess'
+    'OutOfProcessSubprocessPoolTests'                  = 'OutOfProcess'
+    'OutOfProcessToolAssemblyGeneratorTests'           = 'OutOfProcess'
+    'RemoteToolSchemaTests'                            = 'OutOfProcess'
+    'RuntimeModeTests'                                 = 'OutOfProcess'
+    'OutOfProcessIntegrationTests'                     = 'OutOfProcess'
+    'OutOfProcessMcpRoundTripTests'                    = 'OutOfProcess'
+    'OutOfProcessModuleTests'                          = 'OutOfProcess'
+    'OutOfProcessPoolHostIntegrationTests'             = 'OutOfProcess'
+    'OutOfProcessSubprocessPoolIntegrationTests'       = 'OutOfProcess'
+
+    # ---------- Http (binds TCP port / uses HTTP transport) ----------
+    'UnifiedHttpTransportIntegrationTests'             = 'Http'
+    'ApplicationInsightsIntegrationTests'              = 'Http'
+
+    # ---------- Azure (requires Azure credentials) ----------
+    'AzureDeploymentIntegrationTests'                  = 'Azure'
+
+    # ---------- Integration (resource-using, none of the specialised buckets) ----------
+    'CommandLineTests'                                 = 'Integration'
+    'ConfigurationGuidanceIntegrationTests'            = 'Integration'
+    'DeployScriptConfigurationPrecedenceTests'         = 'Integration'
+    'IntegrationTests'                                 = 'Integration'
+    'McpPromptsIntegrationTests'                       = 'Integration'
+    'McpResourcesIntegrationTests'                     = 'Integration'
+    'McpServerIntegrationTests'                        = 'Integration'
+    'McpServerProcessLifecycleTests'                   = 'Integration'
+    'MultiUserIsolationTests'                          = 'Integration'
+    'ToolDescriptionParityTests'                       = 'Integration'
+    'ToolDescriptionRegressionTests'                   = 'Integration'
+    # Functional/StdioLoggingTests uses InProcessMcpServer (subprocess) -> Integration per FR-416.
+    'StdioLoggingTests'                                = 'Integration'
+
+    # ---------- Functional (multi-area, in-process PowerShell only) ----------
+    'McpPromptsTests'                                  = 'Functional'
+    'McpResourcesTests'                                = 'Functional'
+    'SwitchParameterMcpRoundTripTests'                 = 'Functional'
+    'WinPsCompatProxyMethodGenerationTests'            = 'Functional'
+    'ConfigurationReloadTests'                         = 'Functional'
+    'DynamicReloadToolsFeatureFlagTests'               = 'Functional'
+    'EndToEndDynamicReloadToolsTests'                  = 'Functional'
+    'CorrelationIdGenerationTests'                     = 'Functional'
+    'CorrelationIdLoggingTests'                        = 'Functional'
+    'CorrelationIdMiddlewareTests'                     = 'Functional'
+    'CorrelationIdPropagationTests'                    = 'Functional'
+    'ShouldFilterCachedResultsTest'                    = 'Functional'
+    'ShouldReturnNullWhenInvalidScriptTest'            = 'Functional'
+    'ShouldReturnNullWhenNoCacheTest'                  = 'Functional'
+    'ShouldCreateParameterSetSpecificMethodsTest'      = 'Functional'
+    'ShouldCreateValidAssemblyTest'                    = 'Functional'
+    'ShouldIncludeAllUtilityMethodsTest'               = 'Functional'
+    'ShouldIncludeFilterUtilityMethodTest'             = 'Functional'
+    'ShouldIncludePhase3FrameworkParametersTest'       = 'Functional'
+    'ShouldIncludeSortUtilityMethodsTest'              = 'Functional'
+    'ShouldReturnMethodsForCommandsTest'               = 'Functional'
+    'ShouldReturnValidInstanceTest'                    = 'Functional'
+    'ShouldReturnNullTest'                             = 'Functional'  # GetLastCommandOutput + SortLastCommandOutput
+    'ShouldFilterCorrectlyWithExcludePatternsTest'     = 'Functional'
+    'ShouldHandleNonExistentFunctionGracefullyTest'    = 'Functional'
+    'ShouldHaveEmptyDefaultValuesTest'                 = 'Functional'
+    'ShouldParseJsonFileCorrectlyTest'                 = 'Functional'
+    'ShouldReturnEmptyListWithEmptyConfigurationTest'  = 'Functional'
+    'ShouldReturnToolsWithValidConfigurationTest'      = 'Functional'
+    'ShouldThrowExceptionWithInvalidJsonTest'          = 'Functional'
+    'ShouldThrowExceptionWithMissingFileTest'          = 'Functional'
+    'ShouldWorkWithConfigurationToToolsListIntegrationTest' = 'Functional'
+    'ShouldWorkWithDefaultParameterlessOverloadTest'   = 'Functional'
+    'ShouldBeCallableDirectlyTest'                     = 'Functional'
+    'ShouldApplyPhase3PropertyFilteringTest'           = 'Functional'
+    'ShouldCacheResultsTest'                           = 'Functional'
+    'ShouldHandleGetProcessSerializationTest'          = 'Functional'
+    'ShouldHandleInvalidCommandTest'                   = 'Functional'
+    'ShouldHandleValidCommandTest'                     = 'Functional'
+    'ShouldOverwritePreviousCacheTest'                 = 'Functional'
+    'WithParametersTest'                               = 'Functional'
+    'ShouldHandleGetChildItemCorrectlyTest'            = 'Functional'
+    'ShouldReturnObjectArrayTest'                      = 'Functional'
+    'ShouldSortCachedResultsTest'                      = 'Functional'
+    # Partial-class containers: tagged on the *Shared.cs file only.
+    'SetupTests'                                       = 'Functional'
+    'ExecutionTests'                                   = 'Functional'
+    'GeneratedInstance'                                = 'Functional'  # tagged in UtilityMethodsShared.cs
+    'GeneratedMethod'                                  = 'Functional'  # tagged in TypeTestsShared.cs
+    # Partial without Shared.cs — tagged in the alphabetically-first file.
+    'FilterCachedResults'                              = 'Functional'  # tagged in ShouldFilterCachedResultsTest.cs
+    # Single-file classes whose name does NOT match the file basename.
+    'GetLastCommandResult'                             = 'Functional'
+    'ShouldApplyPhase3PropertyFiltering'               = 'Functional'
+    'CacheResults'                                     = 'Functional'
+    'HandleGetProcessSerialization'                    = 'Functional'
+    'InvalidCommand'                                   = 'Functional'
+    'ValidCommand'                                     = 'Functional'
+    'OverwriteCache'                                   = 'Functional'
+    'ExecutePowerShellCommandWithParameters'           = 'Functional'
+    # SortLastCommandOutput\ShouldSortCachedResultsTest.cs declares `Output_Test` (legacy name).
+    'Output_Test'                                      = 'Functional'
+}
+
+# Partial classes without a *Shared.cs — designate the canonical owner file.
+$partialOwner = @{
+    'FilterCachedResults' = 'ShouldFilterCachedResultsTest.cs'
+}
+
+$counts = @{}
+$tagged = @()
+$skipped = @()
+$unknown = @()
+
+$files = Get-ChildItem -Path $Root -Recurse -Filter '*.cs' |
+    Where-Object {
+        $_.FullName -notmatch '\\(bin|obj|TestResults)\\' -and
+        $_.Name -ne 'AssemblyInfo.cs'
+    }
+
+foreach ($file in $files) {
+    $rel = $file.FullName.Substring($Root.Length + 1)
+    $text = Get-Content -Raw -LiteralPath $file.FullName
+    $orig = $text
+
+    # Find all `public ... class FooTests` declarations (handles `sealed`, generics).
+    $pattern = '(?m)^(?<indent>[ \t]*)public\s+(?<modifiers>(?:sealed\s+|static\s+|abstract\s+|partial\s+)*)class\s+(?<name>\w+)(?<rest>[\s\S]*?\{)'
+    $classMatches = [regex]::Matches($text, $pattern)
+
+    if ($classMatches.Count -eq 0) { continue }
+
+    # Process matches in reverse so earlier offsets stay valid.
+    $newText = $text
+    for ($i = $classMatches.Count - 1; $i -ge 0; $i--) {
+        $m = $classMatches[$i]
+        $name = $m.Groups['name'].Value
+        $isPartial = $m.Groups['modifiers'].Value -match '\bpartial\b'
+        # Partial classes accept [Trait] on only ONE declaration.
+        # Default policy: tag the *Shared.cs canonical partial.
+        # Exception: if $partialOwner names a specific file, only tag in that file.
+        if ($isPartial) {
+            if ($partialOwner.ContainsKey($name)) {
+                if ($file.Name -ne $partialOwner[$name]) { continue }
+            } elseif (-not $file.Name.EndsWith('Shared.cs')) {
+                continue
+            }
+        }
+        # Anything in catMap is fair game; class names that don't end in `Test`/`Tests`
+        # (e.g. `CacheResults`, `Output_Test`) are still test classes by other criteria.
+        if (-not $catMap.ContainsKey($name)) {
+            if ($name -notmatch 'Shared$') {
+                $unknown += "$rel : class $name"
+            }
+            continue
+        }
+
+        $category = $catMap[$name]
+        $indent = $m.Groups['indent'].Value
+        $startLine = $m.Index
+
+        # Walk backwards to find the start of the contiguous attribute/comment/doc block
+        # immediately preceding the class declaration.
+        $blockStart = $startLine
+        $lines = $newText.Substring(0, $startLine).Split("`n")
+        $idx = $lines.Length - 1
+        # Track lines that immediately precede the class decl and are part of its attribute/doc cluster.
+        for ($j = $idx; $j -ge 0; $j--) {
+            $line = $lines[$j].TrimStart()
+            if ($line.StartsWith('[') -or $line.StartsWith('///') -or $line.StartsWith('//')) {
+                continue
+            }
+            if ($line -eq '') { continue }  # allow blank lines inside the cluster (rare)
+            $idx = $j + 1
+            break
+        }
+        if ($j -lt 0) { $idx = 0 }
+
+        # Build offset of the attribute-cluster start.
+        $clusterStartOffset = 0
+        for ($k = 0; $k -lt $idx; $k++) {
+            $clusterStartOffset += $lines[$k].Length + 1  # +1 for the \n we split on
+        }
+
+        $cluster = $newText.Substring($clusterStartOffset, $startLine - $clusterStartOffset)
+        # Strip /// doc-comment lines and // line comments so a `[Trait("Category", ...)]`
+        # mentioned inside a docstring doesn't trip the "already tagged" guard.
+        $clusterCode = ($cluster -split "`n" |
+            Where-Object { $_.TrimStart() -notmatch '^(///|//)' }) -join "`n"
+        if ($clusterCode -match '\[Trait\s*\(\s*"Category"') {
+            $skipped += "$rel : $name (already tagged)"
+            continue
+        }
+
+        $traitLine = "$indent[Trait(`"Category`", `"$category`")]`r`n"
+        $newText = $newText.Substring(0, $startLine) + $traitLine + $newText.Substring($startLine)
+        $tagged += "$rel : $name -> $category"
+        if (-not $counts.ContainsKey($category)) { $counts[$category] = 0 }
+        $counts[$category]++
+    }
+
+    if ($newText -ne $orig) {
+        # Ensure `using Xunit;` is present (Trait lives in Xunit namespace).
+        if ($newText -notmatch '(?m)^using\s+Xunit\s*;') {
+            # Insert after the last `using` line, or at the top.
+            $usingMatches = [regex]::Matches($newText, '(?m)^using\s[^\r\n]+;\r?\n')
+            if ($usingMatches.Count -gt 0) {
+                $last = $usingMatches[$usingMatches.Count - 1]
+                $insertAt = $last.Index + $last.Length
+                $newText = $newText.Substring(0, $insertAt) + "using Xunit;`r`n" + $newText.Substring($insertAt)
+            } else {
+                $newText = "using Xunit;`r`n" + $newText
+            }
+        }
+
+        Set-Content -LiteralPath $file.FullName -Value $newText -NoNewline
+    }
+}
+
+Write-Host ""
+Write-Host "=== TAGGED ===" -ForegroundColor Green
+$tagged | ForEach-Object { Write-Host "  $_" }
+Write-Host ""
+Write-Host "=== SKIPPED (already tagged) ===" -ForegroundColor Yellow
+$skipped | ForEach-Object { Write-Host "  $_" }
+Write-Host ""
+Write-Host "=== UNKNOWN (no entry in catMap) ===" -ForegroundColor Red
+$unknown | ForEach-Object { Write-Host "  $_" }
+Write-Host ""
+Write-Host "=== COUNTS ===" -ForegroundColor Cyan
+$counts.GetEnumerator() | Sort-Object Name | ForEach-Object {
+    Write-Host ("  {0,-15} {1}" -f $_.Key, $_.Value)
+}
+Write-Host ("  {0,-15} {1}" -f 'TOTAL', ($counts.Values | Measure-Object -Sum).Sum)


### PR DESCRIPTION
Closes #212

Adds class-level `[Trait("Category", "X")]` to every test class in `PoshMcp.Tests`, using **only** the six canonical categories defined by Spec 009. **Honest tagging only** — no test reclassification (deferred to #213).

## Categories applied (FR-400, FR-406)

| Category | Tests | Notes |
|---|---:|---|
| `Unit` | 424 | In-process, no I/O, no subprocess |
| `Integration` | 71 | In-process MCP server with external client, prompts/resources, tool description parity, command-line, multi-user, etc. |
| `OutOfProcess` | 161 | Subprocess `pwsh` host (`OutOfProcessHost`, pool, modules) |
| `Http` | 4 | HTTP transport integration |
| `Azure` | 3 | Azure deployment integration |
| `Functional` | 124 | `PowerShellTestBase` + isolated runspace, command execution, generated assemblies, return-type, etc. |

Counts are **deterministic across 3 back-to-back runs** of `dotnet test --filter Category=<X> --no-build --list-tests` (FR-415).

## FR-417 — Default-bucket policy

Per FR-417, the default bucket for any untagged test **MUST NOT be `Unit`**. The policy is documented in [`PoshMcp.Tests/AssemblyInfo.cs`](PoshMcp.Tests/AssemblyInfo.cs):

> Untagged tests fall into **`Integration`** by convention — never `Unit` — so an oversight cannot silently inflate the unit-test signal.

A full TESTING.md write-up is out of scope here (#214).

## Pre-existing non-canonical class-level traits replaced

Three class-level traits used non-canonical category values; replaced to canonical:

- `Integration/McpPromptsIntegrationTests.cs`: `McpPrompts` → `Integration`
- `Integration/McpResourcesIntegrationTests.cs`: `McpResources` → `Integration`
- `Integration/OutOfProcessModuleTests.cs`: `OutOfProcessModules` → `OutOfProcess`

## Out of scope (follow-up)

Method-level non-canonical traits remain and will be addressed in #213/#214:

- `Functional/McpPromptsTests.cs`, `Functional/McpResourcesTests.cs`: many `[Trait("Category", "RequiresImplementation")]`
- `Integration/AzureDeploymentIntegrationTests.cs`: method-level `Docker` / `Integration` / `Azure`
- `Integration/OutOfProcessModuleTests.cs`: 6 method-level `OutOfProcessModules`

## Tooling

`scripts/add-category-traits.ps1` is included as a one-shot, idempotent audit/tag tool. It handles partial classes (only tags the declaration in `*Shared.cs` or the explicitly-mapped owner file), strips doc comments before "already tagged" checks, and refuses to tag classes not in its category map.

## Verification

```
Build succeeded.
    0 Error(s)
Unit           424
Integration    71
OutOfProcess   161
Http           4
Azure          3
Functional     124
TOTAL ALL: 784
```

Total tagged (with overlaps from method-level traits): 787 ≥ 784 = full class-level coverage.

---

**Spec FRs covered:** FR-400, FR-406, FR-415, FR-417
**Spec FRs deferred:** FR-401..FR-405 (#213 reclassification), TESTING.md (#214)
