### PR TITLE
test(009): reclassify misfiled Unit tests (#213)

### DIFF
--- a/PoshMcp.Tests/OutOfProcess/OutOfProcessCancellationTests.cs
+++ b/PoshMcp.Tests/OutOfProcess/OutOfProcessCancellationTests.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using PoshMcp.Server.PowerShell.OutOfProcess;
 using Xunit;
 
-namespace PoshMcp.Tests.Unit.OutOfProcess;
+namespace PoshMcp.Tests.OutOfProcess;
 
 /// <summary>
 /// Cancellation propagation tests for issue #188. Cancelling the .NET-side

--- a/PoshMcp.Tests/OutOfProcess/OutOfProcessCommandExecutorTests.cs
+++ b/PoshMcp.Tests/OutOfProcess/OutOfProcessCommandExecutorTests.cs
@@ -10,7 +10,7 @@ using PoshMcp.Server.PowerShell;
 using PoshMcp.Server.PowerShell.OutOfProcess;
 using Xunit;
 
-namespace PoshMcp.Tests.Unit.OutOfProcess;
+namespace PoshMcp.Tests.OutOfProcess;
 
 /// <summary>
 /// Unit tests for OutOfProcessCommandExecutor.

--- a/PoshMcp.Tests/OutOfProcess/OutOfProcessHostConcurrencyTests.cs
+++ b/PoshMcp.Tests/OutOfProcess/OutOfProcessHostConcurrencyTests.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using PoshMcp.Server.PowerShell.OutOfProcess;
 using Xunit;
 
-namespace PoshMcp.Tests.Unit.OutOfProcess;
+namespace PoshMcp.Tests.OutOfProcess;
 
 /// <summary>
 /// Concurrency tests for <see cref="OutOfProcessHost.SendRequestAsync{T}"/>.

--- a/PoshMcp.Tests/OutOfProcess/OutOfProcessHostTests.cs
+++ b/PoshMcp.Tests/OutOfProcess/OutOfProcessHostTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using PoshMcp.Server.PowerShell.OutOfProcess;
 using Xunit;
 
-namespace PoshMcp.Tests.Unit.OutOfProcess;
+namespace PoshMcp.Tests.OutOfProcess;
 
 /// <summary>
 /// Lifecycle unit tests for <see cref="OutOfProcessHost"/>.

--- a/PoshMcp.Tests/OutOfProcess/OutOfProcessSubprocessPoolTests.cs
+++ b/PoshMcp.Tests/OutOfProcess/OutOfProcessSubprocessPoolTests.cs
@@ -6,7 +6,7 @@ using PoshMcp.Server.PowerShell;
 using PoshMcp.Server.PowerShell.OutOfProcess;
 using Xunit;
 
-namespace PoshMcp.Tests.Unit.OutOfProcess;
+namespace PoshMcp.Tests.OutOfProcess;
 
 /// <summary>
 /// Unit tests for <see cref="OutOfProcessSubprocessPool"/> internals that don't

--- a/PoshMcp.Tests/OutOfProcess/OutOfProcessToolAssemblyGeneratorTests.cs
+++ b/PoshMcp.Tests/OutOfProcess/OutOfProcessToolAssemblyGeneratorTests.cs
@@ -9,7 +9,7 @@ using Moq;
 using PoshMcp.Server.PowerShell.OutOfProcess;
 using Xunit;
 
-namespace PoshMcp.Tests.Unit.OutOfProcess;
+namespace PoshMcp.Tests.OutOfProcess;
 
 /// <summary>
 /// Unit tests for OutOfProcessToolAssemblyGenerator.

--- a/PoshMcp.Tests/OutOfProcess/RemoteToolSchemaTests.cs
+++ b/PoshMcp.Tests/OutOfProcess/RemoteToolSchemaTests.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 using PoshMcp.Server.PowerShell.OutOfProcess;
 using Xunit;
 
-namespace PoshMcp.Tests.Unit.OutOfProcess;
+namespace PoshMcp.Tests.OutOfProcess;
 
 /// <summary>
 /// Unit tests for RemoteToolSchema and RemoteParameterSchema DTOs.

--- a/PoshMcp.Tests/OutOfProcess/RuntimeModeTests.cs
+++ b/PoshMcp.Tests/OutOfProcess/RuntimeModeTests.cs
@@ -1,7 +1,7 @@
 using System;
 using Xunit;
 
-namespace PoshMcp.Tests.Unit.OutOfProcess;
+namespace PoshMcp.Tests.OutOfProcess;
 
 /// <summary>
 /// Unit tests for the RuntimeMode enum.


### PR DESCRIPTION
Closes #213 — implements the reclassification step from Spec 009.

## Summary

The `PoshMcp.Tests/Unit/OutOfProcess/` folder contained 8 test files that already carried `[Trait("Category", "OutOfProcess")]` but lived under `Unit/` with `PoshMcp.Tests.Unit.OutOfProcess` namespaces. The misfiling was **directory + namespace, not metadata**. This PR moves them to their correct home.

Per **FR-414** (reclassification is metadata-only): no `[Trait]` attributes, test bodies, assertions, setup, or test data were modified.

## Files moved

| File | Old Trait | Old Namespace | New Trait | New Namespace | Reason |
|---|---|---|---|---|---|
| OutOfProcessCancellationTests.cs | OutOfProcess | PoshMcp.Tests.Unit.OutOfProcess | OutOfProcess | PoshMcp.Tests.OutOfProcess | Folder/namespace mismatch |
| OutOfProcessCommandExecutorTests.cs | OutOfProcess | PoshMcp.Tests.Unit.OutOfProcess | OutOfProcess | PoshMcp.Tests.OutOfProcess | Folder/namespace mismatch |
| OutOfProcessHostConcurrencyTests.cs | OutOfProcess | PoshMcp.Tests.Unit.OutOfProcess | OutOfProcess | PoshMcp.Tests.OutOfProcess | Folder/namespace mismatch |
| OutOfProcessHostTests.cs | OutOfProcess | PoshMcp.Tests.Unit.OutOfProcess | OutOfProcess | PoshMcp.Tests.OutOfProcess | Folder/namespace mismatch |
| OutOfProcessSubprocessPoolTests.cs | OutOfProcess | PoshMcp.Tests.Unit.OutOfProcess | OutOfProcess | PoshMcp.Tests.OutOfProcess | Folder/namespace mismatch |
| OutOfProcessToolAssemblyGeneratorTests.cs | OutOfProcess | PoshMcp.Tests.Unit.OutOfProcess | OutOfProcess | PoshMcp.Tests.OutOfProcess | Folder/namespace mismatch |
| RemoteToolSchemaTests.cs | OutOfProcess | PoshMcp.Tests.Unit.OutOfProcess | OutOfProcess | PoshMcp.Tests.OutOfProcess | Folder/namespace mismatch |
| RuntimeModeTests.cs | OutOfProcess | PoshMcp.Tests.Unit.OutOfProcess | OutOfProcess | PoshMcp.Tests.OutOfProcess | Folder/namespace mismatch |

History preserved via `git mv` (rename similarity 98–99%).

## Files audited and confirmed compliant — left alone per FR-414

These files live under `Unit/` and were inspected against FR-401 (no child processes), FR-402 (no TCP ports), and FR-403 (no shared temp dirs):

- `OAuthProxyEndpointsTests.cs` — uses stub `NoOpEndpointRouteBuilder`, no port binding
- `ProgramCli*Tests.cs` — invoke `Program.Main` in-process, use `TemporaryDirectory` + `CurrentDirectoryScope`, no spawn
- `ServerSessionAwarePowerShellRunspaceTests.cs` — pure mocks
- `WinPsCompatProxyTests.cs` — uses in-process `PowerShell.Create()` (not a subprocess)
- `McpToolFactoryV2Tests.cs`, `McpPrompts/*`, `McpResources/*` — all in-process

## Verification

- ✅ Build clean (0 errors, 9.22s)
- ✅ Unit tier: **432 passed / 0 failed in 39s** (well under 60s target — FR-405)
- ✅ OutOfProcess tier: **155 passed / 0 failed / 6 skipped** (heavy modules)
- ✅ No external code referenced the old namespace (verified via grep — only the 8 self-references)
