### PR TITLE
test(009): centralize temp directory hygiene with TempDirectory helper

### DIFF
--- a/.squad/agents/hermes/history.md
+++ b/.squad/agents/hermes/history.md
@@ -94,3 +94,9 @@ Your work landed in v0.11.0 (csproj 0.10.0 → 0.11.0, CHANGELOG entry, release 
 **By:** Scribe (cross-agent note from coordinator)
 **What:** v0.13.0 commits landed on origin/main: housekeeping `5847efb` + release `a2b9c3e` (csproj 0.12.3 → 0.13.0, CHANGELOG, docs/release-notes/0.13.0.md). Tests 777/0/7. Tag NOT yet created — pending CI green on `a2b9c3e`.
 **Marquee:** Spec 010 — Help-aware tool descriptions. In-process + OOP byte-identical schemas, `IToolMetadataSource` seam, FR-500/510/540 precedence, `HelpAwareToolMetadataSource` as default, doctor `descriptionSource` reporting, OTel counters, parity tests. Includes #222 (SwitchParameter round-trip) and #248 (parameter descriptions on inputSchema).
+
+### 2026-05-14 — #219 spec 009 temp directory hygiene
+- Created `PoshMcp.Tests/Shared/TempDirectory.cs` as the canonical hygiene helper. Pattern: `using var tmp = new TempDirectory("label"); // tmp.Path`. Prefix `poshmcp-test-` + `Guid:N` ensures uniqueness; `Dispose()` is best-effort + idempotent; static `AuditLeftoverDirectories()` lets later agents sweep CI residue.
+- Fixed real audit hits: `OutOfProcessCommandExecutorTests.ResolveModulePaths_DeduplicatesCaseInsensitively` (Farnsworth PR #256 flag), `ProgramTests.ResolveConfigurationPath_*` (two cases writing to bare temp root).
+- Representative refactors only — did NOT touch `OopTestPaths`; it's a deliberate cross-test cache, not a hygiene violation. Document this in PRs that audit it again.
+- Lesson: when changing a field type from `string` to `TempDirectory?`, ALWAYS grep usages first. I broke 12 call sites in OutOfProcessIntegrationTests and recovered with a companion `_testTempDirHolder` field plus a `string _testTempDir` view, keeping the diff small.

--- a/PoshMcp.Tests/Integration/OutOfProcessIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/OutOfProcessIntegrationTests.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using PoshMcp.Server.PowerShell;
 using PoshMcp.Server.PowerShell.OutOfProcess;
+using PoshMcp.Tests.Shared;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -27,6 +28,7 @@ public class OutOfProcessIntegrationTests : IAsyncLifetime
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger _logger;
     private readonly ITestOutputHelper _output;
+    private TempDirectory? _testTempDirHolder;
     private string _testTempDir = string.Empty;
 
     public OutOfProcessIntegrationTests(ITestOutputHelper output)
@@ -42,8 +44,8 @@ public class OutOfProcessIntegrationTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _testTempDir = Path.Combine(Path.GetTempPath(), $"poshmcp-oop-tests-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_testTempDir);
+        _testTempDirHolder = new TempDirectory("oop-int");
+        _testTempDir = _testTempDirHolder.Path;
 
         // Only start if pwsh is available — tests using PwshAvailableFactAttribute won't
         // reach here when pwsh is missing, but guard for safety.
@@ -67,9 +69,7 @@ public class OutOfProcessIntegrationTests : IAsyncLifetime
         if (_executor != null)
             await _executor.DisposeAsync();
         _loggerFactory.Dispose();
-
-        if (Directory.Exists(_testTempDir))
-            Directory.Delete(_testTempDir, recursive: true);
+        _testTempDirHolder?.Dispose();
     }
 
     // ---- Subprocess lifecycle tests ----

--- a/PoshMcp.Tests/Integration/OutOfProcessPoolHostIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/OutOfProcessPoolHostIntegrationTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using PoshMcp.Server.PowerShell;
 using PoshMcp.Server.PowerShell.OutOfProcess;
+using PoshMcp.Tests.Shared;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -195,13 +196,11 @@ public class OutOfProcessPoolHostIntegrationTests
 
         await executor.StartAsync();
 
-        var tempDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
-            "poshmcp-pool-stale-" + Guid.NewGuid().ToString("N"));
-        System.IO.Directory.CreateDirectory(tempDir);
+        var tempDir = new TempDirectory("oop-pool-stale");
         try
         {
             var markerA = "poshmcp-pool-a-" + Guid.NewGuid().ToString("N");
-            var markerDir = System.IO.Path.Combine(tempDir, markerA);
+            var markerDir = System.IO.Path.Combine(tempDir.Path, markerA);
             System.IO.Directory.CreateDirectory(markerDir);
 
             var first = await executor.InvokeAsync(
@@ -225,7 +224,7 @@ public class OutOfProcessPoolHostIntegrationTests
         }
         finally
         {
-            try { System.IO.Directory.Delete(tempDir, recursive: true); } catch { }
+            tempDir.Dispose();
         }
     }
 
@@ -247,13 +246,11 @@ public class OutOfProcessPoolHostIntegrationTests
 
         await executor.StartAsync();
 
-        var tempDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
-            "poshmcp-pool-err-" + Guid.NewGuid().ToString("N"));
-        System.IO.Directory.CreateDirectory(tempDir);
+        var tempDir = new TempDirectory("oop-pool-err");
         try
         {
             var markerA = "poshmcp-pool-x-" + Guid.NewGuid().ToString("N");
-            var markerDir = System.IO.Path.Combine(tempDir, markerA);
+            var markerDir = System.IO.Path.Combine(tempDir.Path, markerA);
             System.IO.Directory.CreateDirectory(markerDir);
 
             var first = await executor.InvokeAsync(
@@ -261,7 +258,7 @@ public class OutOfProcessPoolHostIntegrationTests
                 new Dictionary<string, object?> { ["Path"] = markerDir });
             Assert.Contains(markerA, first, StringComparison.Ordinal);
 
-            var missingPath = System.IO.Path.Combine(tempDir,
+            var missingPath = System.IO.Path.Combine(tempDir.Path,
                 "missing-b-" + Guid.NewGuid().ToString("N"));
             var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
@@ -279,7 +276,7 @@ public class OutOfProcessPoolHostIntegrationTests
         }
         finally
         {
-            try { System.IO.Directory.Delete(tempDir, recursive: true); } catch { }
+            tempDir.Dispose();
         }
     }
 
@@ -301,9 +298,7 @@ public class OutOfProcessPoolHostIntegrationTests
 
         await executor.StartAsync();
 
-        var tempDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
-            "poshmcp-pool-empty-" + Guid.NewGuid().ToString("N"));
-        System.IO.Directory.CreateDirectory(tempDir);
+        var tempDir = new TempDirectory("oop-pool-empty");
         try
         {
             var emptyParams = new Dictionary<string, object?>
@@ -314,7 +309,7 @@ public class OutOfProcessPoolHostIntegrationTests
             var resultA = await executor.InvokeAsync("Write-Verbose", emptyParams);
 
             var sentinel = "POOL-SENTINEL-" + Guid.NewGuid().ToString("N");
-            var sentinelDir = System.IO.Path.Combine(tempDir, sentinel);
+            var sentinelDir = System.IO.Path.Combine(tempDir.Path, sentinel);
             System.IO.Directory.CreateDirectory(sentinelDir);
 
             // Run the sentinel-producing command MANY times to hit every
@@ -338,7 +333,7 @@ public class OutOfProcessPoolHostIntegrationTests
         }
         finally
         {
-            try { System.IO.Directory.Delete(tempDir, recursive: true); } catch { }
+            tempDir.Dispose();
         }
     }
 

--- a/PoshMcp.Tests/Shared/TempDirectory.cs
+++ b/PoshMcp.Tests/Shared/TempDirectory.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace PoshMcp.Tests.Shared;
+
+/// <summary>
+/// Per-test scratch directory under <see cref="Path.GetTempPath"/>. Creates a
+/// unique GUID-suffixed folder on construction and best-effort recursively
+/// deletes it on <see cref="Dispose"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Canonical hygiene helper for spec 009 (FR-403, FR-410). Every test that
+/// needs a writable temp folder should prefer this over hand-rolled
+/// <c>Path.Combine(Path.GetTempPath(), ...)</c> snippets so cleanup is
+/// guaranteed by <c>using</c>-scope rather than ad-hoc <c>try/finally</c>.
+/// </para>
+/// <para>
+/// Failures during <see cref="Dispose"/> are swallowed (best-effort) and
+/// recorded in a process-wide audit list reachable via
+/// <see cref="GetUndeletedDirectories"/> for diagnostic post-test sweeps.
+/// </para>
+/// <para>
+/// All directories created via this helper share the prefix
+/// <see cref="Prefix"/> (default <c>poshmcp-test-</c>) so a post-suite sweep
+/// of <c>Path.GetTempPath()</c> can identify and clean any stragglers.
+/// </para>
+/// </remarks>
+internal sealed class TempDirectory : IDisposable
+{
+    /// <summary>Directory name prefix shared by all instances (audit anchor).</summary>
+    public const string Prefix = "poshmcp-test-";
+
+    private static readonly ConcurrentBag<string> s_undeleted = new();
+    private bool _disposed;
+
+    /// <summary>Creates a unique directory under the system temp path.</summary>
+    /// <param name="label">
+    /// Optional short label inserted between the prefix and the GUID to make the
+    /// directory name self-describing in audit output (e.g., <c>"oop-pool"</c>).
+    /// Whitespace-only or null labels are ignored.
+    /// </param>
+    public TempDirectory(string? label = null)
+    {
+        var name = string.IsNullOrWhiteSpace(label)
+            ? $"{Prefix}{Guid.NewGuid():N}"
+            : $"{Prefix}{label}-{Guid.NewGuid():N}";
+
+        Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), name);
+        Directory.CreateDirectory(Path);
+    }
+
+    /// <summary>Absolute path of the created directory.</summary>
+    public string Path { get; }
+
+    /// <summary>Combines a relative segment with <see cref="Path"/>.</summary>
+    public string Combine(params string[] paths)
+    {
+        var all = new string[paths.Length + 1];
+        all[0] = Path;
+        Array.Copy(paths, 0, all, 1, paths.Length);
+        return System.IO.Path.Combine(all);
+    }
+
+    /// <summary>Best-effort recursive delete. Never throws.</summary>
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        try
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+        catch
+        {
+            // Best-effort: a leaked file handle (open NDJSON log, lingering pwsh
+            // child) shouldn't fail the test that produced the directory. Record
+            // for the post-suite audit instead.
+            s_undeleted.Add(Path);
+        }
+    }
+
+    /// <summary>
+    /// Returns directories created via <see cref="TempDirectory"/> in this process
+    /// whose <see cref="Dispose"/> failed. Diagnostic-only.
+    /// </summary>
+    public static IReadOnlyCollection<string> GetUndeletedDirectories()
+        => s_undeleted.ToArray();
+
+    /// <summary>
+    /// Sweeps <see cref="Path.GetTempPath"/> for directories matching
+    /// <see cref="Prefix"/>. Diagnostic-only — returns leftovers from any
+    /// process (this run or stragglers from prior crashes).
+    /// </summary>
+    public static IReadOnlyCollection<string> AuditLeftoverDirectories()
+    {
+        try
+        {
+            return Directory
+                .EnumerateDirectories(System.IO.Path.GetTempPath(), $"{Prefix}*", SearchOption.TopDirectoryOnly)
+                .ToArray();
+        }
+        catch
+        {
+            return Array.Empty<string>();
+        }
+    }
+}

--- a/PoshMcp.Tests/Unit/ModuleDiscoveryStartupOrderingTests.cs
+++ b/PoshMcp.Tests/Unit/ModuleDiscoveryStartupOrderingTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
 using PoshMcp.Server.PowerShell;
+using PoshMcp.Tests.Shared;
 using Xunit;
 
 namespace PoshMcp.Tests.Unit;
@@ -18,7 +19,8 @@ public sealed class ModuleDiscoveryStartupOrderingTests : IDisposable
     private readonly IsolatedPowerShellRunspace _runspace;
     private readonly McpToolFactoryV2 _toolFactory;
     private readonly PowerShellEnvironmentSetup _environmentSetup;
-    private readonly string _tempDirectory;
+    private readonly TempDirectory _tempDir;
+    private string _tempDirectory => _tempDir.Path;
 
     public ModuleDiscoveryStartupOrderingTests()
     {
@@ -31,8 +33,7 @@ public sealed class ModuleDiscoveryStartupOrderingTests : IDisposable
         _runspace = new IsolatedPowerShellRunspace();
         _toolFactory = new McpToolFactoryV2(_runspace);
         _environmentSetup = new PowerShellEnvironmentSetup(_loggerFactory.CreateLogger<PowerShellEnvironmentSetup>());
-        _tempDirectory = Path.Combine(Path.GetTempPath(), $"poshmcp-module-order-tests-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(_tempDirectory);
+        _tempDir = new TempDirectory("module-order");
     }
 
     [Fact]
@@ -164,10 +165,6 @@ function {functionName} {{
         _toolFactory.ClearCache();
         _runspace.Dispose();
         _loggerFactory.Dispose();
-
-        if (Directory.Exists(_tempDirectory))
-        {
-            Directory.Delete(_tempDirectory, recursive: true);
-        }
+        _tempDir.Dispose();
     }
 }

--- a/PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessCommandExecutorTests.cs
+++ b/PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessCommandExecutorTests.cs
@@ -188,7 +188,12 @@ public class OutOfProcessCommandExecutorTests
     [Fact]
     public void ResolveModulePaths_DeduplicatesCaseInsensitively()
     {
-        var baseDir = Path.Combine(Path.GetTempPath(), "PoshMcp-ResolveModulePaths");
+        // Pure path-string computation — no I/O — but using TempDirectory keeps the
+        // base path unique per test run and consistent with spec 009 hygiene
+        // (FR-403, FR-410). Replaces the previous shared "PoshMcp-ResolveModulePaths"
+        // fixed name flagged in PR #256 review.
+        using var tmp = new Tests.Shared.TempDirectory("oop-resolve-module-paths");
+        var baseDir = tmp.Path;
         var duplicateA = Path.Combine(baseDir, "Modules");
         var duplicateB = duplicateA.ToUpperInvariant();
 

--- a/PoshMcp.Tests/Unit/ProgramTests.cs
+++ b/PoshMcp.Tests/Unit/ProgramTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using PoshMcp.Server.PowerShell;
+using PoshMcp.Tests.Shared;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -125,15 +126,16 @@ public class ProgramTests : PowerShellTestBase
     [Fact]
     public async Task ResolveConfigurationPath_WhenCurrentDirectoryHasAppSettings_ReturnsAppSettings()
     {
-        // Arrange
+        // Arrange — isolated working dir so the generic appsettings.json filename
+        // can't collide with siblings (spec 009 FR-403).
         var originalDirectory = Directory.GetCurrentDirectory();
-        var tempDir = Path.GetTempPath();
-        var appSettingsPath = Path.Combine(tempDir, "appsettings.json");
-        var configPath = Path.Combine(tempDir, "config.json");
+        using var tmp = new TempDirectory("resolve-config-with-appsettings");
+        var appSettingsPath = Path.Combine(tmp.Path, "appsettings.json");
+        var configPath = Path.Combine(tmp.Path, "config.json");
 
         try
         {
-            Directory.SetCurrentDirectory(tempDir);
+            Directory.SetCurrentDirectory(tmp.Path);
             await File.WriteAllTextAsync(appSettingsPath, "{}");
 
             // Act
@@ -145,21 +147,19 @@ public class ProgramTests : PowerShellTestBase
         finally
         {
             Directory.SetCurrentDirectory(originalDirectory);
-            if (File.Exists(appSettingsPath))
-                File.Delete(appSettingsPath);
-            if (File.Exists(configPath))
-                File.Delete(configPath);
         }
     }
 
     [Fact]
     public async Task ResolveConfigurationPath_WhenNeitherExists_CreatesDefaultAndReturnsPath()
     {
-        // Arrange
+        // Arrange — both the candidate config path and the working directory live
+        // inside a single per-test scratch dir so cleanup is guaranteed by Dispose
+        // (spec 009 FR-403).
         var originalDirectory = Directory.GetCurrentDirectory();
-        var tempDir = Path.GetTempPath();
-        var configPath = Path.Combine(tempDir, $"test_config_{Path.GetRandomFileName()}.json");
-        var tempWorkingDir = Path.Combine(tempDir, Path.GetRandomFileName());
+        using var tmp = new TempDirectory("resolve-config-default");
+        var configPath = Path.Combine(tmp.Path, $"test_config_{Path.GetRandomFileName()}.json");
+        var tempWorkingDir = Path.Combine(tmp.Path, Path.GetRandomFileName());
         var userConfigPath = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
             "PoshMcp",
@@ -182,12 +182,8 @@ public class ProgramTests : PowerShellTestBase
         finally
         {
             Directory.SetCurrentDirectory(originalDirectory);
-            if (File.Exists(configPath))
-                File.Delete(configPath);
             if (!userConfigExistedBefore && File.Exists(userConfigPath))
                 File.Delete(userConfigPath);
-            if (Directory.Exists(tempWorkingDir))
-                Directory.Delete(tempWorkingDir, true);
         }
     }
 

--- a/PoshMcp.Tests/Unit/TempDirectoryTests.cs
+++ b/PoshMcp.Tests/Unit/TempDirectoryTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.IO;
+using PoshMcp.Tests.Shared;
+using Xunit;
+
+namespace PoshMcp.Tests.Unit;
+
+[Trait("Category", "Unit")]
+public sealed class TempDirectoryTests
+{
+    [Fact]
+    public void Constructor_CreatesDirectoryUnderTempPath()
+    {
+        using var tmp = new TempDirectory();
+
+        Assert.True(Directory.Exists(tmp.Path), "TempDirectory must create the directory eagerly.");
+        Assert.StartsWith(Path.GetTempPath(), tmp.Path, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(TempDirectory.Prefix, Path.GetFileName(tmp.Path));
+    }
+
+    [Fact]
+    public void Constructor_WithLabel_IncludesLabelInName()
+    {
+        using var tmp = new TempDirectory("oop-pool");
+
+        var name = Path.GetFileName(tmp.Path);
+        Assert.Contains("oop-pool", name);
+        Assert.StartsWith(TempDirectory.Prefix, name);
+    }
+
+    [Fact]
+    public void Constructor_ProducesUniquePathsAcrossInstances()
+    {
+        using var a = new TempDirectory();
+        using var b = new TempDirectory();
+
+        Assert.NotEqual(a.Path, b.Path);
+    }
+
+    [Fact]
+    public void Combine_ReturnsPathRootedAtTempDirectory()
+    {
+        using var tmp = new TempDirectory();
+
+        var combined = tmp.Combine("sub", "file.txt");
+
+        Assert.StartsWith(tmp.Path, combined);
+        Assert.EndsWith(Path.Combine("sub", "file.txt"), combined);
+    }
+
+    [Fact]
+    public void Dispose_RemovesDirectoryAndContents()
+    {
+        string path;
+        using (var tmp = new TempDirectory())
+        {
+            path = tmp.Path;
+            File.WriteAllText(Path.Combine(path, "a.txt"), "x");
+            Directory.CreateDirectory(Path.Combine(path, "nested"));
+            File.WriteAllText(Path.Combine(path, "nested", "b.txt"), "y");
+        }
+
+        Assert.False(Directory.Exists(path), "Dispose must recursively delete the directory.");
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var tmp = new TempDirectory();
+        tmp.Dispose();
+
+        var ex = Record.Exception(() => tmp.Dispose());
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Dispose_DoesNotThrow_WhenDirectoryAlreadyRemoved()
+    {
+        var tmp = new TempDirectory();
+        Directory.Delete(tmp.Path, recursive: true);
+
+        var ex = Record.Exception(() => tmp.Dispose());
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void AuditLeftoverDirectories_FindsLiveInstance()
+    {
+        using var tmp = new TempDirectory("audit-probe");
+
+        var leftovers = TempDirectory.AuditLeftoverDirectories();
+
+        Assert.Contains(tmp.Path, leftovers, StringComparer.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #219.

Implements spec 009 FR-403 (unique temp directories per test) and FR-410 (heavy-category resource drain) by introducing a single canonical hygiene helper, fixing real audit hits, and refactoring representative offenders to lock in the pattern.

## Pattern

```csharp
using var tmp = new TempDirectory("short-label");
// use tmp.Path
```

- `using` ensures cleanup.
- Label is for human grep only — uniqueness comes from the `Guid:N` suffix.
- All hygiene-managed temp dirs share the `poshmcp-test-` prefix so `TempDirectory.AuditLeftoverDirectories()` can sweep them across CI runs.

## Files touched

| File | Change | Why |
|---|---|---|
| `PoshMcp.Tests/Shared/TempDirectory.cs` | **NEW** | Canonical hygiene helper (`IDisposable`, idempotent, best-effort delete, audit hooks). |
| `PoshMcp.Tests/Unit/TempDirectoryTests.cs` | **NEW** (8 tests) | Smoke tests for the helper itself. |
| `PoshMcp.Tests/Unit/OutOfProcess/OutOfProcessCommandExecutorTests.cs` | Fix | `ResolveModulePaths_DeduplicatesCaseInsensitively` was using a fixed name (`PoshMcp-ResolveModulePaths`) — flagged by Farnsworth in PR #256 review. |
| `PoshMcp.Tests/Unit/ProgramTests.cs` | Fix | `ResolveConfigurationPath_*` (two tests) wrote `appsettings.json` / `config.json` directly into bare `Path.GetTempPath()`. |
| `PoshMcp.Tests/Unit/ModuleDiscoveryStartupOrderingTests.cs` | Refactor | Representative — replaces hand-rolled temp dir + manual `Directory.Delete`. |
| `PoshMcp.Tests/Integration/OutOfProcessIntegrationTests.cs` | Refactor | Representative — `_testTempDir` lifecycle now driven by `TempDirectory`. |
| `PoshMcp.Tests/Integration/OutOfProcessPoolHostIntegrationTests.cs` | Refactor | 3 inline temp dirs in pool stale-state / error-path / empty-result tests. |

## Spec mapping

- **FR-403** — Unit tests must NOT write to shared temp dirs. Helper guarantees `Path.Combine(Path.GetTempPath(), $"poshmcp-test-{label}-{Guid:N}")`.
- **FR-410** — Heavy categories must drain shared resources between tests. `Dispose()` is best-effort recursive delete; `AuditLeftoverDirectories()` exposes residue to higher-level cleanup.

## Intentional non-changes

- `OopTestPaths` (cached `ProgramFiles\WindowsPowerShell\Modules` and one fixed `OopE2EProbe`-named temp dir) is **left alone** — it's a process-wide cache that purposely shares state across tests; converting it to per-test would defeat its caching contract. Recommend a separate spec if revisited.

## Validation

- `dotnet build PoshMcp.Tests/PoshMcp.Tests.csproj -c Debug` — succeeds (0 errors, 19 unrelated nullable warnings).
- `dotnet test --filter "FullyQualifiedName~TempDirectoryTests|FullyQualifiedName~OutOfProcessCommandExecutorTests|FullyQualifiedName~ModuleDiscoveryStartupOrderingTests|FullyQualifiedName~ProgramTests"` — **64/64 pass**.
- `dotnet test --filter "FullyQualifiedName~OutOfProcessIntegrationTests|FullyQualifiedName~OutOfProcessPoolHostIntegrationTests"` — **29/29 pass** (3m 57s).

## Follow-up audit (out of scope here)

The whole-suite sweep is intentionally narrow in this PR (helper + real violations + representative refactors). A follow-up issue can systematically migrate any remaining tests that still construct ad hoc temp dirs to the helper, using the `poshmcp-test-` prefix sweep as the regression check.
