### PR TITLE
test(009): apply FR-416 reclassification rule to Functional tests

### DIFF
--- a/PoshMcp.Tests/Functional/ConfigurationReload/ConfigurationReloadTests.cs
+++ b/PoshMcp.Tests/Functional/ConfigurationReload/ConfigurationReloadTests.cs
@@ -15,7 +15,7 @@ namespace PoshMcp.Tests.Functional.ConfigurationReload;
 /// <summary>
 /// Tests for PowerShell configuration reload functionality
 /// </summary>
-[Trait("Category", "Functional")]
+[Trait("Category", "Integration")]
 public class ConfigurationReloadTests : PowerShellTestBase
 {
     public ConfigurationReloadTests(ITestOutputHelper outputHelper) : base(outputHelper)

--- a/PoshMcp.Tests/Functional/McpServerSetup/SetupTestsShared.cs
+++ b/PoshMcp.Tests/Functional/McpServerSetup/SetupTestsShared.cs
@@ -16,7 +16,7 @@ namespace PoshMcp.Tests.Functional.McpServerSetup;
 /// <summary>
 /// Shared setup for MCP server setup tests
 /// </summary>
-[Trait("Category", "Functional")]
+[Trait("Category", "Integration")]
 public partial class SetupTests : PowerShellTestBase
 {
     public SetupTests(ITestOutputHelper output) : base(output) { }

--- a/PoshMcp.Tests/OutOfProcess/StdioLoggingTests.cs
+++ b/PoshMcp.Tests/OutOfProcess/StdioLoggingTests.cs
@@ -7,14 +7,14 @@ using PoshMcp.Tests.Integration;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace PoshMcp.Tests.Functional;
+namespace PoshMcp.Tests.OutOfProcess;
 
 /// <summary>
 /// Functional tests that verify stdio logging suppression behavior:
 /// - No log output leaks to stderr in stdio mode without a log file configured.
 /// - When a log file is configured, logs are written to that file instead.
 /// </summary>
-[Trait("Category", "Integration")]
+[Trait("Category", "OutOfProcess")]
 public class StdioLoggingTests : PowerShellTestBase
 {
     // Matches Serilog template "[2024-01-01 12:00:00 INF]" and MEL console "info: " / "warn: " etc.

--- a/TESTING.md
+++ b/TESTING.md
@@ -89,6 +89,11 @@ dotnet test PoshMcp.sln --filter "Category=Functional"
 ### `Functional`
 
 - Multi-area scenarios that stay in-process. Per FR-416, any `Functional` test that ends up touching external resources (disk, network, subprocesses, ports) must be reclassified as `Integration` (or a more specific resource-bound category). This is a rule applied at categorization time, not a case-by-case judgment call.
+- The FR-416 sweep against the existing `Functional/` folder (issue #220) reclassified three classes:
+  - `Functional/StdioLoggingTests.cs` → moved to `OutOfProcess/StdioLoggingTests.cs` with `Category=OutOfProcess` (spawns the MCP server as a subprocess via `InProcessMcpServer` + `ExternalMcpClient`).
+  - `Functional/ConfigurationReload/ConfigurationReloadTests.cs` → `Category=Integration` (writes config files via `Path.GetTempFileName()` + `File.WriteAllTextAsync`).
+  - `Functional/McpServerSetup/SetupTestsShared.cs` (the `partial class SetupTests`) → `Category=Integration`. The whole partial class promotes together, since FR-416 is a rule, not case-by-case; multiple partials in this class touch tempfiles.
+- The remaining `Functional/` tests are genuine cross-area, in-process scenarios: prompt/resource MCP placeholders, switch-parameter round-trips through PowerShell + MCP, Windows PowerShell compat proxy detection, and the in-proc PowerShell SDK groups under `CorrelationId/`, `PowerShellCommandExecution/`, `MethodExecution/`, `GeneratedAssembly/`, `FilterLastCommandOutput/`, `SortLastCommandOutput/`, and `GetLastCommandOutput/`.
 
 ---
 


### PR DESCRIPTION
Closes #220.

Applies the FR-416 reclassification rule (spec 009) to the existing `PoshMcp.Tests/Functional/*` tests. Same playbook as #213 / #259: audit, retag, optional folder move, metadata-only diff (no body, asserts, setup, or test data changed).

## Audit summary

The audit covered all 50 files under `PoshMcp.Tests/Functional/` (26 with an explicit `[Trait("Category","Functional")]` declaration; the rest pick up category via partial classes or shared bases). The audit checked both raw IO patterns (`File.*`, `Path.GetTempFileName`, `Process.Start`, `HttpClient`, socket binds) and project-specific test-helper patterns (`InProcessMcpServer`, `ExternalMcpClient`, `StartAsync`).

## Reclassifications (3)

| File | Before | After | Move | Reason |
| --- | --- | --- | --- | --- |
| `PoshMcp.Tests/Functional/StdioLoggingTests.cs` | `Category=Integration` (folder mismatch) | `Category=OutOfProcess` | yes -> `PoshMcp.Tests/OutOfProcess/StdioLoggingTests.cs` (namespace `PoshMcp.Tests.OutOfProcess`) | Spawns the MCP server as a real subprocess via `InProcessMcpServer` + `ExternalMcpClient` and asserts on stdio behavior. The shape matches OutOfProcess more specifically than Integration. |
| `PoshMcp.Tests/Functional/ConfigurationReload/ConfigurationReloadTests.cs` | `Category=Functional` | `Category=Integration` | no | Three of four facts call `Path.GetTempFileName()` + `File.WriteAllTextAsync(...)` to stage config files. Disk I/O. |
| `PoshMcp.Tests/Functional/McpServerSetup/SetupTestsShared.cs` (the `partial class SetupTests` Trait holder) | `Category=Functional` | `Category=Integration` | no | The class is split across multiple partial files. Four of them (`ShouldParseJsonFileCorrectlyTest.cs`, `ShouldThrowExceptionWithInvalidJsonTest.cs`, `ShouldThrowExceptionWithMissingFileTest.cs`, `ShouldWorkWithConfigurationToToolsListIntegrationTest.cs`) write tempfiles. Per FR-416 ("rule, not case-by-case"), the entire partial class promotes; the Trait sits on the shared declaration. |

Total: 3 reclassifications, 1 folder move.

## Stays Functional (verified)

The following are genuine cross-area in-process scenarios with no external resource use:

- `Functional/McpPromptsTests.cs`, `Functional/McpResourcesTests.cs` - current contents are placeholder facts (`Assert.True(true)`) for prompts/resources MCP features. The `InProcessMcpServer` references are only in TODO comments.
- `Functional/SwitchParameterMcpRoundTripTests.cs` - switch parameter round-trip across the in-proc PowerShell SDK and the MCP type system.
- `Functional/WinPsCompatProxyMethodGenerationTests.cs` - Windows PowerShell compat proxy method detection across the in-proc PowerShell SDK and code-gen.
- `Functional/CorrelationId/*`, `Functional/PowerShellCommandExecution/*`, `Functional/MethodExecution/*`, `Functional/GeneratedAssembly/*`, `Functional/FilterLastCommandOutput/*`, `Functional/SortLastCommandOutput/*`, `Functional/GetLastCommandOutput/*` - in-proc PowerShell SDK pipeline groups.

## Borderline note

`Functional/ReturnType/ShouldHandleGetChildItemCorrectlyTest.cs` references `Path.GetTempPath()` for a string lookup but is permanently `[Fact(Skip = "Skipping Get-ChildItem test as it's hanging")]`. Left untouched - the test does not execute and the path string lookup is not real disk I/O.

## Verification

- `dotnet build PoshMcp.Tests/PoshMcp.Tests.csproj` - clean (0 errors).
- `dotnet test --filter Category=Unit` - `432 passed, 0 failed` (no regression).
- Targeted re-run of the 3 reclassified classes (`ConfigurationReloadTests`, `SetupTests`, `StdioLoggingTests`) - `18 passed, 0 failed`.
- TESTING.md updated: a paragraph in the `Functional` section documents the sweep and lists what genuinely stays Functional.

Diff is metadata-only: only `[Trait]` strings, one `git mv`, the corresponding `namespace` change on the moved file, and the documentation update. No test bodies, asserts, setup, or test data were modified.
