### PR TITLE
ci(009): add flake-rate measurement workflow

### DIFF
--- a/.github/workflows/flake-rate.yml
+++ b/.github/workflows/flake-rate.yml
@@ -1,0 +1,345 @@
+name: Flake Rate Measurement
+
+# Spec 009 (issue #216 / FR-418, supports FR-405 and SC-105):
+# Re-runs the phased test suite N times back-to-back on a clean runner and
+# aggregates the per-test failure counts into a single human-readable
+# flake-rate summary. Triggered nightly on main and on demand.
+#
+# Phasing matches `.github/workflows/ci.yml` (PR #252 / issue #215). If that
+# workflow has not landed yet, this workflow still runs — it owns its own
+# phased sequence and does not depend on `ci.yml` being present. If #252 is
+# in flight on a different branch, both workflows can co-exist; this one is
+# the source of truth for flake-rate measurement only.
+#
+# Azure phase is intentionally excluded:
+#   - Scheduled / on-demand runs do not have Azure credentials wired
+#     (per spec 009 Non-Goals — credentialed CI for Azure is deferred).
+#   - Azure tests skip-when-no-creds, so including the phase would just
+#     add noise without adding signal.
+
+on:
+  workflow_dispatch:
+    inputs:
+      runs:
+        description: 'Number of suite repetitions (default 5).'
+        required: false
+        default: '5'
+        type: string
+  schedule:
+    # Nightly at 07:00 UTC. Off-peak vs. typical maintainer working hours
+    # so a long measurement run does not contend with on-demand CI.
+    - cron: '0 7 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  measure-flake-rate:
+    runs-on: ubuntu-latest
+
+    # RUN_COUNT defaults to 5 for the nightly schedule; workflow_dispatch
+    # overrides via the `runs` input. The aggregator parses whatever
+    # iteration directories actually exist, so a partial run (e.g. one
+    # iteration crashed early) still produces a usable summary.
+    env:
+      RUN_COUNT: ${{ github.event.inputs.runs || '5' }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.x
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+
+    # ------------------------------------------------------------------
+    # Repetition loop.
+    #
+    # One bash loop runs RUN_COUNT iterations. Each iteration runs the
+    # same phased sequence as ci.yml (Unit -> Integration -> OutOfProcess
+    # -> Http -> Functional). Per-iteration TRX files land in
+    # `flake-runs/run-${i}/` so the aggregator can attribute every result
+    # to the iteration it came from.
+    #
+    # `set +e` is critical: a phase failing in iteration 3 must NOT skip
+    # iterations 4 and 5 — the whole point of the workflow is to measure
+    # flakes across ALL iterations. We capture per-phase exit codes into
+    # iteration-scoped status files so the aggregator can report which
+    # phases failed in which run, but the loop itself never short-circuits.
+    # ------------------------------------------------------------------
+    - name: Run phased suite N times
+      shell: bash
+      run: |
+        set +e
+        mkdir -p flake-runs
+        echo "Running suite ${RUN_COUNT} times."
+        for i in $(seq 1 "${RUN_COUNT}"); do
+          out="flake-runs/run-${i}"
+          mkdir -p "${out}"
+          echo "::group::Iteration ${i} of ${RUN_COUNT}"
+
+          dotnet test --no-build --configuration Release \
+            --filter "Category=Unit" \
+            --logger "trx;LogFileName=phase-unit.trx" \
+            --results-directory "${out}"
+          echo "unit=$?" >> "${out}/exit-codes.txt"
+
+          dotnet test --no-build --configuration Release \
+            --filter "Category=Integration" \
+            --logger "trx;LogFileName=phase-integration.trx" \
+            --results-directory "${out}"
+          echo "integration=$?" >> "${out}/exit-codes.txt"
+
+          dotnet test --no-build --configuration Release \
+            --filter "Category=OutOfProcess" \
+            --logger "trx;LogFileName=phase-outofprocess.trx" \
+            --results-directory "${out}"
+          echo "outofprocess=$?" >> "${out}/exit-codes.txt"
+
+          dotnet test --no-build --configuration Release \
+            --filter "Category=Http" \
+            --logger "trx;LogFileName=phase-http.trx" \
+            --results-directory "${out}"
+          echo "http=$?" >> "${out}/exit-codes.txt"
+
+          dotnet test --no-build --configuration Release \
+            --filter "Category=Functional" \
+            --logger "trx;LogFileName=phase-functional.trx" \
+            --results-directory "${out}"
+          echo "functional=$?" >> "${out}/exit-codes.txt"
+
+          echo "::endgroup::"
+        done
+        # Surface exit code 0 to the loop step itself — failures are
+        # captured in exit-codes.txt and the TRX results, not via the
+        # shell exit code. The aggregator decides whether to fail the job.
+        exit 0
+
+    # ------------------------------------------------------------------
+    # Aggregator.
+    #
+    # PowerShell, because (a) this repo lives in pwsh land and (b)
+    # `Select-Xml` is a clean way to walk TRX without dragging in a
+    # third-party parser. The summary is markdown rather than JSON
+    # because the primary consumer is a human looking at the workflow
+    # run page (we append it to $GITHUB_STEP_SUMMARY).
+    #
+    # Output: flake-rate-summary.md
+    #   - Run metadata (commit SHA, runner OS, .NET SDK, RUN_COUNT,
+    #     start/end timestamps inferred from TRX).
+    #   - Aggregate flake rate (total flaky test instances / total test
+    #     runs across iterations).
+    #   - Per-test failure-count table for any test that failed at least
+    #     once across the N iterations.
+    #   - Per-iteration phase exit codes (so a fully-failed iteration
+    #     stands out from a partially-flaky one).
+    # ------------------------------------------------------------------
+    - name: Aggregate flake rate
+      if: always()
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $runRoot = Join-Path $PWD 'flake-runs'
+        $summary = Join-Path $PWD 'flake-rate-summary.md'
+
+        if (-not (Test-Path $runRoot)) {
+          @"
+        # Flake Rate Summary
+
+        No iterations executed. The repetition step did not produce a
+        ``flake-runs/`` directory. See the workflow log for the failure.
+        "@ | Set-Content -Path $summary -Encoding utf8
+          return
+        }
+
+        # Iteration directories are run-1, run-2, ... — sort numerically
+        # so the per-iteration table reads in execution order, not
+        # lexicographic order (run-10 vs run-2).
+        $iterDirs = Get-ChildItem -Path $runRoot -Directory |
+          Where-Object { $_.Name -match '^run-(\d+)$' } |
+          Sort-Object { [int]($_.Name -replace '^run-','') }
+
+        # Walk every TRX file; xUnit emits a UnitTestResult element per
+        # test invocation with attributes testName, outcome, duration.
+        # We only care about outcome != 'Passed' for flake counting.
+        # 'Passed' / 'Failed' / 'NotExecuted' are the values seen in
+        # practice; treat anything other than 'Passed' as a non-pass and
+        # break it out by outcome in the per-test table for diagnosis.
+        $perTest = @{}        # testName -> @{ Failed = N; NotExecuted = N; Iterations = @() }
+        $totalRuns = 0
+        $totalNonPass = 0
+        $iterPhaseStatus = @{}  # iter -> phase -> exitCode
+
+        foreach ($iter in $iterDirs) {
+          $iterName = $iter.Name
+          $iterPhaseStatus[$iterName] = @{}
+
+          $exitFile = Join-Path $iter.FullName 'exit-codes.txt'
+          if (Test-Path $exitFile) {
+            foreach ($line in Get-Content $exitFile) {
+              if ($line -match '^([^=]+)=(\d+)$') {
+                $iterPhaseStatus[$iterName][$matches[1]] = [int]$matches[2]
+              }
+            }
+          }
+
+          $trxFiles = Get-ChildItem -Path $iter.FullName -Filter '*.trx' -ErrorAction SilentlyContinue
+          foreach ($trx in $trxFiles) {
+            try {
+              [xml]$doc = Get-Content -Path $trx.FullName -Raw
+            }
+            catch {
+              Write-Host "Could not parse $($trx.FullName): $_"
+              continue
+            }
+
+            # TRX uses a default namespace; walk via SelectNodes with
+            # an XmlNamespaceManager rather than dotted property access
+            # (which silently returns nothing under default namespaces).
+            $ns = New-Object System.Xml.XmlNamespaceManager($doc.NameTable)
+            $ns.AddNamespace('t', 'http://microsoft.com/schemas/VisualStudio/TeamTest/2010')
+
+            $results = $doc.SelectNodes('//t:UnitTestResult', $ns)
+            foreach ($r in $results) {
+              $name = $r.GetAttribute('testName')
+              $outcome = $r.GetAttribute('outcome')
+              if (-not $name) { continue }
+              $totalRuns++
+              if ($outcome -ne 'Passed') {
+                $totalNonPass++
+                if (-not $perTest.ContainsKey($name)) {
+                  $perTest[$name] = @{
+                    Failed = 0
+                    NotExecuted = 0
+                    Other = 0
+                    Iterations = New-Object System.Collections.Generic.List[string]
+                  }
+                }
+                switch ($outcome) {
+                  'Failed'      { $perTest[$name].Failed++ }
+                  'NotExecuted' { $perTest[$name].NotExecuted++ }
+                  default       { $perTest[$name].Other++ }
+                }
+                if (-not $perTest[$name].Iterations.Contains($iterName)) {
+                  $perTest[$name].Iterations.Add($iterName) | Out-Null
+                }
+              }
+            }
+          }
+        }
+
+        $iterCount = $iterDirs.Count
+        $sha = $env:GITHUB_SHA
+        $ref = $env:GITHUB_REF
+        $runner = "$($env:RUNNER_OS) $($env:RUNNER_ARCH)"
+        $runId = $env:GITHUB_RUN_ID
+        $runUrl = if ($env:GITHUB_SERVER_URL -and $env:GITHUB_REPOSITORY -and $runId) {
+          "$($env:GITHUB_SERVER_URL)/$($env:GITHUB_REPOSITORY)/actions/runs/$runId"
+        } else { '(not set)' }
+        $dotnet = (& dotnet --version) 2>$null
+        $now = (Get-Date).ToUniversalTime().ToString('u')
+
+        # Aggregate flake rate is non-pass-instances / total-test-runs.
+        # This intentionally counts repeated failures of the same test
+        # in different iterations as separate flake instances — that is
+        # the signal we want (one test failing 3/5 is worse than three
+        # tests each failing 1/5).
+        $rate = if ($totalRuns -gt 0) {
+          '{0:N4} ({1}/{2})' -f ($totalNonPass / $totalRuns), $totalNonPass, $totalRuns
+        } else { 'n/a (no test results parsed)' }
+
+        $sb = New-Object System.Text.StringBuilder
+        [void]$sb.AppendLine('# Flake Rate Summary')
+        [void]$sb.AppendLine()
+        [void]$sb.AppendLine('| Field | Value |')
+        [void]$sb.AppendLine('|---|---|')
+        [void]$sb.AppendLine("| Generated (UTC) | $now |")
+        [void]$sb.AppendLine("| Commit | ``$sha`` |")
+        [void]$sb.AppendLine("| Ref | ``$ref`` |")
+        [void]$sb.AppendLine("| Runner | $runner |")
+        [void]$sb.AppendLine("| .NET SDK | $dotnet |")
+        [void]$sb.AppendLine("| Iterations completed | $iterCount of $env:RUN_COUNT |")
+        [void]$sb.AppendLine("| Total test invocations | $totalRuns |")
+        [void]$sb.AppendLine("| Total non-pass invocations | $totalNonPass |")
+        [void]$sb.AppendLine("| Aggregate flake rate | $rate |")
+        [void]$sb.AppendLine("| Workflow run | $runUrl |")
+        [void]$sb.AppendLine()
+
+        if ($perTest.Count -eq 0) {
+          [void]$sb.AppendLine('## Per-test results')
+          [void]$sb.AppendLine()
+          [void]$sb.AppendLine('No flaky tests observed across all iterations.')
+        } else {
+          [void]$sb.AppendLine('## Per-test failure counts')
+          [void]$sb.AppendLine()
+          [void]$sb.AppendLine("Tests that did not pass in at least one of the $iterCount iterations.")
+          [void]$sb.AppendLine('Sorted by total non-pass count, highest first.')
+          [void]$sb.AppendLine()
+          [void]$sb.AppendLine('| Test | Failed | NotExecuted | Other | Total / Iterations | Iterations affected |')
+          [void]$sb.AppendLine('|---|---:|---:|---:|---:|---|')
+
+          $ranked = $perTest.GetEnumerator() | Sort-Object {
+            -([int]$_.Value.Failed + [int]$_.Value.NotExecuted + [int]$_.Value.Other)
+          }
+          foreach ($entry in $ranked) {
+            $name = $entry.Key
+            $v = $entry.Value
+            $total = $v.Failed + $v.NotExecuted + $v.Other
+            $iters = ($v.Iterations | Sort-Object { [int]($_ -replace '^run-','') }) -join ', '
+            [void]$sb.AppendLine("| ``$name`` | $($v.Failed) | $($v.NotExecuted) | $($v.Other) | $total / $iterCount | $iters |")
+          }
+        }
+
+        [void]$sb.AppendLine()
+        [void]$sb.AppendLine('## Per-iteration phase exit codes')
+        [void]$sb.AppendLine()
+        [void]$sb.AppendLine('Exit code 0 = all tests in the phase passed; non-zero = at least one failure.')
+        [void]$sb.AppendLine('A fully red iteration (all phases non-zero) suggests an environmental issue;')
+        [void]$sb.AppendLine('a single phase flicking red across iterations is the classic flake signature.')
+        [void]$sb.AppendLine()
+        [void]$sb.AppendLine('| Iteration | Unit | Integration | OutOfProcess | Http | Functional |')
+        [void]$sb.AppendLine('|---|---:|---:|---:|---:|---:|')
+        foreach ($iter in $iterDirs) {
+          $name = $iter.Name
+          $p = $iterPhaseStatus[$name]
+          $u = if ($p.ContainsKey('unit'))         { $p['unit'] }         else { '-' }
+          $i = if ($p.ContainsKey('integration'))  { $p['integration'] }  else { '-' }
+          $o = if ($p.ContainsKey('outofprocess')) { $p['outofprocess'] } else { '-' }
+          $h = if ($p.ContainsKey('http'))         { $p['http'] }         else { '-' }
+          $f = if ($p.ContainsKey('functional'))   { $p['functional'] }   else { '-' }
+          [void]$sb.AppendLine("| $name | $u | $i | $o | $h | $f |")
+        }
+
+        [void]$sb.AppendLine()
+        [void]$sb.AppendLine('---')
+        [void]$sb.AppendLine()
+        [void]$sb.AppendLine('Spec 009 / FR-418. The `flake-runs/` artifact contains the raw TRX')
+        [void]$sb.AppendLine('files for every iteration if you need to drill into a specific failure.')
+
+        $sb.ToString() | Set-Content -Path $summary -Encoding utf8
+
+        # Mirror the summary into the workflow run page so reviewers do
+        # not have to download the artifact for the common case.
+        if ($env:GITHUB_STEP_SUMMARY) {
+          Get-Content -Path $summary -Raw | Add-Content -Path $env:GITHUB_STEP_SUMMARY -Encoding utf8
+        }
+
+    - name: Upload flake-rate summary
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: flake-rate-summary
+        path: flake-rate-summary.md
+
+    - name: Upload raw flake runs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: flake-runs-raw
+        path: flake-runs/

--- a/.squad/agents/amy/history.md
+++ b/.squad/agents/amy/history.md
@@ -131,3 +131,15 @@ To find them quickly next time: `git grep -n "<old-version>" -- ':!docs/release-
 - **HARD STOP held:** No tag created or pushed. Release process requires CI green before tagging; Steven (or whoever returns) will run `git tag -a v0.13.0 -m "v0.13.0"` followed by `git push origin v0.13.0` once CI on a2b9c3e passes.
 - Marquee theme for v0.13.0 (per CHANGELOG): Help-aware tool descriptions (spec 010) — in-process and OOP byte-identical schemas, FR-500/FR-510/FR-540, `IToolMetadataSource` seam, doctor `descriptionSource` reporting, OTel counters, parity tests, cold-start gates. Includes fixes for SwitchParameter round-trip (#222), parameter descriptions on inputSchema (#248), and `HelpAwareToolMetadataSource` as default (#250). No breaking API changes.
 - Process pattern reaffirmed: explicit-path `git add` only, no `-A` / no `--force`, push to main only, tag only after CI green.
+
+## Learnings — 2026-05-14 (#216 / spec 009 FR-418)
+
+- Authored `.github/workflows/flake-rate.yml`: separate workflow (cleaner than bolting onto `ci.yml`), triggers `workflow_dispatch` (with `runs` input, default 5) + nightly `schedule` (cron `0 7 * * *`).
+- Mirrors PR #252 phasing exactly (Unit/Integration/OutOfProcess/Http/Functional). Azure phase intentionally excluded — scheduled runs have no creds, would skip silently.
+- Loop pattern: bash `for i in $(seq 1 RUN_COUNT)` with `set +e` so a flaky phase in iteration 3 does NOT short-circuit iterations 4 and 5. Per-phase exit codes captured into `flake-runs/run-{i}/exit-codes.txt`; loop step always exits 0. The aggregator owns the verdict.
+- Aggregator in PowerShell (matches repo idiom). Walks TRX via `Select-Xml` + `XmlNamespaceManager` (TRX uses default namespace `http://microsoft.com/schemas/VisualStudio/TeamTest/2010` — dotted access silently returns nothing). Counts non-Passed outcomes, breaks out Failed / NotExecuted / Other separately so the table tells you what kind of flake it was.
+- Aggregate rate = `total non-pass instances / total test invocations` (intentional: same test failing 3/5 should weigh more than three different tests each failing once).
+- Output is markdown (`flake-rate-summary.md`) — easier human read than JSON. Uploaded as `flake-rate-summary` artifact AND mirrored into `$GITHUB_STEP_SUMMARY` so reviewers see it on the run page without downloading. Raw TRX uploaded as `flake-runs-raw` for drill-down.
+- TESTING.md (PR #253) is owned by another agent — did NOT touch it. PR body calls out exactly where the pointer to `flake-rate-summary` artifact should land in TESTING.md so the next person merging #253 can add it without coordination overhead.
+- Workflow co-exists with `ci.yml` from PR #252; if #252 lands first the phasing already matches, if it lands after this still works (separate workflow file).
+- Gotcha: PowerShell expanded `$(seq 1 ...)` inside an unquoted here-string when appending these notes. Use single-quoted here-strings (or write a file then append) when notes contain literal shell syntax.

--- a/.squad/decisions/inbox/amy-spec009-216-flake-rate.md
+++ b/.squad/decisions/inbox/amy-spec009-216-flake-rate.md
@@ -1,0 +1,59 @@
+# Amy — Spec 009 / #216: flake-rate measurement workflow
+
+**By:** Amy (DevOps / Platform / Azure)
+**For:** Steven Murawski
+**Date:** 2026-05-14
+
+## Decision
+
+Spec 009 FR-418 (and supporting FR-405 / SC-105) is implemented as a **separate workflow file** at `.github/workflows/flake-rate.yml`, not as additional steps inside the existing `ci.yml` from PR #252. The flake-rate workflow re-runs the phased test suite N times (default 5, configurable via `workflow_dispatch` input), aggregates per-test failure counts across iterations, and emits a single markdown summary that is both uploaded as an artifact and mirrored into the workflow run summary.
+
+## Triggers
+
+- `workflow_dispatch` with a single string input `runs` (default `"5"`) so a maintainer can crank N up to e.g. 20 for a deeper measurement on demand without editing the workflow.
+- `schedule: '0 7 * * *'` — nightly at 07:00 UTC. Off-peak versus typical maintainer working hours so a long measurement run does not contend with on-demand CI.
+
+The `Azure` phase is intentionally **not** included. Scheduled runs do not have Azure credentials wired (per spec 009 Non-Goals — credentialed CI for Azure is deferred), and Azure tests already skip-when-no-creds, so the phase would only add noise.
+
+## Phasing
+
+Mirrors PR #252 (`ci.yml`) one-for-one: Unit → Integration → OutOfProcess → Http → Functional. Each iteration writes its TRX outputs to a per-iteration directory (`flake-runs/run-${i}/`) so attribution is unambiguous. The repetition loop uses `set +e` and captures per-phase exit codes into `flake-runs/run-${i}/exit-codes.txt` — a phase failure in iteration 3 must NOT skip iterations 4 and 5; the whole point of the workflow is to measure flakes across all iterations.
+
+## Aggregator format
+
+PowerShell (matches the repo idiom). Walks every TRX file via `Select-Xml` with an explicit `XmlNamespaceManager` (TRX uses a default namespace; dotted-property access silently returns nothing).
+
+The output `flake-rate-summary.md` contains:
+
+1. **Run metadata table** — UTC timestamp, commit SHA, ref, runner OS/arch, .NET SDK version, iterations completed, total test invocations, total non-pass invocations, aggregate flake rate, workflow run URL.
+2. **Per-test failure-count table** — every test that did not pass in at least one iteration, broken out by outcome (`Failed` / `NotExecuted` / `Other`), with `Total / Iterations` ratio (e.g. `3 / 5`) and the list of iterations affected. Sorted by total non-pass count, highest first.
+3. **Per-iteration phase exit codes table** — Unit/Integration/OutOfProcess/Http/Functional per iteration, so a fully red iteration (environmental issue) is visually distinct from a single phase flicking red across iterations (classic flake signature).
+
+**Why markdown over JSON:** the primary consumer is a human looking at the workflow run page. Markdown renders inline in `$GITHUB_STEP_SUMMARY` without an artifact download. Raw TRX is still uploaded separately (`flake-runs-raw` artifact) for anyone who wants to write their own analysis.
+
+**Aggregate rate definition:** `total non-pass instances / total test invocations across all iterations`. This intentionally counts repeated failures of the same test in different iterations as separate flake instances — one test failing 3/5 should weigh more than three different tests each failing 1/5.
+
+## Artifacts
+
+- `flake-rate-summary` — single `flake-rate-summary.md` file. The headline artifact.
+- `flake-runs-raw` — full `flake-runs/` directory tree with per-iteration TRX files and exit-code text files. For drill-down.
+
+Both upload `if: always()` so a partial run still surfaces what data exists.
+
+## Cross-PR coordination
+
+- **PR #252 (`ci.yml`):** flake-rate workflow phasing matches `ci.yml` phasing one-for-one. If #252 lands first, both files reference the same phase definitions implicitly. If #252 has not landed when this PR ships, the flake-rate workflow still works (it is a separate workflow file with no dependency on `ci.yml` existing).
+- **PR #253 (`TESTING.md`):** TESTING.md is being introduced in PR #253 and Amy did NOT edit it from this branch (cross-PR coordination boundary). The PR body for #216 explicitly notes that TESTING.md should add a "Flake-rate measurement" pointer that links to the workflow run page → "Artifacts" → `flake-rate-summary`. Whoever merges #253 (or a follow-up) should add that pointer.
+
+## Trade-offs accepted
+
+- **Markdown over JSON for the summary.** Easier to read on the run page; harder to machine-parse. Acceptable because raw TRX is uploaded separately for any future automation.
+- **PowerShell aggregator instead of bash.** Repo lives in pwsh land; consistent with `docker.ps1`, `install-modules.ps1`, etc. Trade-off is one fewer cross-platform shell at the cost of a less terse parser — `Select-Xml` is cleaner than awk/grep TRX walking.
+- **Loop step swallows exit codes.** The bash loop always exits 0, even when individual phases fail. Necessary so all N iterations run; the per-phase exit codes are captured into text files for the aggregator. Side effect: the only way the workflow itself fails is if the build fails, the loop step itself crashes (not a phase failure), or the aggregator throws.
+- **Azure phase excluded.** Per spec 009 Non-Goals; revisit when credentialed CI lands.
+
+## Files touched
+
+- `.github/workflows/flake-rate.yml` (new)
+- `.squad/agents/amy/history.md` (Learnings appended)
+- `.squad/decisions/inbox/amy-spec009-216-flake-rate.md` (this file)


### PR DESCRIPTION
## Summary

Adds `.github/workflows/flake-rate.yml` — a dedicated CI workflow that re-runs the phased test suite N times back-to-back on a clean runner and emits a single human-readable flake-rate summary.

Closes #216. Implements spec 009 **FR-418** and provides the measurement substrate for **FR-405** / **SC-105** (zero-flake target across 5 consecutive runs on `main`).

## What it does

- **Triggers**
  - `workflow_dispatch` with a `runs` input (default `5`) so a maintainer can crank N up on demand.
  - `schedule: '0 7 * * *'` — nightly at 07:00 UTC, off-peak versus on-demand CI.
- **Loop:** one job runs N iterations of the phased sequence. Each iteration writes its TRX outputs to `flake-runs/run-${i}/`. `set +e` plus per-phase exit codes captured to `exit-codes.txt` so a flaky phase in iteration 3 does **not** short-circuit iterations 4 and 5.
- **Phasing:** Unit → Integration → OutOfProcess → Http → Functional. Mirrors PR #252 (`ci.yml`) one-for-one. Azure phase is intentionally excluded — scheduled runs have no creds and Azure tests already skip-when-no-creds, so including the phase would only add noise.
- **Aggregator** (PowerShell, matches repo idiom): walks every TRX via `Select-Xml` + `XmlNamespaceManager`, counts non-Passed outcomes, breaks out `Failed` / `NotExecuted` / `Other` separately. Writes `flake-rate-summary.md` with:
  1. Run metadata (UTC timestamp, commit SHA, ref, runner, .NET SDK, totals, aggregate flake rate, run URL).
  2. Per-test failure-count table for any test that did not pass in at least one iteration, sorted by total non-pass count, with iteration list.
  3. Per-iteration phase exit-code matrix so a fully red iteration (env issue) reads differently from a single phase flicking red across iterations (classic flake).
- **Artifacts**
  - `flake-rate-summary` → the markdown summary (the headline artifact).
  - `flake-runs-raw` → full `flake-runs/` tree with per-iteration TRX for drill-down.
  - The summary is also mirrored into `$GITHUB_STEP_SUMMARY` so reviewers can read it on the run page without downloading.

**Aggregate rate definition:** `total non-pass instances / total test invocations across all iterations`. This intentionally counts repeated failures of the same test in different iterations as separate flake instances — one test failing 3/5 weighs more than three different tests each failing 1/5.

## Acceptance check (FR-418)

- [x] CI workflow exists that runs the phased suite N=5 times in a single run.
- [x] A single artifact reports flake counts per test across the N runs.
- [x] Triggerable via `workflow_dispatch` (with configurable `runs` input).
- [x] Schedule on `main` (nightly).
- [x] Summary appended to `$GITHUB_STEP_SUMMARY` for inline visibility.

## Cross-PR coordination

- **PR #252 (`ci.yml`).** This workflow's phasing matches `ci.yml` from PR #252 one-for-one. If #252 lands first, both files reference the same phase definitions implicitly. If #252 has not landed when this PR ships, `flake-rate.yml` still works — it is a separate workflow file with no dependency on `ci.yml` existing. Either order is safe.
- **PR #253 (`TESTING.md`).** TESTING.md is being introduced in PR #253 and is **not** edited from this branch. When #253 is merged, the TESTING.md "Triage" / "Where to find flake data" section should add a pointer like:
  > **Flake-rate measurement.** Flake counts across N consecutive runs of the phased suite are produced by the `Flake Rate Measurement` workflow. Look for the `flake-rate-summary` artifact on a recent run, or read the rendered summary directly on the workflow run page.
  
  Whoever lands #253 (or a follow-up PR) should add that pointer; nothing here is gated on it.

## Why a separate workflow file rather than extending `ci.yml`

- A flake-rate run is fundamentally a different shape (loops + aggregator) than a normal CI build (single pass, fail fast). Forcing them into one workflow either bloats every PR build or hides the loop behind a job conditional that is harder to reason about.
- Separate workflow → separate trigger surface (`workflow_dispatch` + `schedule`) without polluting the on-push/on-PR triggers in `ci.yml`.
- Independent runtime budget — a 5x phased run is multi-multiple of a normal CI run; isolating it keeps PR CI snappy.

## Files touched

- `.github/workflows/flake-rate.yml` (new)
- `.squad/agents/amy/history.md` (Learnings appended)
- `.squad/decisions/inbox/amy-spec009-216-flake-rate.md` (decision drop, will be merged into `decisions.md` by Scribe)
