### PR TITLE
feat(auth): map Identity.Name from configurable claim (#262)

### DIFF
--- a/PoshMcp.Server/Authentication/AuthenticationConfiguration.cs
+++ b/PoshMcp.Server/Authentication/AuthenticationConfiguration.cs
@@ -46,6 +46,16 @@ public class ClaimsMappingConfiguration
 {
     public string ScopeClaim { get; set; } = "scp";
     public string RoleClaim { get; set; } = "roles";
+
+    /// <summary>
+    /// Short claim name to use as <see cref="System.Security.Claims.ClaimsIdentity.Name"/>.
+    /// When null/empty, the JwtBearer default (<c>"name"</c>) is preserved for backwards
+    /// compatibility. Set to <c>"preferred_username"</c> for AAD v2.0 access tokens, which
+    /// do not carry a <c>name</c> claim by default and would otherwise leave
+    /// <c>Identity.Name</c> as <c>null</c>. Other common values: <c>"upn"</c>, <c>"oid"</c>,
+    /// <c>"sub"</c>, or <c>"unique_name"</c> for AAD v1.0 tokens.
+    /// </summary>
+    public string? NameClaim { get; set; }
 }
 
 public class ApiKeyDefinition

--- a/PoshMcp.Server/Authentication/AuthenticationServiceExtensions.cs
+++ b/PoshMcp.Server/Authentication/AuthenticationServiceExtensions.cs
@@ -56,6 +56,18 @@ public static class AuthenticationServiceExtensions
                         // now that inbound claim mapping is disabled.
                         options.TokenValidationParameters.RoleClaimType = scheme.ClaimsMapping.RoleClaim;
 
+                        // If a NameClaim is configured, override the JwtBearer default
+                        // (NameClaimType = "name") so ClaimsIdentity.Name resolves to a
+                        // claim that actually exists on the token. Critical for AAD v2.0
+                        // access tokens, which carry "preferred_username"/"oid"/"sub" but
+                        // no "name" claim — leaving Identity.Name null without this.
+                        // Backwards-compatible: when NameClaim is null/empty, the
+                        // JwtBearer default is preserved untouched.
+                        if (!string.IsNullOrEmpty(scheme.ClaimsMapping.NameClaim))
+                        {
+                            options.TokenValidationParameters.NameClaimType = scheme.ClaimsMapping.NameClaim;
+                        }
+
                         // Build the full set of valid audiences: primary Audience + any extras.
                         var allAudiences = scheme.ValidAudiences.ToList();
                         if (!string.IsNullOrEmpty(scheme.Audience) &&

--- a/PoshMcp.Tests/Unit/AuthenticationServiceExtensionsTests.cs
+++ b/PoshMcp.Tests/Unit/AuthenticationServiceExtensionsTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -100,5 +101,65 @@ public class AuthenticationServiceExtensionsTests
         var options = sp.GetRequiredService<IOptions<AuthenticationConfiguration>>();
 
         Assert.False(options.Value.Enabled);
+    }
+
+    [Fact]
+    public void WhenNameClaimNotConfigured_JwtBearerNameClaimType_PreservesDefault()
+    {
+        // Backwards compatibility: if NameClaim is absent from config, do NOT mutate
+        // the JwtBearer default ("name"). Existing deployments must keep the same
+        // Identity.Name resolution behavior.
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Authentication:Enabled"] = "true",
+                ["Authentication:DefaultScheme"] = "Bearer",
+                ["Authentication:Schemes:Bearer:Type"] = "JwtBearer",
+                ["Authentication:Schemes:Bearer:Authority"] = "https://login.microsoftonline.com/tenant/v2.0",
+                ["Authentication:Schemes:Bearer:Audience"] = "api://my-app",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddPoshMcpAuthentication(config);
+
+        var sp = services.BuildServiceProvider();
+        var jwtOptions = sp.GetRequiredService<IOptionsMonitor<JwtBearerOptions>>().Get("Bearer");
+
+        // JwtBearer's stock default is the SOAP-style name URI; make sure we left it alone.
+        const string defaultNameClaim = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name";
+        Assert.Equal(defaultNameClaim, jwtOptions.TokenValidationParameters.NameClaimType);
+        Assert.Null(sp.GetRequiredService<IOptions<AuthenticationConfiguration>>().Value
+            .Schemes["Bearer"].ClaimsMapping.NameClaim);
+    }
+
+    [Fact]
+    public void WhenNameClaimConfigured_JwtBearerNameClaimType_IsOverridden()
+    {
+        // AAD v2.0 access tokens carry "preferred_username" instead of "name".
+        // Verify operators can wire that through ClaimsMapping.NameClaim so
+        // Identity.Name (and therefore the doctor report) resolves correctly.
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Authentication:Enabled"] = "true",
+                ["Authentication:DefaultScheme"] = "Bearer",
+                ["Authentication:Schemes:Bearer:Type"] = "JwtBearer",
+                ["Authentication:Schemes:Bearer:Authority"] = "https://login.microsoftonline.com/tenant/v2.0",
+                ["Authentication:Schemes:Bearer:Audience"] = "api://my-app",
+                ["Authentication:Schemes:Bearer:ClaimsMapping:NameClaim"] = "preferred_username",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddPoshMcpAuthentication(config);
+
+        var sp = services.BuildServiceProvider();
+        var jwtOptions = sp.GetRequiredService<IOptionsMonitor<JwtBearerOptions>>().Get("Bearer");
+
+        Assert.Equal("preferred_username", jwtOptions.TokenValidationParameters.NameClaimType);
+        Assert.Equal("preferred_username",
+            sp.GetRequiredService<IOptions<AuthenticationConfiguration>>().Value
+                .Schemes["Bearer"].ClaimsMapping.NameClaim);
     }
 }

--- a/docs/entra-id-auth-guide.md
+++ b/docs/entra-id-auth-guide.md
@@ -208,7 +208,8 @@ Authentication configuration goes in the `Authentication` section of your PoshMc
         "ValidIssuers": ["https://login.microsoftonline.com/{tenant-id}/v2.0"],
         "ClaimsMapping": {
           "ScopeClaim": "scp",
-          "RoleClaim": "roles"
+          "RoleClaim": "roles",
+          "NameClaim": "preferred_username"
         }
       }
     },
@@ -320,6 +321,7 @@ Update these values with your Azure AD app info:
 | `AuthorizationServers[0]` | **Entra v2.0 base URL** (v1.0 may issue v1.0 tokens) | `https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/v2.0` |
 | `ClaimsMapping.ScopeClaim` | Short claim name for scopes (always `scp` for Entra v2.0) | `scp` |
 | `ClaimsMapping.RoleClaim` | Short claim name for roles (typically `roles` for Entra) | `roles` |
+| `ClaimsMapping.NameClaim` | Short claim name to use for `Identity.Name`. **Required for Entra v2.0** — its access tokens carry `preferred_username` instead of `name`, so leaving this unset will leave `Identity.Name` (and the doctor report's `identity.name`) `null`. Omit for v1.0 tokens to keep the JwtBearer default. | `preferred_username` |
 
 #### Production Configuration
 
@@ -830,7 +832,8 @@ The configuration is identical to app registration; the difference is where cred
         "ValidIssuers": ["https://login.microsoftonline.com/{tenant-id}/v2.0"],
         "ClaimsMapping": {
           "ScopeClaim": "scp",
-          "RoleClaim": "roles"
+          "RoleClaim": "roles",
+          "NameClaim": "preferred_username"
         }
       }
     },


### PR DESCRIPTION
## Summary

Fixes a deployment-time gotcha for Entra ID v2.0 setups: `Identity.Name` (and the `identity.name` field in the doctor report) was always `null` because AAD v2.0 access tokens carry `preferred_username` instead of the `name` claim that JwtBearer maps by default.

This adds a per-scheme `ClaimsMapping.NameClaim` knob. When set, it drives `TokenValidationParameters.NameClaimType`, so `ClaimsIdentity.Name` resolves from whatever claim the token actually carries.

## Acceptance criteria

- ✅ `ClaimsMapping.NameClaim` is configurable in `appsettings.json` (added to `ClaimsMappingConfiguration`).
- ✅ When set, `options.TokenValidationParameters.NameClaimType` is updated in `AuthenticationServiceExtensions`.
- ✅ `identity.name` in the doctor report reflects the configured claim (no code change needed — `DoctorReport` reads `principal.Identity?.Name`, which now resolves correctly).
- ✅ Docs (`docs/entra-id-auth-guide.md`) updated: both JSON examples include `"NameClaim": "preferred_username"`, and the reference table has a new row explaining the AAD v2.0 use case.
- ✅ Tests cover both default (preserved JwtBearer behavior) and override (resolves to `preferred_username`).
- ✅ `dotnet build` is clean. All `AuthenticationServiceExtensionsTests` (6 total — 4 existing + 2 new) pass.

## Backwards compatibility

Conditional assignment — when `NameClaim` is null/empty (the default), the JwtBearer pipeline default is left untouched. Existing deployments are unaffected.

## Files changed

- `PoshMcp.Server/Authentication/AuthenticationConfiguration.cs` — new nullable `NameClaim` property with XML docs.
- `PoshMcp.Server/Authentication/AuthenticationServiceExtensions.cs` — conditional `NameClaimType` wiring.
- `PoshMcp.Tests/Unit/AuthenticationServiceExtensionsTests.cs` — 2 new tests (default + override).
- `docs/entra-id-auth-guide.md` — JSON examples + reference table row.

Closes #262
