### PR TITLE
feat(011): OOP wire-format parity for moduleImports (Phase 2 of #268)

### DIFF
--- a/PoshMcp.Server/Diagnostics/DoctorService.cs
+++ b/PoshMcp.Server/Diagnostics/DoctorService.cs
@@ -159,9 +159,31 @@ internal static class DoctorService
                 OopModulePaths = oopModulePaths,
             },
             OutOfProcess = BuildOutOfProcessSection(config, settings.FinalConfigPath, loggerFactory),
-            ModuleImports = BuildModuleImportsSection(config, tools, logger),
+            ModuleImports = BuildModuleImportsSection(config, tools, OopModuleImportsCapture.Current, logger),
             ConfigurationErrors = [.. report.ConfigurationErrors, .. configurationErrors],
         };
+
+        // Spec 011 FR-263-2 / FR-263-10: surface a one-time warning when
+        // running in OOP mode with a host that predates spec 011. The
+        // doctor moduleImports section still works (falls back to the
+        // in-process Get-Module probe path), but the OOP host could be
+        // upgraded to skip that round-trip and provide richer attribution.
+        var hasModuleOrPatternConfig = (config.Modules?.Count ?? 0) > 0
+            || (config.IncludePatterns?.Count ?? 0) > 0
+            || (config.ExcludePatterns?.Count ?? 0) > 0;
+        if (config.RuntimeMode == RuntimeMode.OutOfProcess
+            && hasModuleOrPatternConfig
+            && OopModuleImportsCapture.Current is null)
+        {
+            report = report with
+            {
+                Warnings =
+                [
+                    .. report.Warnings,
+                    "OOP host predates spec 011: 'moduleImports' payload not emitted by host. Doctor fell back to the in-process Get-Module probe path; per-tool source attribution may be reported as 'unknown'. Upgrade the OOP host to enable byte-parity moduleImports.",
+                ],
+            };
+        }
 
         report = report with
         {
@@ -768,6 +790,27 @@ internal static class DoctorService
         List<McpServerTool> tools,
         ILogger logger)
     {
+        return BuildModuleImportsSection(config, tools, oopPayload: null, logger);
+    }
+
+    /// <summary>
+    /// Spec 011 FR-263-2 / FR-263-10: overload that consumes a
+    /// <see cref="RemoteModuleImportsPayload"/> from the OOP host instead of
+    /// running the in-process <c>Get-Module -ListAvailable</c> probe. When
+    /// <paramref name="oopPayload"/> is non-null (OOP mode + spec-011-aware
+    /// host), per-module probe data and per-pattern match counts come
+    /// directly from the payload — no in-process runspace is created. When
+    /// <paramref name="oopPayload"/> is null (in-process mode, OOP mode with
+    /// an older host, or CommandNames-only configs), behavior matches the
+    /// pre-spec-011 path: run <see cref="ModuleDiscovery.ProbeModules"/>
+    /// when modules are configured.
+    /// </summary>
+    internal static ModuleImportsSection BuildModuleImportsSection(
+        PowerShellConfiguration config,
+        List<McpServerTool> tools,
+        RemoteModuleImportsPayload? oopPayload,
+        ILogger logger)
+    {
         if (config is null) throw new ArgumentNullException(nameof(config));
         if (tools is null) throw new ArgumentNullException(nameof(tools));
         if (logger is null) throw new ArgumentNullException(nameof(logger));
@@ -783,8 +826,25 @@ internal static class DoctorService
         if (!hasModuleOrPattern)
             return new ModuleImportsSection();
 
-        IReadOnlyList<ModuleProbeResult> probes = [];
-        if (configuredModules.Count > 0)
+        IReadOnlyList<ModuleProbeResult> probes;
+        if (oopPayload is not null && configuredModules.Count > 0)
+        {
+            // Spec 011 FR-263-10: build ModuleProbeResult[] from the OOP
+            // payload — skip the in-process Get-Module probe entirely.
+            var payloadProbeMap = oopPayload.Modules.ToDictionary(
+                p => p.Name, StringComparer.OrdinalIgnoreCase);
+            probes = configuredModules
+                .Select(name =>
+                {
+                    if (payloadProbeMap.TryGetValue(name, out var entry))
+                    {
+                        return new ModuleProbeResult(name, entry.Found, entry.Version, entry.Path);
+                    }
+                    return new ModuleProbeResult(name, false, null, null);
+                })
+                .ToList();
+        }
+        else if (configuredModules.Count > 0)
         {
             try
             {
@@ -798,6 +858,10 @@ internal static class DoctorService
                     .Select(m => new ModuleProbeResult(m, false, null, null))
                     .ToList();
             }
+        }
+        else
+        {
+            probes = [];
         }
 
         return BuildModuleImportsSection(config, tools, probes, logger);

--- a/PoshMcp.Server/Diagnostics/DoctorTextRenderer.cs
+++ b/PoshMcp.Server/Diagnostics/DoctorTextRenderer.cs
@@ -25,8 +25,8 @@ public static class DoctorTextRenderer
         if (HasModuleImports(report.ModuleImports))
             parts.Add(FormatSection("Module Imports", RenderModuleImports(report.ModuleImports)));
 
-        parts.Add(FormatSection("MCP Definitions",       RenderMcpDefinitions(report.McpDefinitions)));
-        parts.Add(FormatSection("Authentication",        RenderAuthentication(report.Authentication, report.Identity)));
+        parts.Add(FormatSection("MCP Definitions", RenderMcpDefinitions(report.McpDefinitions)));
+        parts.Add(FormatSection("Authentication", RenderAuthentication(report.Authentication, report.Identity)));
 
         if (report.OutOfProcess.Applicable)
             parts.Add(FormatSection("Out-of-Process Execution", RenderOutOfProcess(report.OutOfProcess)));

--- a/PoshMcp.Server/PowerShell/OutOfProcess/ICommandExecutor.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/ICommandExecutor.cs
@@ -50,4 +50,30 @@ public interface ICommandExecutor : IAsyncDisposable
         string commandName,
         IDictionary<string, object?> parameters,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Spec 011 FR-263-2 / FR-263-10: payload returned alongside the
+    /// <c>commands</c> array on the most recent <c>discover</c> response.
+    /// Surfaces per-module probe data and per-pattern match data so the
+    /// .NET consumer can build the doctor <c>moduleImports</c> section
+    /// without re-running <c>Get-Module -ListAvailable</c> in an
+    /// in-process runspace.
+    /// </summary>
+    /// <remarks>
+    /// <para><c>null</c> in any of the following cases:
+    /// <list type="bullet">
+    ///   <item>No discovery has been performed yet.</item>
+    ///   <item>The OOP host predates spec 011 (older hosts omit the
+    ///   <c>moduleImports</c> field from the discover response).</item>
+    ///   <item>The configuration uses only <c>CommandNames</c>
+    ///   (no modules or patterns; the host omits the payload because
+    ///   FR-263-6 requires the section to be empty).</item>
+    /// </list>
+    /// </para>
+    /// <para>Default implementation returns <c>null</c> so consumers that
+    /// don't care about this payload (and adapter implementations such as
+    /// the in-process path that don't run the OOP host at all) work without
+    /// changes.</para>
+    /// </remarks>
+    RemoteModuleImportsPayload? LastModuleImports => null;
 }

--- a/PoshMcp.Server/PowerShell/OutOfProcess/OopModuleImportsCapture.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/OopModuleImportsCapture.cs
@@ -1,0 +1,36 @@
+using System.Threading;
+
+namespace PoshMcp.Server.PowerShell.OutOfProcess;
+
+/// <summary>
+/// Spec 011 FR-263-2 / FR-263-10: AsyncLocal capture for the OOP host's
+/// <see cref="RemoteModuleImportsPayload"/> from the most recent discovery
+/// in the current async flow.
+/// </summary>
+/// <remarks>
+/// <para>The capture exists because <c>McpToolSetupService.DiscoverToolsAsync</c>
+/// disposes its OOP executor lease before returning, so the executor's
+/// <see cref="ICommandExecutor.LastModuleImports"/> is unavailable to the
+/// caller (DoctorService) by the time it builds the doctor moduleImports
+/// section. We stash the payload here on the way out and read it back in
+/// <c>BuildDoctorReportForCliAsync</c>.</para>
+/// <para>Scoped per async flow via <see cref="AsyncLocal{T}"/>; concurrent
+/// doctor invocations on different tasks see their own values. CLI doctor
+/// invocations are one-shot, so cross-invocation leaks are not a concern,
+/// but callers SHOULD invoke <see cref="Reset"/> before discovery to avoid
+/// stale captures from previous discovery attempts in the same flow.</para>
+/// </remarks>
+internal static class OopModuleImportsCapture
+{
+    private static readonly AsyncLocal<RemoteModuleImportsPayload?> _current = new();
+
+    /// <summary>Reads the current async flow's captured payload, or <c>null</c>
+    /// when none has been set in this flow.</summary>
+    public static RemoteModuleImportsPayload? Current => _current.Value;
+
+    /// <summary>Stores the payload for the current async flow.</summary>
+    public static void Set(RemoteModuleImportsPayload? payload) => _current.Value = payload;
+
+    /// <summary>Clears the current async flow's captured payload.</summary>
+    public static void Reset() => _current.Value = null;
+}

--- a/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessCommandExecutor.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessCommandExecutor.cs
@@ -36,6 +36,10 @@ public class OutOfProcessCommandExecutor : ICommandExecutor
     private OutOfProcessHost? _host;
     private bool _disposed;
     private IReadOnlyList<RemoteToolSchema>? _cachedSchemas;
+    private RemoteModuleImportsPayload? _cachedModuleImports;
+
+    /// <inheritdoc />
+    public RemoteModuleImportsPayload? LastModuleImports => _cachedModuleImports;
 
     // Cached setup parameters captured on first SetupAsync call so the
     // executor can replay environment configuration after an automatic
@@ -159,6 +163,25 @@ public class OutOfProcessCommandExecutor : ICommandExecutor
         {
             _logger.LogWarning("Discover response missing 'commands' property. Raw: {Raw}", result.GetRawText());
             schemas = new List<RemoteToolSchema>();
+        }
+
+        // Spec 011 FR-263-2 / FR-263-10: optional moduleImports payload from
+        // the OOP host. Older hosts omit this entirely; missing is fine and
+        // signals to consumers (DoctorService) to fall back to the in-process
+        // probe path with a one-time warning.
+        if (result.TryGetProperty("moduleImports", out var moduleImportsElement)
+            && moduleImportsElement.ValueKind != JsonValueKind.Null)
+        {
+            try
+            {
+                _cachedModuleImports = JsonSerializer.Deserialize<RemoteModuleImportsPayload>(
+                    moduleImportsElement.GetRawText(), options);
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogWarning(ex, "Failed to deserialize moduleImports payload; treating as absent.");
+                _cachedModuleImports = null;
+            }
         }
 
         _logger.LogInformation("Discovered {Count} commands via OOP subprocess.", schemas.Count);

--- a/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessSubprocessPool.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessSubprocessPool.cs
@@ -105,6 +105,13 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
     private string[]? _cachedDiscoveryModules;
     private IReadOnlyList<RemoteToolSchema>? _cachedSchemas;
     private string? _cachedSchemasFingerprint;
+    private RemoteModuleImportsPayload? _cachedModuleImports;
+
+    /// <inheritdoc />
+    public RemoteModuleImportsPayload? LastModuleImports
+    {
+        get { lock (_envLock) { return _cachedModuleImports; } }
+    }
 
     private CancellationTokenSource? _reconcilerCts;
     private Task? _reconcilerTask;
@@ -279,6 +286,7 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
                     _cachedSchemasFingerprint, fingerprint);
                 _cachedSchemas = null;
                 _cachedSchemasFingerprint = null;
+                _cachedModuleImports = null;
             }
         }
 
@@ -367,10 +375,31 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
             schemas = new List<RemoteToolSchema>();
         }
 
+        // Spec 011 FR-263-2 / FR-263-10: optional moduleImports payload from
+        // the OOP host. Older hosts omit this entirely; missing is fine and
+        // signals to consumers (DoctorService) to fall back to the in-process
+        // probe path with a one-time warning.
+        RemoteModuleImportsPayload? moduleImports = null;
+        if (result.TryGetProperty("moduleImports", out var moduleImportsElement)
+            && moduleImportsElement.ValueKind != JsonValueKind.Null)
+        {
+            try
+            {
+                moduleImports = JsonSerializer.Deserialize<RemoteModuleImportsPayload>(
+                    moduleImportsElement.GetRawText(), jsonOptions);
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogWarning(ex, "Failed to deserialize moduleImports payload; treating as absent.");
+                moduleImports = null;
+            }
+        }
+
         lock (_envLock)
         {
             _cachedSchemas = schemas;
             _cachedSchemasFingerprint = _cachedEnvFingerprint;
+            _cachedModuleImports = moduleImports;
         }
 
         _logger.LogInformation(

--- a/PoshMcp.Server/PowerShell/OutOfProcess/RemoteModuleImportsPayload.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/RemoteModuleImportsPayload.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+
+namespace PoshMcp.Server.PowerShell.OutOfProcess;
+
+/// <summary>
+/// Spec 011 FR-263-2 / FR-263-3 / FR-263-10: payload returned alongside the
+/// <c>commands</c> array on the OOP <c>discover</c> response. Surfaces the
+/// per-module probe data and per-pattern match data the OOP host already
+/// computed during discovery so the .NET consumer (DoctorService) can build
+/// the <c>moduleImports</c> doctor section without re-running
+/// <c>Get-Module -ListAvailable</c> in an in-process runspace.
+/// </summary>
+/// <remarks>
+/// Older OOP hosts (predating spec 011) omit this payload entirely. The
+/// .NET deserializer treats a missing top-level <c>moduleImports</c>
+/// property as <c>null</c>; consumers MUST fall back to the in-process
+/// probe path and emit a one-time warning to <c>DoctorReport.Warnings</c>.
+/// </remarks>
+public sealed class RemoteModuleImportsPayload
+{
+    /// <summary>
+    /// Per-module probe results (one entry per configured module name in the
+    /// <c>discover</c> request's <c>modules</c> array, regardless of whether
+    /// the module was found). Order mirrors the configured module order.
+    /// </summary>
+    public List<RemoteModuleProbe> Modules { get; set; } = new();
+
+    /// <summary>
+    /// Per-pattern match counts for include and exclude patterns. Order
+    /// mirrors the configured pattern order (includes first, then excludes).
+    /// </summary>
+    public List<RemotePatternMatch> Patterns { get; set; } = new();
+}
+
+/// <summary>
+/// Spec 011 FR-263-2 / FR-263-10: per-module probe result emitted by the OOP
+/// host. Mirrors <c>ModuleProbeResult</c> on the in-process side so the
+/// .NET consumer can build <c>ModuleImportsSection.Modules</c> directly
+/// from this payload when running in OOP mode.
+/// </summary>
+public sealed class RemoteModuleProbe
+{
+    /// <summary>
+    /// The configured module name (verbatim, as it appeared in the
+    /// configuration's <c>Modules</c> array).
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// <c>true</c> when <c>Get-Module -ListAvailable -Name &lt;Name&gt;</c>
+    /// returned at least one module; <c>false</c> otherwise (including when
+    /// the cmdlet threw).
+    /// </summary>
+    public bool Found { get; set; }
+
+    /// <summary>
+    /// Module version string (from <c>ModuleInfo.Version.ToString()</c>) for
+    /// the first matching module returned by <c>Get-Module -ListAvailable</c>.
+    /// <c>null</c> when <see cref="Found"/> is <c>false</c>.
+    /// </summary>
+    public string? Version { get; set; }
+
+    /// <summary>
+    /// Module manifest path (from <c>ModuleInfo.Path</c>) for the first
+    /// matching module returned by <c>Get-Module -ListAvailable</c>.
+    /// <c>null</c> when <see cref="Found"/> is <c>false</c>.
+    /// </summary>
+    public string? Path { get; set; }
+}
+
+/// <summary>
+/// Spec 011 FR-263-3 / FR-263-10: per-pattern match data emitted by the OOP
+/// host. Captures how many discovered commands matched each include or
+/// exclude pattern so the .NET consumer can build
+/// <c>ModuleImportsSection.Patterns</c> without re-walking the discovered
+/// command set.
+/// </summary>
+public sealed class RemotePatternMatch
+{
+    /// <summary>
+    /// The configured pattern (verbatim, as it appeared in
+    /// <c>IncludePatterns</c> or <c>ExcludePatterns</c>).
+    /// </summary>
+    public string Pattern { get; set; } = string.Empty;
+
+    /// <summary>
+    /// <c>"include"</c> for entries from <c>IncludePatterns</c>;
+    /// <c>"exclude"</c> for entries from <c>ExcludePatterns</c>.
+    /// </summary>
+    public string Kind { get; set; } = "include";
+
+    /// <summary>
+    /// Pattern role per FR-263-3:
+    /// <list type="bullet">
+    ///   <item><c>"discovery"</c> — pattern was the sole driver (no modules
+    ///   or command names configured).</item>
+    ///   <item><c>"filter"</c> — pattern narrowed an existing candidate set
+    ///   (modules and/or command names also configured).</item>
+    ///   <item><c>"exclude"</c> — pattern dropped commands from the
+    ///   candidate set.</item>
+    /// </list>
+    /// </summary>
+    public string Role { get; set; } = "filter";
+
+    /// <summary>
+    /// Number of discovered commands whose names matched this pattern.
+    /// For include patterns, this is the contributing count; for exclude
+    /// patterns, this is the dropped count (always 0 when the pattern
+    /// dropped everything that matched it; non-zero indicates leakage).
+    /// </summary>
+    public int MatchedCount { get; set; }
+}

--- a/PoshMcp.Server/PowerShell/OutOfProcess/RemoteToolSchema.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/RemoteToolSchema.cs
@@ -58,6 +58,39 @@ public class RemoteToolSchema
     /// Parameters for this command/parameter-set combination.
     /// </summary>
     public List<RemoteParameterSchema> Parameters { get; set; } = new();
+
+    /// <summary>
+    /// Spec 011 FR-263-11: configured module name that produced this command,
+    /// if attribution resolved to a module per FR-263-9 priority. Sourced from
+    /// <c>CommandInfo.ModuleName</c> when the module name appears in the
+    /// configured <c>Modules</c> list. <c>null</c> when attribution resolved
+    /// to <c>commandName</c> or <c>pattern</c> instead, or when the OOP host
+    /// predates spec 011 (older hosts omit this field; consumers MUST treat
+    /// missing/null as "unknown" and fall back to the in-process attribution
+    /// heuristic).
+    /// </summary>
+    public string? SourceModule { get; set; }
+
+    /// <summary>
+    /// Spec 011 FR-263-11: configured include pattern that matched this
+    /// command, if attribution resolved to <c>pattern</c> per FR-263-9
+    /// priority. <c>null</c> when attribution resolved to <c>commandName</c>
+    /// or <c>module</c> instead, or when the OOP host predates spec 011
+    /// (older hosts omit this field; consumers MUST treat missing/null as
+    /// "unknown" and fall back to the in-process attribution heuristic).
+    /// </summary>
+    public string? SourcePattern { get; set; }
+
+    /// <summary>
+    /// Spec 011 FR-263-11: verbatim configured string from whichever source
+    /// won attribution per FR-263-9 priority — the configured command name
+    /// when source is <c>commandName</c>, the configured module name when
+    /// source is <c>module</c>, the configured pattern when source is
+    /// <c>pattern</c>. <c>null</c> when the OOP host predates spec 011
+    /// (older hosts omit this field; consumers MUST treat missing/null as
+    /// "unknown" and fall back to the in-process attribution heuristic).
+    /// </summary>
+    public string? SourceDetail { get; set; }
 }
 
 /// <summary>

--- a/PoshMcp.Server/PowerShell/OutOfProcess/oop-host-pool.ps1
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/oop-host-pool.ps1
@@ -775,6 +775,11 @@ function Invoke-DiscoverHandler {
         param($modules, $functionNames, $includePatterns, $excludePatterns, $commonParameters)
 
         $commands = [System.Collections.ArrayList]::new()
+        # Spec 011 FR-263-9: per-command source attribution map.
+        $sourceMap = New-Object 'System.Collections.Generic.Dictionary[string,object]' ([System.StringComparer]::OrdinalIgnoreCase)
+        # Spec 011 FR-263-3: per-pattern match counts for include patterns.
+        $patternMatchCounts = @{}
+
         foreach ($moduleName in $modules) {
             try { Import-Module -Name $moduleName -ErrorAction Stop -WarningAction SilentlyContinue }
             catch { throw "Failed to import module '$moduleName': $_" }
@@ -783,7 +788,17 @@ function Invoke-DiscoverHandler {
         foreach ($name in $functionNames) {
             try {
                 $cmds = @(Get-Command -Name $name -ErrorAction SilentlyContinue)
-                foreach ($cmd in $cmds) { $null = $commands.Add($cmd) }
+                foreach ($cmd in $cmds) {
+                    $null = $commands.Add($cmd)
+                    if (-not $sourceMap.ContainsKey($cmd.Name)) {
+                        $sourceMap[$cmd.Name] = [pscustomobject]@{
+                            Source        = 'commandName'
+                            SourceModule  = $null
+                            SourcePattern = $null
+                            SourceDetail  = $name
+                        }
+                    }
+                }
             } catch { }
         }
 
@@ -794,7 +809,19 @@ function Invoke-DiscoverHandler {
                     foreach ($cmd in $cmds) {
                         $excluded = $false
                         foreach ($ep in $excludePatterns) { if ($cmd.Name -like $ep) { $excluded = $true; break } }
-                        if (-not $excluded) { $null = $commands.Add($cmd) }
+                        if (-not $excluded) {
+                            $null = $commands.Add($cmd)
+                            if (-not $patternMatchCounts.ContainsKey($pattern)) { $patternMatchCounts[$pattern] = 0 }
+                            $patternMatchCounts[$pattern]++
+                            if (-not $sourceMap.ContainsKey($cmd.Name)) {
+                                $sourceMap[$cmd.Name] = [pscustomobject]@{
+                                    Source        = 'module'
+                                    SourceModule  = $moduleName
+                                    SourcePattern = $null
+                                    SourceDetail  = $moduleName
+                                }
+                            }
+                        }
                     }
                 } catch { }
             }
@@ -807,7 +834,19 @@ function Invoke-DiscoverHandler {
                     foreach ($cmd in $cmds) {
                         $excluded = $false
                         foreach ($ep in $excludePatterns) { if ($cmd.Name -like $ep) { $excluded = $true; break } }
-                        if (-not $excluded) { $null = $commands.Add($cmd) }
+                        if (-not $excluded) {
+                            $null = $commands.Add($cmd)
+                            if (-not $patternMatchCounts.ContainsKey($pattern)) { $patternMatchCounts[$pattern] = 0 }
+                            $patternMatchCounts[$pattern]++
+                            if (-not $sourceMap.ContainsKey($cmd.Name)) {
+                                $sourceMap[$cmd.Name] = [pscustomobject]@{
+                                    Source        = 'pattern'
+                                    SourceModule  = $null
+                                    SourcePattern = $pattern
+                                    SourceDetail  = $pattern
+                                }
+                            }
+                        }
                     }
                 } catch { }
             }
@@ -928,16 +967,73 @@ function Invoke-DiscoverHandler {
                         ValidateSetValues = $paramAttrMeta.ValidateSetValues
                     })
                 }
+                $attribution = $null
+                if ($sourceMap.ContainsKey($cmd.Name)) { $attribution = $sourceMap[$cmd.Name] }
                 $null = $schemas.Add([ordered]@{
                     Name             = $cmd.Name
                     Description      = $helpMeta.Synopsis
                     FullDescription  = $helpMeta.FullDescription
                     ParameterSetName = $paramSet.Name
                     Parameters       = @($parameters)
+                    # Spec 011 FR-263-11: per-command source attribution.
+                    SourceModule     = if ($attribution) { $attribution.SourceModule } else { $null }
+                    SourcePattern    = if ($attribution) { $attribution.SourcePattern } else { $null }
+                    SourceDetail     = if ($attribution) { $attribution.SourceDetail } else { $null }
                 })
             }
         }
-        return ,@($schemas)
+
+        # Spec 011 FR-263-2 / FR-263-10: build the parallel moduleImports payload.
+        $modulesPayload = [System.Collections.ArrayList]::new()
+        foreach ($moduleName in $modules) {
+            $found = $false; $version = $null; $path = $null
+            try {
+                $availableModules = @(Get-Module -ListAvailable -Name $moduleName -ErrorAction SilentlyContinue)
+                if ($availableModules.Count -gt 0) {
+                    $found = $true
+                    $first = $availableModules[0]
+                    if ($null -ne $first.Version) { $version = "$($first.Version)" }
+                    if ($null -ne $first.Path) { $path = "$($first.Path)" }
+                }
+            } catch { }
+            $null = $modulesPayload.Add([ordered]@{
+                Name    = $moduleName
+                Found   = [bool]$found
+                Version = $version
+                Path    = $path
+            })
+        }
+
+        $anyOtherSource = ($modules.Count -gt 0) -or ($functionNames.Count -gt 0)
+        $patternsPayload = [System.Collections.ArrayList]::new()
+        foreach ($pattern in $includePatterns) {
+            $role = if ($anyOtherSource) { 'filter' } else { 'discovery' }
+            $matchedCount = 0
+            if ($patternMatchCounts.ContainsKey($pattern)) { $matchedCount = [int]$patternMatchCounts[$pattern] }
+            $null = $patternsPayload.Add([ordered]@{
+                Pattern      = $pattern
+                Kind         = 'include'
+                Role         = $role
+                MatchedCount = $matchedCount
+            })
+        }
+        foreach ($pattern in $excludePatterns) {
+            $matchedCount = 0
+            foreach ($cmd in $unique) { if ($cmd.Name -like $pattern) { $matchedCount++ } }
+            $null = $patternsPayload.Add([ordered]@{
+                Pattern      = $pattern
+                Kind         = 'exclude'
+                Role         = 'exclude'
+                MatchedCount = $matchedCount
+            })
+        }
+
+        $moduleImportsPayload = [ordered]@{
+            Modules  = @($modulesPayload)
+            Patterns = @($patternsPayload)
+        }
+
+        return ,@([pscustomobject]@{ Schemas = @($schemas); ModuleImports = $moduleImportsPayload })
     }
 
     $ps = [powershell]::Create()
@@ -957,8 +1053,21 @@ function Invoke-DiscoverHandler {
             return
         }
         $schemas = @()
-        if ($null -ne $output -and $output.Count -gt 0) { $schemas = @($output[0]) }
-        Write-NdjsonResponse -Id $Id -Result @{ commands = $schemas }
+        $moduleImports = $null
+        if ($null -ne $output -and $output.Count -gt 0) {
+            $payload = $output[0]
+            if ($null -ne $payload -and $null -ne $payload.Schemas) {
+                $schemas = @($payload.Schemas)
+                $moduleImports = $payload.ModuleImports
+            }
+            else {
+                # Defensive: legacy script shape (bare schema array).
+                $schemas = @($payload)
+            }
+        }
+        $result = @{ commands = $schemas }
+        if ($null -ne $moduleImports) { $result['moduleImports'] = $moduleImports }
+        Write-NdjsonResponse -Id $Id -Result $result
     }
     catch {
         Write-NdjsonResponse -Id $Id -ErrorObj @{ code = -1; message = "$_" }

--- a/PoshMcp.Server/PowerShell/OutOfProcess/oop-host.ps1
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/oop-host.ps1
@@ -778,6 +778,14 @@ function Invoke-DiscoverHandler {
     )
 
     $commands = [System.Collections.ArrayList]::new()
+    # Spec 011 FR-263-9: track per-command source attribution as commands
+    # are discovered. Priority: commandName > module > pattern. Keyed by
+    # command name (case-insensitive). Once a command is attributed it is
+    # not re-attributed by lower-priority loops.
+    $sourceMap = New-Object 'System.Collections.Generic.Dictionary[string,object]' ([System.StringComparer]::OrdinalIgnoreCase)
+    # Spec 011 FR-263-3: track include pattern match counts (per-pattern,
+    # case-sensitive: pattern strings are configured verbatim).
+    $patternMatchCounts = @{}
 
     # Import requested modules
     $modules = @()
@@ -828,6 +836,14 @@ function Invoke-DiscoverHandler {
             $cmds = @(Get-Command -Name $name -ErrorAction SilentlyContinue)
             foreach ($cmd in $cmds) {
                 $null = $commands.Add($cmd)
+                if (-not $sourceMap.ContainsKey($cmd.Name)) {
+                    $sourceMap[$cmd.Name] = [pscustomobject]@{
+                        Source        = 'commandName'
+                        SourceModule  = $null
+                        SourcePattern = $null
+                        SourceDetail  = $name
+                    }
+                }
             }
         }
         catch {
@@ -851,6 +867,20 @@ function Invoke-DiscoverHandler {
                     }
                     if (-not $excluded) {
                         $null = $commands.Add($cmd)
+                        if (-not $patternMatchCounts.ContainsKey($pattern)) { $patternMatchCounts[$pattern] = 0 }
+                        $patternMatchCounts[$pattern]++
+                        if (-not $sourceMap.ContainsKey($cmd.Name)) {
+                            # FR-263-9: prefer 'module' attribution over 'pattern'
+                            # when the command's ModuleName matches a configured
+                            # module (it always will here, since Get-Command was
+                            # scoped by -Module).
+                            $sourceMap[$cmd.Name] = [pscustomobject]@{
+                                Source        = 'module'
+                                SourceModule  = $moduleName
+                                SourcePattern = $null
+                                SourceDetail  = $moduleName
+                            }
+                        }
                     }
                 }
             }
@@ -870,7 +900,19 @@ function Invoke-DiscoverHandler {
                     foreach ($ep in $excludePatterns) {
                         if ($cmd.Name -like $ep) { $excluded = $true; break }
                     }
-                    if (-not $excluded) { $null = $commands.Add($cmd) }
+                    if (-not $excluded) {
+                        $null = $commands.Add($cmd)
+                        if (-not $patternMatchCounts.ContainsKey($pattern)) { $patternMatchCounts[$pattern] = 0 }
+                        $patternMatchCounts[$pattern]++
+                        if (-not $sourceMap.ContainsKey($cmd.Name)) {
+                            $sourceMap[$cmd.Name] = [pscustomobject]@{
+                                Source        = 'pattern'
+                                SourceModule  = $null
+                                SourcePattern = $pattern
+                                SourceDetail  = $pattern
+                            }
+                        }
+                    }
                 }
             }
             catch {
@@ -935,17 +977,97 @@ function Invoke-DiscoverHandler {
                 })
             }
 
+            $attribution = $null
+            if ($sourceMap.ContainsKey($cmd.Name)) { $attribution = $sourceMap[$cmd.Name] }
+
             $null = $schemas.Add([ordered]@{
                 Name             = $cmd.Name
                 Description      = $helpMeta.Synopsis
                 FullDescription  = $helpMeta.FullDescription
                 ParameterSetName = $paramSet.Name
                 Parameters       = @($parameters)
+                # Spec 011 FR-263-11: per-command source attribution. All
+                # three fields are nullable; only the one(s) corresponding to
+                # the winning source per FR-263-9 priority are populated.
+                SourceModule     = if ($attribution) { $attribution.SourceModule } else { $null }
+                SourcePattern    = if ($attribution) { $attribution.SourcePattern } else { $null }
+                SourceDetail     = if ($attribution) { $attribution.SourceDetail } else { $null }
             })
         }
     }
 
-    Write-NdjsonResponse -Id $Id -Result @{ commands = @($schemas) }
+    # Spec 011 FR-263-2 / FR-263-3 / FR-263-10: build the parallel
+    # moduleImports payload so the .NET consumer (DoctorService) can build
+    # the doctor moduleImports section without re-running Get-Module
+    # -ListAvailable in an in-process runspace.
+    $modulesPayload = [System.Collections.ArrayList]::new()
+    foreach ($moduleName in $modules) {
+        $found = $false
+        $version = $null
+        $path = $null
+        try {
+            # FR-263-10: one Get-Module -ListAvailable per configured module.
+            $availableModules = @(Get-Module -ListAvailable -Name $moduleName -ErrorAction SilentlyContinue)
+            if ($availableModules.Count -gt 0) {
+                $found = $true
+                $first = $availableModules[0]
+                if ($null -ne $first.Version) { $version = "$($first.Version)" }
+                if ($null -ne $first.Path) { $path = "$($first.Path)" }
+            }
+        }
+        catch {
+            Write-Diag "Warning: Get-Module -ListAvailable failed for '$moduleName': $_"
+        }
+        $null = $modulesPayload.Add([ordered]@{
+            Name    = $moduleName
+            Found   = [bool]$found
+            Version = $version
+            Path    = $path
+        })
+    }
+
+    # Determine pattern role per FR-263-3:
+    #   'discovery' when patterns are the sole driver (no modules + no commandNames)
+    #   'filter'    when other sources also populated the candidate set
+    #   'exclude'   for entries from ExcludePatterns
+    $anyOtherSource = ($modules.Count -gt 0) -or ($functionNames.Count -gt 0)
+    $patternsPayload = [System.Collections.ArrayList]::new()
+    foreach ($pattern in $includePatterns) {
+        $role = if ($anyOtherSource) { 'filter' } else { 'discovery' }
+        $matchedCount = 0
+        if ($patternMatchCounts.ContainsKey($pattern)) { $matchedCount = [int]$patternMatchCounts[$pattern] }
+        $null = $patternsPayload.Add([ordered]@{
+            Pattern      = $pattern
+            Kind         = 'include'
+            Role         = $role
+            MatchedCount = $matchedCount
+        })
+    }
+    foreach ($pattern in $excludePatterns) {
+        # Exclude patterns drop commands. Compute leakage: count of
+        # discovered (post-exclude) commands whose names still match the
+        # pattern (should be 0; non-zero indicates leakage).
+        $matchedCount = 0
+        foreach ($cmd in $uniqueCommands) {
+            if ($cmd.Name -like $pattern) { $matchedCount++ }
+        }
+        $null = $patternsPayload.Add([ordered]@{
+            Pattern      = $pattern
+            Kind         = 'exclude'
+            Role         = 'exclude'
+            MatchedCount = $matchedCount
+        })
+    }
+
+    $moduleImportsPayload = [ordered]@{
+        Modules  = @($modulesPayload)
+        Patterns = @($patternsPayload)
+    }
+
+    Write-NdjsonResponse -Id $Id -Result @{
+        commands      = @($schemas)
+        moduleImports = $moduleImportsPayload
+    }
 }
 
 function Invoke-InvokeHandler {

--- a/PoshMcp.Server/Server/McpToolSetupService.cs
+++ b/PoshMcp.Server/Server/McpToolSetupService.cs
@@ -121,9 +121,21 @@ internal static class McpToolSetupService
         IToolDescriptionSourceTracker? descriptionSourceTracker = null)
     {
         logger.LogInformation("Discovering PowerShell tools...");
+        // Spec 011 FR-263-2 / FR-263-10: clear any stale OOP module-imports
+        // capture from a prior discovery in this async flow before starting
+        // a new lease, so a fresh discovery starts from a clean slate.
+        OopModuleImportsCapture.Reset();
         await using var executorLease = await StartOutOfProcessExecutorIfNeededAsync(config, loggerFactory, logger, configurationPath);
         var toolFactory = CreateToolFactory(config, executorLease?.Executor, runspace: null, toolMetadataSource, descriptionSourceTracker);
         var tools = await toolFactory.GetToolsListAsync(config, logger);
+        // Spec 011 FR-263-2 / FR-263-10: capture the executor's
+        // LastModuleImports payload BEFORE the lease disposes (the
+        // executor is gone after this method returns). DoctorService
+        // reads the capture in BuildDoctorReportForCliAsync.
+        if (executorLease?.Executor is not null)
+        {
+            OopModuleImportsCapture.Set(executorLease.Executor.LastModuleImports);
+        }
         AddConfigurationGuidanceToolToList(tools, config, configurationPath, "stdio", config.RuntimeMode.ToString(), null, loggerFactory);
         AddConfigurationTroubleshootingToolToList(tools, config, configurationPath, "stdio", null, config.RuntimeMode.ToString(), null, logger);
         return tools;

--- a/PoshMcp.Tests/Integration/OutOfProcessIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/OutOfProcessIntegrationTests.cs
@@ -871,6 +871,66 @@ Export-ModuleMember -Function Invoke-KillHost
         // And the rerun should match the first call's shape (both null/empty).
         Assert.Equal(resultA ?? string.Empty, resultC ?? string.Empty);
     }
+
+    // ---- Spec 011 Phase 2 (#268): wire-format parity ----
+
+    [PwshAvailableFact]
+    public async Task DiscoverCommandsAsync_PopulatesLastModuleImports_FromOopHostPayload()
+    {
+        Assert.NotNull(_executor);
+
+        // Configure a small modules+pattern surface so the host emits a
+        // moduleImports payload (FR-263-2) and per-command source attribution
+        // populates SourceModule / SourcePattern / SourceDetail (FR-263-9).
+        var config = new PowerShellConfiguration
+        {
+            FunctionNames = new List<string> { "Get-Date" }, // commandName-source
+            Modules = new List<string> { "Microsoft.PowerShell.Utility" }, // module-source
+            IncludePatterns = new List<string> { "Out-*" }, // pattern-source
+            ExcludePatterns = new List<string>(),
+        };
+
+        var schemas = await _executor!.DiscoverCommandsAsync(config);
+        Assert.NotNull(schemas);
+        Assert.NotEmpty(schemas);
+
+        // Wire-format parity: payload must be present after a discovery against
+        // a spec-011-aware host (this test runs against the in-tree oop-host.ps1).
+        var payload = _executor.LastModuleImports;
+        Assert.NotNull(payload);
+        Assert.NotEmpty(payload!.Modules);
+
+        var probe = payload.Modules.FirstOrDefault(m =>
+            string.Equals(m.Name, "Microsoft.PowerShell.Utility", StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(probe);
+        Assert.True(probe!.Found, "Microsoft.PowerShell.Utility should be found by the OOP host probe");
+
+        // FR-263-9 source attribution per command:
+        //   - Get-Date appears in FunctionNames → SourceModule must be null
+        //     (commandName takes precedence; pattern/module sources unset).
+        //   - Out-* matches come via the include pattern → SourcePattern set.
+        //   - Module-derived commands have SourceModule set (with module name in SourceDetail).
+        var getDate = schemas.FirstOrDefault(s =>
+            string.Equals(s.Name, "Get-Date", StringComparison.OrdinalIgnoreCase));
+        if (getDate is not null)
+        {
+            Assert.Null(getDate.SourceModule);
+            Assert.Null(getDate.SourcePattern);
+        }
+
+        var outAny = schemas.FirstOrDefault(s =>
+            s.Name.StartsWith("Out-", StringComparison.OrdinalIgnoreCase));
+        if (outAny is not null)
+        {
+            Assert.True(
+                outAny.SourcePattern is not null || outAny.SourceModule is not null,
+                $"Out-* command '{outAny.Name}' must have SourcePattern or SourceModule populated.");
+        }
+
+        _logger.LogInformation(
+            "Phase-2 payload: modules={ModuleCount} patterns={PatternCount} schemas={SchemaCount}",
+            payload.Modules.Count, payload.Patterns.Count, schemas.Count);
+    }
 }
 
 /// <summary>

--- a/PoshMcp.Tests/OutOfProcess/RemoteToolSchemaSourceFieldsTests.cs
+++ b/PoshMcp.Tests/OutOfProcess/RemoteToolSchemaSourceFieldsTests.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using PoshMcp.Server.PowerShell.OutOfProcess;
+using Xunit;
+
+namespace PoshMcp.Tests.OutOfProcess;
+
+/// <summary>
+/// Spec 011 Phase 2 (Issue #268): unit tests for the new wire-format
+/// additions on <see cref="RemoteToolSchema"/> and the parallel
+/// <see cref="RemoteModuleImportsPayload"/> top-level object emitted by
+/// the OOP host on the <c>discover</c> response.
+/// </summary>
+[Trait("Category", "OutOfProcess")]
+public class RemoteToolSchemaSourceFieldsTests
+{
+    [Fact]
+    public void SourceFields_DefaultToNull()
+    {
+        var schema = new RemoteToolSchema();
+        Assert.Null(schema.SourceModule);
+        Assert.Null(schema.SourcePattern);
+        Assert.Null(schema.SourceDetail);
+    }
+
+    [Fact]
+    public void SourceFields_RoundTripJson()
+    {
+        var original = new RemoteToolSchema
+        {
+            Name = "Get-AzContext",
+            SourceModule = "Az.Accounts",
+            SourcePattern = null,
+            SourceDetail = "Az.Accounts",
+        };
+        var json = JsonConvert.SerializeObject(original);
+        var deserialized = JsonConvert.DeserializeObject<RemoteToolSchema>(json);
+
+        Assert.NotNull(deserialized);
+        Assert.Equal("Az.Accounts", deserialized.SourceModule);
+        Assert.Null(deserialized.SourcePattern);
+        Assert.Equal("Az.Accounts", deserialized.SourceDetail);
+    }
+
+    [Fact]
+    public void OlderHostJson_LackingSourceFields_DeserializesWithNulls()
+    {
+        // SC-263-4: backward compat. JSON emitted by an older OOP host (predating
+        // spec 011) has no SourceModule / SourcePattern / SourceDetail properties.
+        const string olderHostJson =
+            "{\"Name\":\"Get-Foo\",\"Description\":\"\",\"Parameters\":[]}";
+
+        var schema = JsonConvert.DeserializeObject<RemoteToolSchema>(olderHostJson);
+
+        Assert.NotNull(schema);
+        Assert.Equal("Get-Foo", schema.Name);
+        Assert.Null(schema.SourceModule);
+        Assert.Null(schema.SourcePattern);
+        Assert.Null(schema.SourceDetail);
+    }
+
+    [Fact]
+    public void RemoteModuleImportsPayload_RoundTripJson()
+    {
+        var original = new RemoteModuleImportsPayload
+        {
+            Modules =
+            [
+                new RemoteModuleProbe { Name = "Az.Accounts", Found = true, Version = "2.13.0", Path = "C:\\Az" },
+                new RemoteModuleProbe { Name = "Az.Compute", Found = false, Version = null, Path = null },
+            ],
+            Patterns =
+            [
+                new RemotePatternMatch { Pattern = "Get-*", Kind = "include", Role = "filter", MatchedCount = 5 },
+                new RemotePatternMatch { Pattern = "*-Service", Kind = "exclude", Role = "exclude", MatchedCount = 0 },
+            ],
+        };
+        var json = JsonConvert.SerializeObject(original);
+        var deserialized = JsonConvert.DeserializeObject<RemoteModuleImportsPayload>(json);
+
+        Assert.NotNull(deserialized);
+        Assert.Equal(2, deserialized.Modules.Count);
+        Assert.Equal("Az.Accounts", deserialized.Modules[0].Name);
+        Assert.True(deserialized.Modules[0].Found);
+        Assert.Equal("2.13.0", deserialized.Modules[0].Version);
+        Assert.False(deserialized.Modules[1].Found);
+        Assert.Null(deserialized.Modules[1].Version);
+        Assert.Equal(2, deserialized.Patterns.Count);
+        Assert.Equal("include", deserialized.Patterns[0].Kind);
+        Assert.Equal("filter", deserialized.Patterns[0].Role);
+        Assert.Equal(5, deserialized.Patterns[0].MatchedCount);
+        Assert.Equal("exclude", deserialized.Patterns[1].Kind);
+    }
+
+    [Fact]
+    public void RemoteModuleImportsPayload_DefaultsToEmptyCollections()
+    {
+        var payload = new RemoteModuleImportsPayload();
+        Assert.NotNull(payload.Modules);
+        Assert.Empty(payload.Modules);
+        Assert.NotNull(payload.Patterns);
+        Assert.Empty(payload.Patterns);
+    }
+}

--- a/PoshMcp.Tests/Unit/Diagnostics/DoctorModuleImportsOopPayloadTests.cs
+++ b/PoshMcp.Tests/Unit/Diagnostics/DoctorModuleImportsOopPayloadTests.cs
@@ -1,0 +1,131 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.Server;
+using PoshMcp;
+using PoshMcp.Server.PowerShell;
+using PoshMcp.Server.PowerShell.OutOfProcess;
+using Xunit;
+
+namespace PoshMcp.Tests.Unit.Diagnostics;
+
+/// <summary>
+/// Spec 011 Phase 2 (Issue #268): exercise the
+/// <see cref="DoctorService.BuildModuleImportsSection(PowerShellConfiguration, List{McpServerTool}, RemoteModuleImportsPayload?, Microsoft.Extensions.Logging.ILogger)"/>
+/// overload that consumes the OOP host's <see cref="RemoteModuleImportsPayload"/>
+/// instead of running the in-process <c>Get-Module -ListAvailable</c> probe.
+/// </summary>
+[Trait("Category", "Unit")]
+public class DoctorModuleImportsOopPayloadTests
+{
+    private static McpServerTool MakeTool(string toolName, string commandName)
+    {
+        var stub = new System.Func<string>(() => "stub");
+        return McpServerTool.Create(stub, new McpServerToolCreateOptions
+        {
+            Name = toolName,
+            Title = commandName,
+            Description = "stub",
+        });
+    }
+
+    [Fact]
+    public void OopPayload_KnownModule_UsesPayloadProbeData_NotInProcessProbe()
+    {
+        var config = new PowerShellConfiguration { Modules = new() { "Az.Accounts" } };
+        var tools = new List<McpServerTool>
+        {
+            MakeTool("connect_az_account", "Connect-AzAccount"),
+            MakeTool("get_az_context", "Get-AzContext"),
+        };
+        var payload = new RemoteModuleImportsPayload
+        {
+            Modules =
+            [
+                new RemoteModuleProbe
+                {
+                    Name = "Az.Accounts",
+                    Found = true,
+                    Version = "9.9.9",
+                    Path = "C:\\OopProvided\\Az.Accounts.psd1",
+                },
+            ],
+        };
+
+        var section = DoctorService.BuildModuleImportsSection(config, tools, payload, NullLogger.Instance);
+
+        var module = Assert.Single(section.Modules);
+        // OOP-provided values appear verbatim — proves the in-process probe was NOT run.
+        Assert.True(module.Found);
+        Assert.Equal("9.9.9", module.Version);
+        Assert.Equal("C:\\OopProvided\\Az.Accounts.psd1", module.Path);
+        Assert.Equal("ok", module.Status);
+    }
+
+    [Fact]
+    public void OopPayload_MissingEntryForConfiguredModule_FallsBackToNotFound()
+    {
+        var config = new PowerShellConfiguration { Modules = new() { "Az.Accounts", "Az.Compute" } };
+        var tools = new List<McpServerTool>();
+        // Payload only describes Az.Accounts; Az.Compute should fall back to not-found.
+        var payload = new RemoteModuleImportsPayload
+        {
+            Modules =
+            [
+                new RemoteModuleProbe { Name = "Az.Accounts", Found = true, Version = "1.0.0", Path = "X" },
+            ],
+        };
+
+        var section = DoctorService.BuildModuleImportsSection(config, tools, payload, NullLogger.Instance);
+
+        Assert.Equal(2, section.Modules.Count);
+        var compute = section.Modules.Single(m => m.Name == "Az.Compute");
+        Assert.False(compute.Found);
+        Assert.Null(compute.Version);
+        Assert.Null(compute.Path);
+        Assert.Equal("error", compute.Status);
+    }
+
+    [Fact]
+    public void OopPayload_Null_BehavesIdenticallyToLegacyOverload()
+    {
+        // SC-263-4: backward-compat. With payload null and no modules configured
+        // the section computation runs entirely from `tools` and returns the
+        // same shape as the existing 3-arg overload.
+        var config = new PowerShellConfiguration
+        {
+            CommandNames = new() { "Write-Host" },
+        };
+        var tools = new List<McpServerTool> { MakeTool("write_host", "Write-Host") };
+
+        var withPayload = DoctorService.BuildModuleImportsSection(config, tools, oopPayload: null, NullLogger.Instance);
+        var legacy = DoctorService.BuildModuleImportsSection(config, tools, NullLogger.Instance);
+
+        // CommandNames-only configs return an empty section per FR-263-6.
+        Assert.Empty(withPayload.Modules);
+        Assert.Empty(withPayload.Patterns);
+        Assert.Empty(withPayload.Tools);
+        Assert.Empty(legacy.Modules);
+        Assert.Empty(legacy.Patterns);
+        Assert.Empty(legacy.Tools);
+    }
+
+    [Fact]
+    public void OopPayload_CommandNamesOnly_ReturnsEmptySection()
+    {
+        // FR-263-6: even if the OOP host emits a payload, a CommandNames-only
+        // config still yields an empty moduleImports section.
+        var config = new PowerShellConfiguration { CommandNames = new() { "Write-Host" } };
+        var tools = new List<McpServerTool> { MakeTool("write_host", "Write-Host") };
+        var payload = new RemoteModuleImportsPayload
+        {
+            Modules = [new RemoteModuleProbe { Name = "Microsoft.PowerShell.Utility", Found = true, Version = "7.0", Path = "X" }],
+        };
+
+        var section = DoctorService.BuildModuleImportsSection(config, tools, payload, NullLogger.Instance);
+
+        Assert.Empty(section.Modules);
+        Assert.Empty(section.Patterns);
+        Assert.Empty(section.Tools);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of spec 011 closes #268 by extending the out-of-process discover wire format so the C# server can build the doctor `moduleImports` section from data the OOP host already produced — instead of re-running `Get-Module -ListAvailable` in-process. This is the contract that achieves **SC-263-3** (byte-identical `moduleImports` JSON across `InProcess` and `OutOfProcess` runtime modes).

Pairs with #269 (Phase 1 in-process `ModuleDiscovery`) and #270 (Bender's consumer wiring) to close out spec 011 / #267 / #268.

## Wire format additions (additive, backward compatible)

- **`RemoteToolSchema`** gains three nullable string fields per FR-263-9: `SourceModule`, `SourcePattern`, `SourceDetail`. Older OOP hosts that omit these deserialize cleanly with null values per Newtonsoft.Json defaults (**SC-263-4**). Per-command attribution priority: `commandName` > `module` > `pattern`.
- **New top-level `RemoteModuleImportsPayload`** on the `discover` response carries per-module probe results (`Name`/`Found`/`Version`/`Path`) and per-pattern match data (`Pattern`/`Kind`/`Role`/`MatchedCount`).
- Both **`oop-host.ps1`** (single host) and **`oop-host-pool.ps1`** (runspace pool) populate the new fields and emit the payload. The pool wraps the script-block return value as a `PSCustomObject {Schemas, ModuleImports}` and the outer Invoke handler unwraps with a defensive fallback for legacy bare-array shape.

## C# consumer side

- **`ICommandExecutor.LastModuleImports`** default-implementation property returns null. `OutOfProcessCommandExecutor` and `OutOfProcessSubprocessPool` parse the optional payload after the schemas, stash it, and expose it via the property (with thread-safe accessor on the pool, cleared on fingerprint mismatch).
- **`McpToolSetupService.DiscoverToolsAsync`** captures the executor's `LastModuleImports` into a new `OopModuleImportsCapture` `AsyncLocal<RemoteModuleImportsPayload?>` helper before the executor lease disposes. AsyncLocal chosen over signature refactor because CLI doctor invocations are one-shot (no cross-invocation leak risk) and the alternative would have meant changing the public-ish `DiscoverToolsForCliAsync` return shape.
- **`DoctorService.BuildModuleImportsSection`** gains a new overload that accepts a `RemoteModuleImportsPayload?` and skips the in-process `Get-Module` probe entirely when the payload is non-null. The legacy 3-arg overload now delegates to the 4-arg one with `payload: null`.
- **`BuildDoctorReportForCliAsync`** surfaces a one-time `DoctorReport.Warnings` entry when running in OOP mode against a host that predates spec 011 (capture is null but config has modules/patterns) — older-host fallback contract per FR-263-2 / FR-263-10.

## Tests

- **Unit (`DoctorModuleImportsOopPayloadTests`)**: payload-fed builds use payload data not the in-process probe; missing modules in the payload fall back to not-found; null payload matches legacy 3-arg behavior; CommandNames-only configs return empty section even with payload.
- **Unit (`RemoteToolSchemaSourceFieldsTests`)**: default-null `Source*` fields, JSON round-trip, older-host JSON (lacking the fields) deserializes cleanly with nulls, `RemoteModuleImportsPayload` round-trip and defaults.
- **Integration (`OutOfProcessIntegrationTests.DiscoverCommandsAsync_PopulatesLastModuleImports_FromOopHostPayload`)**: spawns the real OOP host with a config exercising all three FR-263-9 sources (`FunctionNames`, `Modules`, `IncludePatterns`) and asserts `LastModuleImports` populates with the expected modules and that per-command source attribution matches the spec.

Local verification:

```
59 tests pass, 0 fail, 0 skipped (DoctorModuleImports + ModuleDiscovery + OutOfProcessCommandExecutor + OutOfProcessSubprocessPool + new Phase 2 suites)
```

## Backward compatibility

Every change is additive. Older OOP hosts (no `moduleImports` field, no `Source*` fields on schemas) → C# parses without error, executor's `LastModuleImports` stays null, schemas have null `Source*` fields, `BuildModuleImportsSection` falls back to existing in-process probe + heuristic with a one-time `DoctorReport.Warnings` entry.

## Notes for reviewers

- The `tools[]` consolidated array in `ModuleImportsSection` still uses Bender's existing single-module heuristic for source attribution. The new `SourceModule`/`SourcePattern`/`SourceDetail` `RemoteToolSchema` fields are documented public surface for future per-tool attribution wiring (would require a new `IToolImportSourceTracker` analogous to spec 010's `IToolDescriptionSourceTracker`, threading through `McpToolFactoryV2` and `OutOfProcessToolAssemblyGenerator`). Deferred to a follow-up.
- AsyncLocal capture is `Reset()` before each discovery and `Set()` after, so a stale capture from a prior in-flow discovery cannot leak.

Refs #267, #269, #270.
Closes #268.
