### PR TITLE
fix(doctor): show n/a for ProcessPool sizing in Pool mode (#261)

### DIFF
--- a/PoshMcp.Server/Diagnostics/DoctorReport.cs
+++ b/PoshMcp.Server/Diagnostics/DoctorReport.cs
@@ -562,17 +562,26 @@ public sealed record OutOfProcessSection
     [JsonPropertyName("processPoolSize")]
     public int ProcessPoolSize { get; init; }
 
-    /// <summary>Effective process pool size after clamping.</summary>
+    /// <summary>
+    /// Effective process pool size after clamping (string for display parity with
+    /// <see cref="EffectiveRunspacePoolSize"/>). Renders as <c>"n/a (Pool mode)"</c>
+    /// when <see cref="HostMode"/> is not <c>ProcessPool</c>, since this knob is
+    /// inert outside ProcessPool mode.
+    /// </summary>
     [JsonPropertyName("effectiveProcessPoolSize")]
-    public int EffectiveProcessPoolSize { get; init; }
+    public string EffectiveProcessPoolSize { get; init; } = string.Empty;
 
     /// <summary>Minimum healthy hosts required at startup for <c>ProcessPool</c> mode (configured value).</summary>
     [JsonPropertyName("minHealthyForStartup")]
     public int MinHealthyForStartup { get; init; }
 
-    /// <summary>Minimum healthy hosts after clamping (capped at the effective pool size).</summary>
+    /// <summary>
+    /// Minimum healthy hosts after clamping (capped at the effective pool size).
+    /// Renders as <c>"n/a (Pool mode)"</c> when <see cref="HostMode"/> is not
+    /// <c>ProcessPool</c>, since this knob is inert outside ProcessPool mode.
+    /// </summary>
     [JsonPropertyName("effectiveMinHealthyForStartup")]
-    public int EffectiveMinHealthyForStartup { get; init; }
+    public string EffectiveMinHealthyForStartup { get; init; } = string.Empty;
 
     /// <summary>Per-request timeout enforced by the host for outbound invokes (defaults to 30s).</summary>
     [JsonPropertyName("requestTimeoutSeconds")]

--- a/PoshMcp.Server/Diagnostics/DoctorService.cs
+++ b/PoshMcp.Server/Diagnostics/DoctorService.cs
@@ -334,15 +334,25 @@ internal static class DoctorService
             _ => "n/a",
         };
 
-        var effectiveProcessPoolSize = config.SubprocessHostMode == SubprocessHostMode.ProcessPool
-            ? (config.SubprocessPoolSize > 0 ? config.SubprocessPoolSize : 4)
-            : 0;
-
-        var effectiveMinHealthy = config.SubprocessHostMode == SubprocessHostMode.ProcessPool
-            ? Math.Max(1, Math.Min(
+        // ProcessPool-only sizing knobs. In other modes (e.g., Pool) these knobs are
+        // inert, so render "n/a (Pool mode)" to avoid alarming operators who see
+        // configured values of 4/1 next to effective values of 0. (Issue #261)
+        string effectiveProcessPoolSize;
+        string effectiveMinHealthy;
+        if (config.SubprocessHostMode == SubprocessHostMode.ProcessPool)
+        {
+            var processPoolSize = config.SubprocessPoolSize > 0 ? config.SubprocessPoolSize : 4;
+            var minHealthy = Math.Max(1, Math.Min(
                 config.SubprocessMinHealthyForStartup > 0 ? config.SubprocessMinHealthyForStartup : 1,
-                effectiveProcessPoolSize > 0 ? effectiveProcessPoolSize : 1))
-            : 0;
+                processPoolSize));
+            effectiveProcessPoolSize = processPoolSize.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            effectiveMinHealthy = minHealthy.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
+        else
+        {
+            effectiveProcessPoolSize = "n/a (Pool mode)";
+            effectiveMinHealthy = "n/a (Pool mode)";
+        }
 
         // Best-effort host script resolution. Mirrors the executor's resolution
         // path without starting the subprocess. Failures are reported, not thrown.

--- a/PoshMcp.Tests/Unit/Diagnostics/DoctorOutOfProcessSectionTests.cs
+++ b/PoshMcp.Tests/Unit/Diagnostics/DoctorOutOfProcessSectionTests.cs
@@ -1,0 +1,103 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using PoshMcp;
+using PoshMcp.Server.PowerShell;
+using PoshMcp.Server.PowerShell.OutOfProcess;
+using Xunit;
+
+namespace PoshMcp.Tests.Unit.Diagnostics;
+
+[Trait("Category", "Unit")]
+public class DoctorOutOfProcessSectionTests
+{
+    // Issue #261: in Pool mode, the ProcessPool sizing knobs are inert. The doctor
+    // report previously emitted 0 for both effective values, which looked like a
+    // bug. We now render "n/a (Pool mode)" to make the inertness explicit.
+
+    [Fact]
+    public void BuildOutOfProcessSection_PoolMode_RendersNaForProcessPoolKnobs()
+    {
+        var config = new PowerShellConfiguration
+        {
+            RuntimeMode = RuntimeMode.OutOfProcess,
+            SubprocessHostMode = SubprocessHostMode.Pool,
+            SubprocessRunspacePoolSize = 0,
+            SubprocessPoolSize = 4,
+            SubprocessMinHealthyForStartup = 1,
+        };
+
+        var section = DoctorService.BuildOutOfProcessSection(config, configurationPath: null, NullLoggerFactory.Instance);
+
+        Assert.True(section.Applicable);
+        Assert.Equal(nameof(SubprocessHostMode.Pool), section.HostMode);
+        Assert.Equal("n/a (Pool mode)", section.EffectiveProcessPoolSize);
+        Assert.Equal("n/a (Pool mode)", section.EffectiveMinHealthyForStartup);
+    }
+
+    [Fact]
+    public void BuildOutOfProcessSection_ProcessPoolMode_RendersIntegerStringsForEffectiveSizes()
+    {
+        var config = new PowerShellConfiguration
+        {
+            RuntimeMode = RuntimeMode.OutOfProcess,
+            SubprocessHostMode = SubprocessHostMode.ProcessPool,
+            SubprocessPoolSize = 4,
+            SubprocessMinHealthyForStartup = 1,
+        };
+
+        var section = DoctorService.BuildOutOfProcessSection(config, configurationPath: null, NullLoggerFactory.Instance);
+
+        Assert.True(section.Applicable);
+        Assert.Equal(nameof(SubprocessHostMode.ProcessPool), section.HostMode);
+        Assert.Equal("4", section.EffectiveProcessPoolSize);
+        Assert.Equal("1", section.EffectiveMinHealthyForStartup);
+    }
+
+    [Fact]
+    public void BuildOutOfProcessSection_ProcessPoolMode_ClampsMinHealthyToPoolSize()
+    {
+        // SubprocessMinHealthyForStartup > SubprocessPoolSize must clamp down.
+        var config = new PowerShellConfiguration
+        {
+            RuntimeMode = RuntimeMode.OutOfProcess,
+            SubprocessHostMode = SubprocessHostMode.ProcessPool,
+            SubprocessPoolSize = 2,
+            SubprocessMinHealthyForStartup = 10,
+        };
+
+        var section = DoctorService.BuildOutOfProcessSection(config, configurationPath: null, NullLoggerFactory.Instance);
+
+        Assert.Equal("2", section.EffectiveProcessPoolSize);
+        Assert.Equal("2", section.EffectiveMinHealthyForStartup);
+    }
+
+    [Fact]
+    public void BuildOutOfProcessSection_ProcessPoolMode_DefaultsPoolSizeWhenZero()
+    {
+        var config = new PowerShellConfiguration
+        {
+            RuntimeMode = RuntimeMode.OutOfProcess,
+            SubprocessHostMode = SubprocessHostMode.ProcessPool,
+            SubprocessPoolSize = 0,
+            SubprocessMinHealthyForStartup = 0,
+        };
+
+        var section = DoctorService.BuildOutOfProcessSection(config, configurationPath: null, NullLoggerFactory.Instance);
+
+        // Defaults: pool size 4, min healthy 1.
+        Assert.Equal("4", section.EffectiveProcessPoolSize);
+        Assert.Equal("1", section.EffectiveMinHealthyForStartup);
+    }
+
+    [Fact]
+    public void BuildOutOfProcessSection_NotOutOfProcess_IsNotApplicable()
+    {
+        var config = new PowerShellConfiguration
+        {
+            RuntimeMode = RuntimeMode.InProcess,
+        };
+
+        var section = DoctorService.BuildOutOfProcessSection(config, configurationPath: null, NullLoggerFactory.Instance);
+
+        Assert.False(section.Applicable);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the doctor report's display of `effectiveProcessPoolSize` and `effectiveMinHealthyForStartup` so that operators running in **Pool** host mode no longer see alarming `0` values next to their non-zero configured values. These knobs are inert outside ProcessPool mode; the report now says so explicitly.

Mirrors the existing `effectiveRunspacePoolSize` pattern, which has always rendered `"n/a"` outside Pool mode.

### What changed

- `OutOfProcessSection.EffectiveProcessPoolSize` and `EffectiveMinHealthyForStartup` are now `string` (were `int`).
- `DoctorService.BuildOutOfProcessSection` emits `"n/a (Pool mode)"` in Pool / non-ProcessPool modes, and the integer-as-string in ProcessPool mode.
- ProcessPool semantics unchanged — same clamping, same defaults.
- Text renderer needed no logic change; it only renders the section for the active host mode.

### Acceptance criteria

- [x] JSON `effectiveProcessPoolSize` / `effectiveMinHealthyForStartup` are strings (`"n/a (Pool mode)"` in Pool mode, integer-as-string in ProcessPool mode).
- [x] ProcessPool mode behavior unchanged in semantics — operator still sees the effective integer value.
- [x] Text renderer output is clean (verified by inspection — no formatting changes needed).
- [x] Unit tests cover both modes, plus clamping, defaults, and not-applicable path (`PoshMcp.Tests/Unit/Diagnostics/DoctorOutOfProcessSectionTests.cs`, 5 cases).
- [x] `dotnet build` clean. New + existing Doctor tests green (54 passed, 0 failed).

### Spec 009 compliance

New tests carry `[Trait("Category", "Unit")]` and live under `PoshMcp.Tests/Unit/Diagnostics/`. Pure in-memory: no FS, no process spawning, no port binding.

Closes #261
