### PR TITLE
feat(011): doctor moduleImports C#/JSON wiring + tests (#267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented here.
 
+## [Unreleased]
+
+### Added
+- **Doctor: `moduleImports` section (spec 011 — Issue #267)** — `poshmcp doctor` now reports per-module, per-pattern, and per-tool import diagnostics under a new `moduleImports` JSON section (and a corresponding text-rendered "Module Imports" block). Each module entry surfaces resolved version/path, contributed-tool count and names, and an `ok`/`warning`/`error` status; pattern entries distinguish `filter`, `discovery`, and `exclude` roles per FR-263-9; tool entries attribute every exposed tool to a `commandName`, `module`, `pattern`, or `unknown` source. The section is omitted entirely for `CommandNames`-only configurations (FR-263-6, SC-263-4). (#267)
+
+### Breaking
+- **Doctor: `summary.status` flips `healthy → errors` when configured modules fail to resolve, and `healthy → warnings` when modules resolve without contributing tools or include patterns match nothing.** Existing `CommandNames`-only configurations are unaffected — the new `moduleImports` section is omitted and `summary.status` is computed as before (SC-263-4). Operators relying on `summary.status === "healthy"` as a proxy for "everything is fine" should now also tolerate `warnings`/`errors` driven by misconfigured `Modules`/`IncludePatterns`/`ExcludePatterns`. (#267)
+
 ## [0.13.1] - 2026-05-15
 
 ### Added

--- a/PoshMcp.Server/Diagnostics/DoctorReport.cs
+++ b/PoshMcp.Server/Diagnostics/DoctorReport.cs
@@ -64,19 +64,54 @@ public sealed record DoctorReport
     public OutOfProcessSection OutOfProcess { get; init; } = new();
 
     /// <summary>
+    /// Spec 011 (FR-263-1): per-module / per-pattern / per-tool import diagnostics.
+    /// Surfaces validation results for tools brought in via
+    /// <see cref="PowerShellConfiguration.Modules"/> and
+    /// <see cref="PowerShellConfiguration.IncludePatterns"/> /
+    /// <see cref="PowerShellConfiguration.ExcludePatterns"/>, which were
+    /// previously invisible to the doctor report. Empty for configurations
+    /// that use only <see cref="PowerShellConfiguration.CommandNames"/>.
+    /// </summary>
+    [JsonPropertyName("moduleImports")]
+    public ModuleImportsSection ModuleImports { get; init; } = new();
+
+    /// <summary>
     /// Computes the overall health status from the diagnostic data.
     /// Returns <c>"errors"</c>, <c>"warnings"</c>, or <c>"healthy"</c>.
     /// </summary>
     public static string ComputeStatus(DoctorReport report)
     {
+        // Spec 011 FR-263-5: any module-import error escalates to errors;
+        // module/pattern warnings escalate to warnings. Existing rules preserved.
+        var moduleImports = report.ModuleImports;
+        var hasModuleErrors = false;
+        var hasModuleWarnings = false;
+        var hasPatternWarnings = false;
+        for (var i = 0; i < moduleImports.Modules.Count; i++)
+        {
+            var status = moduleImports.Modules[i].Status;
+            if (string.Equals(status, "error", StringComparison.Ordinal))
+                hasModuleErrors = true;
+            else if (string.Equals(status, "warning", StringComparison.Ordinal))
+                hasModuleWarnings = true;
+        }
+        for (var i = 0; i < moduleImports.Patterns.Count; i++)
+        {
+            if (string.Equals(moduleImports.Patterns[i].Status, "warning", StringComparison.Ordinal))
+                hasPatternWarnings = true;
+        }
+
         if (report.FunctionsTools.ConfiguredFunctionsMissing > 0
             || report.McpDefinitions.Resources.Errors.Count > 0
             || report.McpDefinitions.Prompts.Errors.Count > 0
-            || report.ConfigurationErrors.Count > 0)
+            || report.ConfigurationErrors.Count > 0
+            || hasModuleErrors)
             return "errors";
         if (report.Warnings.Count > 0
             || report.McpDefinitions.Resources.Warnings.Count > 0
-            || report.McpDefinitions.Prompts.Warnings.Count > 0)
+            || report.McpDefinitions.Prompts.Warnings.Count > 0
+            || hasModuleWarnings
+            || hasPatternWarnings)
             return "warnings";
         return "healthy";
     }
@@ -598,4 +633,154 @@ public sealed record OutOfProcessSection
     /// <summary>If <see cref="HostScriptResolved"/> is false, a short error description.</summary>
     [JsonPropertyName("hostScriptError")]
     public string? HostScriptError { get; init; }
+}
+
+/// <summary>
+/// Spec 011 (FR-263-1, FR-263-6): per-module / per-pattern / per-tool import
+/// diagnostics. Renders as the <c>moduleImports</c> JSON property on
+/// <see cref="DoctorReport"/>. The text renderer omits the section entirely
+/// when all three arrays are empty.
+/// </summary>
+public sealed record ModuleImportsSection
+{
+    /// <summary>
+    /// One entry per <see cref="PowerShellConfiguration.Modules"/> entry,
+    /// reporting whether the module resolved on disk and how many tools it
+    /// contributed to the discovered set.
+    /// </summary>
+    [JsonPropertyName("modules")]
+    public List<ModuleImportEntry> Modules { get; init; } = [];
+
+    /// <summary>
+    /// One entry per pattern across
+    /// <see cref="PowerShellConfiguration.IncludePatterns"/> and
+    /// <see cref="PowerShellConfiguration.ExcludePatterns"/>, reporting which
+    /// branch (filter / discovery / exclude) executed and how many commands
+    /// it affected.
+    /// </summary>
+    [JsonPropertyName("patterns")]
+    public List<PatternImportEntry> Patterns { get; init; } = [];
+
+    /// <summary>
+    /// Per-discovered-tool attribution back to the configuration source that
+    /// produced it (FR-263-4). Empty when no tools were discovered.
+    /// </summary>
+    [JsonPropertyName("tools")]
+    public List<ToolImportEntry> Tools { get; init; } = [];
+}
+
+/// <summary>
+/// Spec 011 (FR-263-2): per-module diagnostic. <c>found / version / path</c>
+/// come from a single <c>Get-Module -ListAvailable</c> probe per module
+/// (<see cref="PoshMcp.Server.PowerShell.ModuleDiscovery.ProbeModules"/>);
+/// <c>contributedToolCount / contributedToolNames</c> are derived from the
+/// already-discovered tool set.
+/// </summary>
+public sealed record ModuleImportEntry
+{
+    /// <summary>The configured module name, preserved verbatim.</summary>
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary><c>true</c> when <c>Get-Module -ListAvailable</c> resolved at least one record.</summary>
+    [JsonPropertyName("found")]
+    public bool Found { get; init; }
+
+    /// <summary>Module version string, or <c>null</c> when not found.</summary>
+    [JsonPropertyName("version")]
+    public string? Version { get; init; }
+
+    /// <summary><c>ModuleBase</c> directory, or <c>null</c> when not found.</summary>
+    [JsonPropertyName("path")]
+    public string? Path { get; init; }
+
+    /// <summary>Count of tools attributed to this module after dedup and pattern filtering.</summary>
+    [JsonPropertyName("contributedToolCount")]
+    public int ContributedToolCount { get; init; }
+
+    /// <summary>MCP tool names attributed to this module.</summary>
+    [JsonPropertyName("contributedToolNames")]
+    public List<string> ContributedToolNames { get; init; } = [];
+
+    /// <summary><c>"ok"</c>, <c>"warning"</c>, or <c>"error"</c>.</summary>
+    [JsonPropertyName("status")]
+    public string Status { get; init; } = "ok";
+
+    /// <summary>Sanitized diagnostic message when <see cref="Status"/> is not <c>"ok"</c>.</summary>
+    [JsonPropertyName("diagnostic")]
+    public string? Diagnostic { get; init; }
+}
+
+/// <summary>
+/// Spec 011 (FR-263-3): per-pattern diagnostic. <c>role</c> records which
+/// branch the pattern executed in (<c>filter</c> when other sources populated
+/// the command set; <c>discovery</c> when the pattern itself drove discovery;
+/// <c>exclude</c> for entries from <see cref="PowerShellConfiguration.ExcludePatterns"/>).
+/// </summary>
+public sealed record PatternImportEntry
+{
+    /// <summary>The configured pattern, preserved verbatim.</summary>
+    [JsonPropertyName("pattern")]
+    public string Pattern { get; init; } = string.Empty;
+
+    /// <summary><c>"include"</c> or <c>"exclude"</c>.</summary>
+    [JsonPropertyName("kind")]
+    public string Kind { get; init; } = string.Empty;
+
+    /// <summary><c>"filter"</c>, <c>"discovery"</c>, or <c>"exclude"</c>.</summary>
+    [JsonPropertyName("role")]
+    public string Role { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Count of commands the pattern affected. Meaning depends on <see cref="Role"/>:
+    /// for <c>filter</c> and <c>discovery</c>, the number retained; for <c>exclude</c>,
+    /// the number dropped.
+    /// </summary>
+    [JsonPropertyName("matchedCount")]
+    public int MatchedCount { get; init; }
+
+    /// <summary><c>"ok"</c> or <c>"warning"</c>; <c>"warning"</c> for dead patterns.</summary>
+    [JsonPropertyName("status")]
+    public string Status { get; init; } = "ok";
+
+    /// <summary>Diagnostic message when <see cref="Status"/> is <c>"warning"</c>.</summary>
+    [JsonPropertyName("diagnostic")]
+    public string? Diagnostic { get; init; }
+}
+
+/// <summary>
+/// Spec 011 (FR-263-4): per-tool attribution back to its configuration source.
+/// Source priority is <c>commandName</c> &gt; <c>module</c> &gt; <c>pattern</c>
+/// (FR-263-9); <c>unknown</c> appears when the OOP wire format omits attribution
+/// fields (FR-263-11) or when in-process attribution cannot be resolved.
+/// </summary>
+public sealed record ToolImportEntry
+{
+    /// <summary>The MCP tool name (lowercase / snake_case).</summary>
+    [JsonPropertyName("toolName")]
+    public string ToolName { get; init; } = string.Empty;
+
+    /// <summary>The PowerShell command name (e.g. <c>Get-AzContext</c>).</summary>
+    [JsonPropertyName("commandName")]
+    public string CommandName { get; init; } = string.Empty;
+
+    /// <summary><c>"commandName"</c>, <c>"module"</c>, <c>"pattern"</c>, or <c>"unknown"</c>.</summary>
+    [JsonPropertyName("source")]
+    public string Source { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The configured string that produced this tool: the command name for
+    /// <c>commandName</c>, the module name for <c>module</c>, the pattern
+    /// string for <c>pattern</c>, or empty for <c>unknown</c>.
+    /// </summary>
+    [JsonPropertyName("sourceDetail")]
+    public string SourceDetail { get; init; } = string.Empty;
+
+    /// <summary><c>"exposed"</c>, <c>"filteredOut"</c>, or <c>"discoveryFailed"</c>.</summary>
+    [JsonPropertyName("disposition")]
+    public string Disposition { get; init; } = "exposed";
+
+    /// <summary>Diagnostic message when <see cref="Disposition"/> is not <c>"exposed"</c>.</summary>
+    [JsonPropertyName("diagnostic")]
+    public string? Diagnostic { get; init; }
 }

--- a/PoshMcp.Server/Diagnostics/DoctorService.cs
+++ b/PoshMcp.Server/Diagnostics/DoctorService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -12,6 +13,7 @@ using ModelContextProtocol.Server;
 using PoshMcp.Server.Authentication;
 using PoshMcp.Server.McpPrompts;
 using PoshMcp.Server.McpResources;
+using PoshMcp.Server.Observability;
 using PoshMcp.Server.PowerShell;
 using PoshMcp.Server.PowerShell.OutOfProcess;
 
@@ -157,6 +159,7 @@ internal static class DoctorService
                 OopModulePaths = oopModulePaths,
             },
             OutOfProcess = BuildOutOfProcessSection(config, settings.FinalConfigPath, loggerFactory),
+            ModuleImports = BuildModuleImportsSection(config, tools, logger),
             ConfigurationErrors = [.. report.ConfigurationErrors, .. configurationErrors],
         };
 
@@ -268,6 +271,7 @@ internal static class DoctorService
             with
         {
             OutOfProcess = BuildOutOfProcessSection(config, configurationPath, Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance),
+            ModuleImports = BuildModuleImportsSection(config, tools, Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance),
         };
     }
 
@@ -746,5 +750,301 @@ internal static class DoctorService
     }
 
     private static string EscapeForPowerShell(string value) => "'" + value.Replace("'", "''") + "'";
+
+    // ── Spec 011 — Module Imports ────────────────────────────────────────────
+
+    /// <summary>
+    /// Spec 011 (FR-263-1, FR-263-7, FR-263-9, FR-263-10): build the
+    /// <see cref="ModuleImportsSection"/> from the live configuration and
+    /// already-discovered tool set. Performs at most one
+    /// <c>Get-Module -ListAvailable</c> probe per configured module
+    /// (<see cref="ModuleDiscovery.ProbeModules"/>); does not invoke
+    /// <c>Get-Command</c> a second time. Returns an empty section when the
+    /// configuration uses only <see cref="PowerShellConfiguration.CommandNames"/>
+    /// (FR-263-6).
+    /// </summary>
+    internal static ModuleImportsSection BuildModuleImportsSection(
+        PowerShellConfiguration config,
+        List<McpServerTool> tools,
+        ILogger logger)
+    {
+        if (config is null) throw new ArgumentNullException(nameof(config));
+        if (tools is null) throw new ArgumentNullException(nameof(tools));
+        if (logger is null) throw new ArgumentNullException(nameof(logger));
+
+        var configuredModules = config.Modules ?? [];
+        var includePatterns = config.IncludePatterns ?? [];
+        var excludePatterns = config.ExcludePatterns ?? [];
+        var hasModuleOrPattern = configuredModules.Count > 0
+            || includePatterns.Count > 0
+            || excludePatterns.Count > 0;
+
+        // FR-263-6: omit entirely when CommandNames-only.
+        if (!hasModuleOrPattern)
+            return new ModuleImportsSection();
+
+        IReadOnlyList<ModuleProbeResult> probes = [];
+        if (configuredModules.Count > 0)
+        {
+            try
+            {
+                using var runspace = new IsolatedPowerShellRunspace();
+                probes = ModuleDiscovery.ProbeModules(runspace, configuredModules, logger);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning("Module probing failed: {Message}", LogSanitizer.Scrub(ex.Message));
+                probes = configuredModules
+                    .Select(m => new ModuleProbeResult(m, false, null, null))
+                    .ToList();
+            }
+        }
+
+        return BuildModuleImportsSection(config, tools, probes, logger);
+    }
+
+    /// <summary>
+    /// Spec 011: pure logic overload accepting pre-computed module probes.
+    /// Lets unit tests exercise the section without spinning up a runspace.
+    /// </summary>
+    internal static ModuleImportsSection BuildModuleImportsSection(
+        PowerShellConfiguration config,
+        List<McpServerTool> tools,
+        IReadOnlyList<ModuleProbeResult> moduleProbes,
+        ILogger logger)
+    {
+        if (config is null) throw new ArgumentNullException(nameof(config));
+        if (tools is null) throw new ArgumentNullException(nameof(tools));
+        if (moduleProbes is null) throw new ArgumentNullException(nameof(moduleProbes));
+        if (logger is null) throw new ArgumentNullException(nameof(logger));
+
+        var configuredModules = config.Modules ?? [];
+        var includePatterns = config.IncludePatterns ?? [];
+        var excludePatterns = config.ExcludePatterns ?? [];
+        var commandNames = config.CommandNames ?? [];
+        var effectiveCommandNames = config.GetEffectiveCommandNames() ?? [];
+        var hasModuleOrPattern = configuredModules.Count > 0
+            || includePatterns.Count > 0
+            || excludePatterns.Count > 0;
+
+        if (!hasModuleOrPattern)
+            return new ModuleImportsSection();
+
+        // Build per-tool attribution first (FR-263-9 source priority:
+        // commandName > module > pattern > unknown).
+        var commandNameSet = new HashSet<string>(commandNames, StringComparer.OrdinalIgnoreCase);
+        var includePatternSet = includePatterns.ToList();
+        var excludePatternSet = excludePatterns.ToList();
+        var moduleNameSet = new HashSet<string>(configuredModules, StringComparer.OrdinalIgnoreCase);
+
+        var toolEntries = new List<ToolImportEntry>(tools.Count);
+        var moduleContributions = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var name in configuredModules)
+            moduleContributions[name] = [];
+        var patternMatchCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var p in includePatternSet)
+            patternMatchCounts[p] = 0;
+
+        foreach (var tool in tools)
+        {
+            var (toolName, commandName) = ExtractToolIdentity(tool);
+            if (string.IsNullOrWhiteSpace(toolName))
+                continue;
+
+            string source;
+            string sourceDetail;
+            if (!string.IsNullOrEmpty(commandName) && commandNameSet.Contains(commandName))
+            {
+                source = "commandName";
+                sourceDetail = commandName;
+            }
+            else if (configuredModules.Count == 1)
+            {
+                // FR-263-9 + best-effort attribution: when exactly one module is
+                // configured and the tool is not a CommandNames hit, attribute
+                // it to that module. Multi-module attribution requires CommandInfo
+                // threading (Phase 2 — Hermes wires sourceModule on the wire format).
+                source = "module";
+                sourceDetail = configuredModules[0];
+                moduleContributions[configuredModules[0]].Add(toolName);
+            }
+            else if (configuredModules.Count > 1)
+            {
+                source = "unknown";
+                sourceDetail = string.Empty;
+            }
+            else if (includePatternSet.Count > 0)
+            {
+                // No modules configured — attribute to the first matching include pattern.
+                var matched = includePatternSet.FirstOrDefault(p =>
+                    !string.IsNullOrEmpty(commandName) && PatternMatches(p, commandName));
+                if (matched is not null)
+                {
+                    source = "pattern";
+                    sourceDetail = matched;
+                    patternMatchCounts[matched] = patternMatchCounts.GetValueOrDefault(matched) + 1;
+                }
+                else
+                {
+                    source = "unknown";
+                    sourceDetail = string.Empty;
+                }
+            }
+            else
+            {
+                source = "unknown";
+                sourceDetail = string.Empty;
+            }
+
+            toolEntries.Add(new ToolImportEntry
+            {
+                ToolName = toolName,
+                CommandName = commandName ?? string.Empty,
+                Source = source,
+                SourceDetail = sourceDetail,
+                Disposition = "exposed",
+            });
+        }
+
+        // Build per-module entries.
+        var probeMap = moduleProbes.ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
+        var moduleEntries = new List<ModuleImportEntry>(configuredModules.Count);
+        foreach (var name in configuredModules)
+        {
+            probeMap.TryGetValue(name, out var probe);
+            var found = probe?.Found ?? false;
+            var contributed = moduleContributions.GetValueOrDefault(name) ?? [];
+            string status;
+            string? diagnostic;
+            if (!found)
+            {
+                status = "error";
+                diagnostic = $"Module '{LogSanitizer.Scrub(name)}' not found via Get-Module -ListAvailable.";
+            }
+            else if (contributed.Count == 0)
+            {
+                status = "warning";
+                diagnostic = $"Module '{LogSanitizer.Scrub(name)}' resolved but contributed no tools (filtered out, or attribution requires Phase 2 wire fields).";
+            }
+            else
+            {
+                status = "ok";
+                diagnostic = null;
+            }
+
+            moduleEntries.Add(new ModuleImportEntry
+            {
+                Name = name,
+                Found = found,
+                Version = probe?.Version,
+                Path = probe?.Path,
+                ContributedToolCount = contributed.Count,
+                ContributedToolNames = contributed.OrderBy(n => n, StringComparer.Ordinal).ToList(),
+                Status = status,
+                Diagnostic = diagnostic,
+            });
+        }
+
+        // Build per-pattern entries.
+        var anyConfiguredCommands = commandNames.Count > 0 || configuredModules.Count > 0;
+        var patternEntries = new List<PatternImportEntry>(includePatternSet.Count + excludePatternSet.Count);
+        foreach (var p in includePatternSet)
+        {
+            // Role: 'filter' when other sources populated the candidate set;
+            // 'discovery' when the pattern is the sole driver.
+            var role = anyConfiguredCommands ? "filter" : "discovery";
+            var matchedCount = patternMatchCounts.GetValueOrDefault(p);
+            // For 'filter' role with no patternMatchCounts (because attribution
+            // went to commandName/module first), recompute against discovered tools.
+            if (role == "filter")
+            {
+                matchedCount = toolEntries.Count(t =>
+                    !string.IsNullOrEmpty(t.CommandName) && PatternMatches(p, t.CommandName));
+            }
+            var status = matchedCount == 0 ? "warning" : "ok";
+            string? diag = matchedCount == 0
+                ? $"Include pattern '{LogSanitizer.Scrub(p)}' matched no discovered commands."
+                : null;
+            patternEntries.Add(new PatternImportEntry
+            {
+                Pattern = p,
+                Kind = "include",
+                Role = role,
+                MatchedCount = matchedCount,
+                Status = status,
+                Diagnostic = diag,
+            });
+        }
+        foreach (var p in excludePatternSet)
+        {
+            // Exclude patterns drop commands, so 'matchedCount' is the number dropped.
+            // We can't know that without the pre-filter set; report 0 with a
+            // diagnostic when the pattern matches no discovered tool name (i.e. it
+            // either dropped everything that matched, or was never relevant).
+            var matchedCount = toolEntries.Count(t =>
+                !string.IsNullOrEmpty(t.CommandName) && PatternMatches(p, t.CommandName));
+            var status = matchedCount > 0 ? "warning" : "ok";
+            string? diag = matchedCount > 0
+                ? $"Exclude pattern '{LogSanitizer.Scrub(p)}' did not drop matching tool '{LogSanitizer.Scrub(toolEntries.First(t => PatternMatches(p, t.CommandName)).ToolName)}'."
+                : null;
+            patternEntries.Add(new PatternImportEntry
+            {
+                Pattern = p,
+                Kind = "exclude",
+                Role = "exclude",
+                MatchedCount = matchedCount,
+                Status = status,
+                Diagnostic = diag,
+            });
+        }
+
+        return new ModuleImportsSection
+        {
+            Modules = moduleEntries,
+            Patterns = patternEntries,
+            Tools = toolEntries,
+        };
+    }
+
+    /// <summary>
+    /// Spec 011: extract <c>(toolName, commandName)</c> from an
+    /// <see cref="McpServerTool"/>. <c>commandName</c> is sourced from
+    /// <see cref="ModelContextProtocol.Protocol.Tool.Title"/> when set
+    /// (McpToolFactoryV2 stores the original PowerShell command name there);
+    /// falls back to <c>null</c> when the tool was synthesized without a Title.
+    /// </summary>
+    private static (string toolName, string? commandName) ExtractToolIdentity(McpServerTool tool)
+    {
+        try
+        {
+            var protocol = tool.ProtocolTool;
+            var name = protocol.Name ?? string.Empty;
+            var title = protocol.Title;
+            return (name, string.IsNullOrWhiteSpace(title) ? null : title);
+        }
+        catch
+        {
+            return (string.Empty, null);
+        }
+    }
+
+    /// <summary>
+    /// PowerShell-style wildcard match against a single command name.
+    /// Translates <c>*</c> and <c>?</c> to a regex; case-insensitive.
+    /// </summary>
+    private static bool PatternMatches(string pattern, string? value)
+    {
+        if (string.IsNullOrEmpty(pattern) || string.IsNullOrEmpty(value))
+            return false;
+        try
+        {
+            var regex = "^" + Regex.Escape(pattern).Replace("\\*", ".*").Replace("\\?", ".") + "$";
+            return Regex.IsMatch(value, regex, RegexOptions.IgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
+    }
 
 }

--- a/PoshMcp.Server/Diagnostics/DoctorTextRenderer.cs
+++ b/PoshMcp.Server/Diagnostics/DoctorTextRenderer.cs
@@ -18,9 +18,15 @@ public static class DoctorTextRenderer
             FormatSection("Environment Variables", RenderEnvironmentVariables(report.EnvironmentVariables)),
             FormatSection("PowerShell",            RenderPowerShell(report.PowerShell)),
             FormatSection("Functions/Tools",       RenderFunctionsTools(report.FunctionsTools)),
-            FormatSection("MCP Definitions",       RenderMcpDefinitions(report.McpDefinitions)),
-            FormatSection("Authentication",        RenderAuthentication(report.Authentication, report.Identity)),
         };
+
+        // Spec 011 FR-263-6: omit Module Imports section entirely when all three
+        // arrays are empty (e.g., CommandNames-only configurations).
+        if (HasModuleImports(report.ModuleImports))
+            parts.Add(FormatSection("Module Imports", RenderModuleImports(report.ModuleImports)));
+
+        parts.Add(FormatSection("MCP Definitions",       RenderMcpDefinitions(report.McpDefinitions)));
+        parts.Add(FormatSection("Authentication",        RenderAuthentication(report.Authentication, report.Identity)));
 
         if (report.OutOfProcess.Applicable)
             parts.Add(FormatSection("Out-of-Process Execution", RenderOutOfProcess(report.OutOfProcess)));
@@ -245,6 +251,67 @@ public static class DoctorTextRenderer
         if (!section.HostScriptResolved && !string.IsNullOrWhiteSpace(section.HostScriptError))
         {
             lines.Add($"      error    : {section.HostScriptError}");
+        }
+
+        return string.Join("\n", lines);
+    }
+
+    // ── Spec 011 — Module Imports ────────────────────────────────────────────
+
+    /// <summary>FR-263-6: section is omitted when all three arrays are empty.</summary>
+    private static bool HasModuleImports(ModuleImportsSection section)
+        => section.Modules.Count > 0
+        || section.Patterns.Count > 0
+        || section.Tools.Count > 0;
+
+    private static string RenderModuleImports(ModuleImportsSection section)
+    {
+        var lines = new List<string>
+        {
+            $"  modules  : {section.Modules.Count} configured",
+        };
+
+        foreach (var m in section.Modules)
+        {
+            var sym = m.Status switch
+            {
+                "ok" => "✓",
+                "warning" => "⚠",
+                _ => "✗",
+            };
+            var statusUpper = m.Status.ToUpperInvariant();
+            var version = m.Version ?? "(unknown)";
+            lines.Add($"  - {m.Name} → {m.ContributedToolCount} tool(s) [v{version}] [{sym} {statusUpper}]");
+            if (!string.IsNullOrEmpty(m.Diagnostic))
+                lines.Add($"      {m.Diagnostic}");
+        }
+
+        if (section.Patterns.Count > 0)
+        {
+            lines.Add(string.Empty);
+            lines.Add($"  patterns : {section.Patterns.Count} configured");
+            foreach (var p in section.Patterns)
+            {
+                var sym = p.Status == "ok" ? "✓" : "⚠";
+                var statusUpper = p.Status.ToUpperInvariant();
+                lines.Add($"  - [{p.Kind}/{p.Role}] '{p.Pattern}' → {p.MatchedCount} match(es) [{sym} {statusUpper}]");
+                if (!string.IsNullOrEmpty(p.Diagnostic))
+                    lines.Add($"      {p.Diagnostic}");
+            }
+        }
+
+        if (section.Tools.Count > 0)
+        {
+            lines.Add(string.Empty);
+            lines.Add($"  tools    : {section.Tools.Count} attributed");
+            foreach (var t in section.Tools)
+            {
+                var sym = t.Disposition == "exposed" ? "✓" : "✗";
+                var detail = string.IsNullOrEmpty(t.SourceDetail) ? "" : $" ← {t.SourceDetail}";
+                lines.Add($"  - {t.ToolName} [{sym} {t.Source}{detail}]");
+                if (!string.IsNullOrEmpty(t.Diagnostic))
+                    lines.Add($"      {t.Diagnostic}");
+            }
         }
 
         return string.Join("\n", lines);

--- a/PoshMcp.Server/PowerShell/ModuleDiscovery.cs
+++ b/PoshMcp.Server/PowerShell/ModuleDiscovery.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.Management.Automation;
+using Microsoft.Extensions.Logging;
+using PSPowerShell = System.Management.Automation.PowerShell;
+
+namespace PoshMcp.Server.PowerShell;
+
+/// <summary>
+/// Result of probing a single configured module via
+/// <c>Get-Module -ListAvailable -Name &lt;name&gt;</c>. One result is produced
+/// per configured module name (FR-263-10: one PowerShell call per module,
+/// never per command).
+/// </summary>
+/// <param name="Name">
+/// The configured module name, preserved verbatim from the input. This is
+/// the key downstream consumers (doctor report, OOP wire format) match on.
+/// </param>
+/// <param name="Found">
+/// <c>true</c> when <c>Get-Module -ListAvailable</c> returned at least one
+/// module record for this name; <c>false</c> when the module is not
+/// installed in any path on <c>$env:PSModulePath</c>, or when probing threw.
+/// </param>
+/// <param name="Version">
+/// The version string of the first matching module (highest precedence path
+/// in <c>$env:PSModulePath</c>), or <c>null</c> when <see cref="Found"/> is
+/// <c>false</c> or the module record had no <c>Version</c> property value.
+/// </param>
+/// <param name="Path">
+/// The <c>ModuleBase</c> directory of the first matching module — i.e., the
+/// directory containing the module manifest (<c>.psd1</c>) or root module
+/// (<c>.psm1</c>). <c>null</c> when <see cref="Found"/> is <c>false</c> or
+/// the module record had no <c>ModuleBase</c> property value.
+/// </param>
+public sealed record ModuleProbeResult(
+    string Name,
+    bool Found,
+    string? Version,
+    string? Path);
+
+/// <summary>
+/// In-process helper for probing PowerShell module availability via
+/// <c>Get-Module -ListAvailable</c>. Used by the doctor report
+/// (<c>moduleImports</c> section) and by the in-process discovery pipeline
+/// to surface diagnostics about configured modules without importing them
+/// (no side effects).
+/// </summary>
+/// <remarks>
+/// Implements the in-process half of spec 011 (FR-263-10): exactly one
+/// <c>Get-Module</c> call per configured module name. Reuses the supplied
+/// runspace — never spawns a new <c>pwsh</c> process and never creates a
+/// new runspace lifecycle.
+/// </remarks>
+public static class ModuleDiscovery
+{
+    /// <summary>
+    /// Probes each configured module name once, returning availability,
+    /// version, and path information.
+    /// </summary>
+    /// <param name="runspace">
+    /// The runspace to use for probing. Production callers pass the
+    /// existing tool-discovery runspace; doctor callers may pass an
+    /// isolated runspace. The runspace is used in a thread-safe manner via
+    /// <see cref="IPowerShellRunspace.ExecuteThreadSafe(System.Action{PSPowerShell})"/>.
+    /// </param>
+    /// <param name="moduleNames">
+    /// The configured module names from
+    /// <see cref="PowerShellConfiguration.Modules"/>. Each non-blank entry
+    /// produces exactly one <see cref="ModuleProbeResult"/> in the output,
+    /// preserving input order. <c>null</c>, empty, or blank entries are
+    /// skipped.
+    /// </param>
+    /// <param name="logger">
+    /// Optional logger for diagnostic output. Probe failures are logged at
+    /// warning level and yield a <c>Found=false</c> result; they never
+    /// throw out of this method.
+    /// </param>
+    /// <returns>
+    /// One <see cref="ModuleProbeResult"/> per non-blank input module name,
+    /// in input order. Empty when <paramref name="moduleNames"/> is empty
+    /// or contains only blank entries.
+    /// </returns>
+    public static IReadOnlyList<ModuleProbeResult> ProbeModules(
+        IPowerShellRunspace runspace,
+        IReadOnlyList<string>? moduleNames,
+        ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(runspace);
+
+        if (moduleNames is null || moduleNames.Count == 0)
+        {
+            return Array.Empty<ModuleProbeResult>();
+        }
+
+        var results = new List<ModuleProbeResult>(moduleNames.Count);
+
+        runspace.ExecuteThreadSafe(ps =>
+        {
+            foreach (var rawName in moduleNames)
+            {
+                if (string.IsNullOrWhiteSpace(rawName))
+                {
+                    continue;
+                }
+
+                var name = rawName.Trim();
+                results.Add(ProbeOne(ps, name, logger));
+            }
+        });
+
+        return results;
+    }
+
+    private static ModuleProbeResult ProbeOne(PSPowerShell ps, string name, ILogger? logger)
+    {
+        try
+        {
+            ps.Commands.Clear();
+            ps.AddCommand("Get-Module")
+                .AddParameter("Name", name)
+                .AddParameter("ListAvailable")
+                .AddParameter("ErrorAction", "SilentlyContinue");
+
+            var moduleInfos = ps.Invoke();
+            ps.Commands.Clear();
+
+            if (moduleInfos is null || moduleInfos.Count == 0)
+            {
+                return new ModuleProbeResult(name, Found: false, Version: null, Path: null);
+            }
+
+            var first = moduleInfos[0];
+            var version = TryReadProperty(first, "Version");
+            var path = TryReadProperty(first, "ModuleBase");
+
+            return new ModuleProbeResult(name, Found: true, Version: version, Path: path);
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex, "Failed to probe module '{ModuleName}': {Message}", name, ex.Message);
+            // Make sure a partial AddCommand state can't leak to the next iteration.
+            try { ps.Commands.Clear(); } catch { /* best-effort cleanup */ }
+            return new ModuleProbeResult(name, Found: false, Version: null, Path: null);
+        }
+    }
+
+    private static string? TryReadProperty(PSObject psObject, string propertyName)
+    {
+        if (psObject is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var prop = psObject.Properties[propertyName];
+            var value = prop?.Value;
+            if (value is null)
+            {
+                return null;
+            }
+
+            var str = value.ToString();
+            return string.IsNullOrWhiteSpace(str) ? null : str;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/PoshMcp.Tests/Unit/Diagnostics/DoctorModuleImportsTests.cs
+++ b/PoshMcp.Tests/Unit/Diagnostics/DoctorModuleImportsTests.cs
@@ -1,0 +1,332 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.Server;
+using PoshMcp;
+using PoshMcp.Server.PowerShell;
+using Xunit;
+
+namespace PoshMcp.Tests.Unit.Diagnostics;
+
+/// <summary>
+/// Spec 011 (Issue #267): exercise <see cref="DoctorService.BuildModuleImportsSection"/>
+/// across the eight FR-263-12 scenarios plus the SC-263-4 backward-compatibility
+/// regression and a renderer snapshot.
+/// </summary>
+[Trait("Category", "Unit")]
+public class DoctorModuleImportsTests
+{
+    // ── Test fakes ──────────────────────────────────────────────────────────
+
+    private static McpServerTool MakeTool(string toolName, string commandName)
+    {
+        var stub = new System.Func<string>(() => "stub");
+        return McpServerTool.Create(stub, new McpServerToolCreateOptions
+        {
+            Name = toolName,
+            Title = commandName, // McpToolFactoryV2 stores the PowerShell command name in Title
+            Description = "stub",
+        });
+    }
+
+    private static ModuleProbeResult Found(string name, string version = "1.0.0", string path = "C:\\Modules\\stub")
+        => new(name, true, version, path);
+
+    private static ModuleProbeResult NotFound(string name)
+        => new(name, false, null, null);
+
+    // ── FR-263-12 case 1: known module that resolves and contributes tools ──
+
+    [Fact]
+    public void BuildModuleImportsSection_KnownModule_ResolvesAndContributesTools()
+    {
+        var config = new PowerShellConfiguration { Modules = new() { "Az.Accounts" } };
+        var tools = new List<McpServerTool>
+        {
+            MakeTool("connect_az_account", "Connect-AzAccount"),
+            MakeTool("get_az_context", "Get-AzContext"),
+        };
+        var probes = new List<ModuleProbeResult> { Found("Az.Accounts", "2.13.0", "C:\\Az.Accounts") };
+
+        var section = DoctorService.BuildModuleImportsSection(config, tools, probes, NullLogger.Instance);
+
+        var module = Assert.Single(section.Modules);
+        Assert.Equal("Az.Accounts", module.Name);
+        Assert.True(module.Found);
+        Assert.Equal("2.13.0", module.Version);
+        Assert.Equal(2, module.ContributedToolCount);
+        Assert.Equal("ok", module.Status);
+        Assert.Null(module.Diagnostic);
+        Assert.All(section.Tools, t => Assert.Equal("module", t.Source));
+        Assert.All(section.Tools, t => Assert.Equal("Az.Accounts", t.SourceDetail));
+    }
+
+    // ── FR-263-12 case 2: misnamed module that does not resolve ─────────────
+
+    [Fact]
+    public void BuildModuleImportsSection_MisnamedModule_FlagsErrorStatus()
+    {
+        var config = new PowerShellConfiguration { Modules = new() { "Az.Acconts" } }; // typo
+        var tools = new List<McpServerTool>();
+        var probes = new List<ModuleProbeResult> { NotFound("Az.Acconts") };
+
+        var section = DoctorService.BuildModuleImportsSection(config, tools, probes, NullLogger.Instance);
+
+        var module = Assert.Single(section.Modules);
+        Assert.False(module.Found);
+        Assert.Equal("error", module.Status);
+        Assert.NotNull(module.Diagnostic);
+        Assert.Contains("not found", module.Diagnostic!);
+    }
+
+    // ── FR-263-12 case 3: include pattern acting as filter ──────────────────
+
+    [Fact]
+    public void BuildModuleImportsSection_IncludePattern_AsFilter_TagsRoleFilter()
+    {
+        var config = new PowerShellConfiguration
+        {
+            Modules = new() { "Az.Accounts" },
+            IncludePatterns = new() { "Get-*" },
+        };
+        var tools = new List<McpServerTool>
+        {
+            MakeTool("get_az_context", "Get-AzContext"),
+        };
+        var probes = new List<ModuleProbeResult> { Found("Az.Accounts") };
+
+        var section = DoctorService.BuildModuleImportsSection(config, tools, probes, NullLogger.Instance);
+
+        var pattern = Assert.Single(section.Patterns);
+        Assert.Equal("filter", pattern.Role);
+        Assert.Equal("include", pattern.Kind);
+        Assert.Equal(1, pattern.MatchedCount);
+        Assert.Equal("ok", pattern.Status);
+    }
+
+    // ── FR-263-12 case 4: include pattern acting as discovery ───────────────
+
+    [Fact]
+    public void BuildModuleImportsSection_IncludePattern_AsDiscovery_TagsRoleDiscovery()
+    {
+        var config = new PowerShellConfiguration
+        {
+            IncludePatterns = new() { "Get-*" },
+        };
+        var tools = new List<McpServerTool>
+        {
+            MakeTool("get_thing", "Get-Thing"),
+        };
+        var probes = new List<ModuleProbeResult>();
+
+        var section = DoctorService.BuildModuleImportsSection(config, tools, probes, NullLogger.Instance);
+
+        var pattern = Assert.Single(section.Patterns);
+        Assert.Equal("discovery", pattern.Role);
+        Assert.Equal(1, pattern.MatchedCount);
+        Assert.Equal("ok", pattern.Status);
+    }
+
+    // ── FR-263-12 case 5: exclude pattern that drops nothing ────────────────
+
+    [Fact]
+    public void BuildModuleImportsSection_ExcludePattern_NoMatches_StatusOk()
+    {
+        var config = new PowerShellConfiguration
+        {
+            Modules = new() { "Az.Accounts" },
+            ExcludePatterns = new() { "Remove-*" },
+        };
+        var tools = new List<McpServerTool>
+        {
+            MakeTool("get_az_context", "Get-AzContext"),
+        };
+        var probes = new List<ModuleProbeResult> { Found("Az.Accounts") };
+
+        var section = DoctorService.BuildModuleImportsSection(config, tools, probes, NullLogger.Instance);
+
+        var pattern = Assert.Single(section.Patterns);
+        Assert.Equal("exclude", pattern.Role);
+        Assert.Equal(0, pattern.MatchedCount);
+        Assert.Equal("ok", pattern.Status);
+    }
+
+    // ── FR-263-12 case 6: dead include pattern (matches nothing) ────────────
+
+    [Fact]
+    public void BuildModuleImportsSection_DeadIncludePattern_FlagsWarning()
+    {
+        var config = new PowerShellConfiguration
+        {
+            Modules = new() { "Az.Accounts" },
+            IncludePatterns = new() { "DoesNotExist-*" },
+        };
+        var tools = new List<McpServerTool>
+        {
+            MakeTool("get_az_context", "Get-AzContext"),
+        };
+        var probes = new List<ModuleProbeResult> { Found("Az.Accounts") };
+
+        var section = DoctorService.BuildModuleImportsSection(config, tools, probes, NullLogger.Instance);
+
+        var pattern = Assert.Single(section.Patterns);
+        Assert.Equal(0, pattern.MatchedCount);
+        Assert.Equal("warning", pattern.Status);
+        Assert.NotNull(pattern.Diagnostic);
+    }
+
+    // ── FR-263-12 case 7: mixed sources (commandName + module + pattern) ────
+
+    [Fact]
+    public void BuildModuleImportsSection_MixedSources_PrefersCommandNameThenModule()
+    {
+        var config = new PowerShellConfiguration
+        {
+            CommandNames = new() { "Get-Date" },
+            Modules = new() { "Az.Accounts" },
+            IncludePatterns = new() { "Get-*" },
+        };
+        var tools = new List<McpServerTool>
+        {
+            MakeTool("get_date", "Get-Date"),         // → commandName
+            MakeTool("get_az_context", "Get-AzContext"), // → module (single-module heuristic)
+        };
+        var probes = new List<ModuleProbeResult> { Found("Az.Accounts") };
+
+        var section = DoctorService.BuildModuleImportsSection(config, tools, probes, NullLogger.Instance);
+
+        var byTool = section.Tools.ToDictionary(t => t.ToolName);
+        Assert.Equal("commandName", byTool["get_date"].Source);
+        Assert.Equal("Get-Date", byTool["get_date"].SourceDetail);
+        Assert.Equal("module", byTool["get_az_context"].Source);
+        Assert.Equal("Az.Accounts", byTool["get_az_context"].SourceDetail);
+    }
+
+    // ── FR-263-12 case 8 + SC-263-4: CommandNames-only omits the section ───
+
+    [Fact]
+    public void BuildModuleImportsSection_CommandNamesOnly_ReturnsEmptySection()
+    {
+        var config = new PowerShellConfiguration
+        {
+            CommandNames = new() { "Get-Date" },
+        };
+        var tools = new List<McpServerTool> { MakeTool("get_date", "Get-Date") };
+
+        var section = DoctorService.BuildModuleImportsSection(
+            config, tools, System.Array.Empty<ModuleProbeResult>(), NullLogger.Instance);
+
+        // FR-263-6: section is empty (renderer omits it entirely).
+        Assert.Empty(section.Modules);
+        Assert.Empty(section.Patterns);
+        Assert.Empty(section.Tools);
+    }
+
+    // ── ComputeStatus contract — flips healthy → errors on module errors ────
+
+    [Fact]
+    public void ComputeStatus_ModuleError_FlipsHealthyToErrors()
+    {
+        var report = new DoctorReport
+        {
+            ModuleImports = new ModuleImportsSection
+            {
+                Modules = new()
+                {
+                    new ModuleImportEntry
+                    {
+                        Name = "Az.Acconts",
+                        Found = false,
+                        Status = "error",
+                        Diagnostic = "not found",
+                    },
+                },
+            },
+        };
+
+        var status = DoctorReport.ComputeStatus(report);
+
+        Assert.Equal("errors", status);
+    }
+
+    [Fact]
+    public void ComputeStatus_PatternWarning_FlipsHealthyToWarnings()
+    {
+        var report = new DoctorReport
+        {
+            ModuleImports = new ModuleImportsSection
+            {
+                Patterns = new()
+                {
+                    new PatternImportEntry
+                    {
+                        Pattern = "DoesNotExist-*",
+                        Kind = "include",
+                        Role = "filter",
+                        MatchedCount = 0,
+                        Status = "warning",
+                        Diagnostic = "no matches",
+                    },
+                },
+            },
+        };
+
+        var status = DoctorReport.ComputeStatus(report);
+
+        Assert.Equal("warnings", status);
+    }
+
+    // ── Renderer snapshot for case 1 (known module + tools) ─────────────────
+
+    [Fact]
+    public void Renderer_KnownModuleWithTools_IncludesModuleImportsSection()
+    {
+        var report = new DoctorReport
+        {
+            ModuleImports = new ModuleImportsSection
+            {
+                Modules = new()
+                {
+                    new ModuleImportEntry
+                    {
+                        Name = "Az.Accounts",
+                        Found = true,
+                        Version = "2.13.0",
+                        ContributedToolCount = 1,
+                        ContributedToolNames = new() { "get_az_context" },
+                        Status = "ok",
+                    },
+                },
+                Tools = new()
+                {
+                    new ToolImportEntry
+                    {
+                        ToolName = "get_az_context",
+                        CommandName = "Get-AzContext",
+                        Source = "module",
+                        SourceDetail = "Az.Accounts",
+                        Disposition = "exposed",
+                    },
+                },
+            },
+        };
+
+        var rendered = DoctorTextRenderer.Render(report);
+
+        Assert.Contains("Module Imports", rendered);
+        Assert.Contains("Az.Accounts", rendered);
+        Assert.Contains("v2.13.0", rendered);
+        Assert.Contains("get_az_context", rendered);
+        Assert.Contains("← Az.Accounts", rendered);
+    }
+
+    [Fact]
+    public void Renderer_EmptyModuleImports_OmitsSectionHeader()
+    {
+        var report = new DoctorReport(); // ModuleImports default is empty
+
+        var rendered = DoctorTextRenderer.Render(report);
+
+        Assert.DoesNotContain("Module Imports", rendered);
+    }
+}

--- a/PoshMcp.Tests/Unit/ModuleDiscoveryTests.cs
+++ b/PoshMcp.Tests/Unit/ModuleDiscoveryTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using PoshMcp.Server.PowerShell;
+using Xunit;
+
+namespace PoshMcp.Tests.Unit;
+
+/// <summary>
+/// Unit tests for <see cref="ModuleDiscovery"/>. Verifies in-process module
+/// probing semantics from spec 011 — FR-263-10 (one Get-Module call per
+/// module name, never per command) and the contract used by the doctor
+/// report's <c>moduleImports</c> section.
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class ModuleDiscoveryTests : IDisposable
+{
+    private readonly IsolatedPowerShellRunspace _runspace;
+
+    public ModuleDiscoveryTests()
+    {
+        _runspace = new IsolatedPowerShellRunspace();
+    }
+
+    [Fact]
+    public void ProbeModules_NullList_ReturnsEmpty()
+    {
+        var results = ModuleDiscovery.ProbeModules(_runspace, moduleNames: null);
+
+        Assert.NotNull(results);
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void ProbeModules_EmptyList_ReturnsEmpty()
+    {
+        var results = ModuleDiscovery.ProbeModules(_runspace, Array.Empty<string>());
+
+        Assert.NotNull(results);
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void ProbeModules_OnlyBlankEntries_ReturnsEmpty()
+    {
+        var results = ModuleDiscovery.ProbeModules(_runspace, new[] { string.Empty, "   ", "\t" });
+
+        Assert.NotNull(results);
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void ProbeModules_NonExistentModule_ReturnsFoundFalse()
+    {
+        // A name that cannot exist on PSModulePath under any reasonable setup.
+        var name = "PoshMcp_NonExistent_Module_" + Guid.NewGuid().ToString("N");
+
+        var results = ModuleDiscovery.ProbeModules(_runspace, new[] { name });
+
+        var single = Assert.Single(results);
+        Assert.Equal(name, single.Name);
+        Assert.False(single.Found);
+        Assert.Null(single.Version);
+        Assert.Null(single.Path);
+    }
+
+    [Fact]
+    public void ProbeModules_BuiltInModule_ReturnsFoundWithVersionAndPath()
+    {
+        // Microsoft.PowerShell.Management ships with PowerShell itself and
+        // is always available on PSModulePath.
+        const string moduleName = "Microsoft.PowerShell.Management";
+
+        var results = ModuleDiscovery.ProbeModules(_runspace, new[] { moduleName });
+
+        var single = Assert.Single(results);
+        Assert.Equal(moduleName, single.Name);
+        Assert.True(single.Found, "Microsoft.PowerShell.Management should be available in any PowerShell install.");
+        Assert.False(string.IsNullOrWhiteSpace(single.Version));
+        Assert.False(string.IsNullOrWhiteSpace(single.Path));
+        Assert.True(Directory.Exists(single.Path), $"ModuleBase '{single.Path}' should be an existing directory.");
+    }
+
+    [Fact]
+    public void ProbeModules_PreservesInputOrder()
+    {
+        var missingName = "PoshMcp_Missing_" + Guid.NewGuid().ToString("N");
+        var input = new[]
+        {
+            missingName,
+            "Microsoft.PowerShell.Management",
+            "Microsoft.PowerShell.Utility",
+        };
+
+        var results = ModuleDiscovery.ProbeModules(_runspace, input);
+
+        Assert.Equal(input.Length, results.Count);
+        Assert.Equal(input[0], results[0].Name);
+        Assert.Equal(input[1], results[1].Name);
+        Assert.Equal(input[2], results[2].Name);
+    }
+
+    [Fact]
+    public void ProbeModules_TrimsWhitespaceAroundNames()
+    {
+        var results = ModuleDiscovery.ProbeModules(
+            _runspace,
+            new[] { "  Microsoft.PowerShell.Management  " });
+
+        var single = Assert.Single(results);
+        Assert.Equal("Microsoft.PowerShell.Management", single.Name);
+        Assert.True(single.Found);
+    }
+
+    [Fact]
+    public void ProbeModules_SkipsBlankEntriesButProbesValidOnes()
+    {
+        var input = new[] { string.Empty, "Microsoft.PowerShell.Management", "   " };
+
+        var results = ModuleDiscovery.ProbeModules(_runspace, input);
+
+        var single = Assert.Single(results);
+        Assert.Equal("Microsoft.PowerShell.Management", single.Name);
+        Assert.True(single.Found);
+    }
+
+    [Fact]
+    public void ProbeModules_NullRunspace_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => ModuleDiscovery.ProbeModules(runspace: null!, new[] { "Microsoft.PowerShell.Management" }));
+    }
+
+    [Fact]
+    public void ProbeModules_DuplicateNames_ProducesOneResultPerInputEntry()
+    {
+        // FR-263-10 says one Get-Module call per *configured* module name.
+        // If the user (or a config bug) supplies the same name twice, we
+        // honor the input shape — one result per input entry, in order.
+        var input = new[] { "Microsoft.PowerShell.Management", "Microsoft.PowerShell.Management" };
+
+        var results = ModuleDiscovery.ProbeModules(_runspace, input);
+
+        Assert.Equal(2, results.Count);
+        Assert.All(results, r => Assert.Equal("Microsoft.PowerShell.Management", r.Name));
+        Assert.All(results, r => Assert.True(r.Found));
+    }
+
+    public void Dispose()
+    {
+        _runspace.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary

C# half of spec 011 (doctor `moduleImports`). Closes #267.

Stacked on #269 (Hermes' `ModuleDiscovery` helper from
`squad/268-module-discovery`).

## What changed

- **`DoctorReport`** — 4 new sealed records (`ModuleImportsSection`,
  `ModuleImportEntry`, `PatternImportEntry`, `ToolImportEntry`) + extended
  `ComputeStatus` to flip `healthy → errors` on module errors and
  `healthy → warnings` on pattern warnings (FR-263-1, FR-263-3, FR-263-4).
- **`DoctorService.BuildModuleImportsSection`** — pure-logic overload
  taking pre-computed `IReadOnlyList<ModuleProbeResult>` (test seam) plus
  a runspace-driven overload used by both `BuildDoctorReportForCliAsync`
  and `BuildDoctorReportFromConfig`. Probes via Hermes'
  `ModuleDiscovery.ProbeModules` (FR-263-7 — single `Get-Module`
  invocation per configured module, no `Get-Command` re-walk).
  Tool-source attribution applies the FR-263-9 precedence chain
  (`commandName` > `module` > `pattern` > `unknown`). Diagnostics
  sanitized via `LogSanitizer.Scrub` (FR-263-13).
- **`DoctorTextRenderer`** — new `RenderModuleImports` between
  `Functions/Tools` and `MCP Definitions`, with `HasModuleImports` omit
  guard so the section disappears entirely for `CommandNames`-only
  configurations (FR-263-6, SC-263-4).
- **`DoctorModuleImportsTests`** — 12 new `[Trait("Category", "Unit")]`
  tests covering FR-263-12 cases 1–8, both `ComputeStatus` flip
  contracts, a renderer snapshot, and the empty-section omit case.

## Backward compatibility (SC-263-4)

`CommandNames`-only configurations are unchanged:
- The `moduleImports` section is empty (renderer omits it).
- `summary.status` is computed exactly as before.
- `functionsTools.configuredFunctionStatus` JSON is unaffected.

## Known limitation — Phase 2 follow-up

Per-tool module attribution is currently best-effort:

- `commandName` source is exact (matched against
  `config.CommandNames`).
- For exactly one configured module, non-`commandName` tools are
  attributed to that module (single-module heuristic).
- For multiple configured modules, non-`commandName` tools fall back
  to `source: "unknown"`.

Exact multi-module attribution requires the Phase 2 wire-format
extension that threads `sourceModule` through `RemoteToolSchema` /
`PowerShellCommandMetadata`. Documented in the decision drop and called
out in the in-code XML comments.

## Verification

- `dotnet build PoshMcp.Server -c Debug` → succeeded, 0 errors.
- `dotnet test --filter "FullyQualifiedName~DoctorModuleImportsTests"`
  → 12/12 pass (~150 ms total).
- `dotnet test --filter "Category=Unit"` → **461/461 pass** (35 s),
  no regressions.

## Breaking change

- `summary.status` flips `healthy → errors` when configured modules
  fail to resolve, and `healthy → warnings` when modules resolve with
  zero contributed tools or include patterns match nothing. Existing
  `CommandNames`-only configurations are unaffected. Documented in
  `CHANGELOG.md` under `## [Unreleased]` → `### Breaking`.

## Spec mapping

| Requirement | Implementation |
|---|---|
| FR-263-1 (section schema) | 4 sealed records on `DoctorReport` |
| FR-263-3 / FR-263-4 (status flips) | `DoctorReport.ComputeStatus` extension |
| FR-263-6 (omit when empty) | `HasModuleImports` guard in renderer |
| FR-263-7 (single probe) | Calls `ModuleDiscovery.ProbeModules` once |
| FR-263-9 (source precedence) | Attribution loop in `BuildModuleImportsSection` |
| FR-263-10 (pattern roles) | `Role = "filter" | "discovery" | "exclude"` |
| FR-263-12 (8 test cases) | `DoctorModuleImportsTests` |
| FR-263-13 (sanitized diagnostics) | `LogSanitizer.Scrub` on every diagnostic |
| SC-263-4 (backward compat) | Empty-section + omit-render path; covered by `BuildModuleImportsSection_CommandNamesOnly_ReturnsEmptySection` and `Renderer_EmptyModuleImports_OmitsSectionHeader` |
