### PR TITLE
docs(toc): nest authentication and deployment under advanced topics

### DIFF
--- a/.squad/agents/cubert/history-archive.md
+++ b/.squad/agents/cubert/history-archive.md
@@ -466,3 +466,60 @@ Lesson: When BDN reports show 3-decimal seconds, recomputed % deltas can differ 
 - When `--list-tests` per-category sums exceed the unique-test total, look for class-level + method-level Category dual tags on the same class — those tests appear under multiple filters and double-count in the sum. Reconcile by computing `sum − unique = overlap_count` and finding a class with that many dual-tagged methods.
 - PowerShell `-Command` through `cmd /c` swallows `$variable` and `\` characters unpredictably. For anything beyond trivial one-liners, write a `.ps1` script and invoke with `-File` plus `-LiteralPath` parameters.
 
+
+---
+# Archived 2026-05-16 (Scribe) — 2026-05-14 PR review entries
+
+## 2026-05-14 — PR #253 re-verify (TESTING.md)
+
+- Fry pushed c12f26d addressing both findings.
+- F1 fixed: dead pointer to PoshMcp.Tests/README.md replaced with inline 'default bucket = Integration' citing PoshMcp.Tests/AssemblyInfo.cs. Verified against squad/212-category-traits-baseline — AssemblyInfo policy block matches verbatim.
+- F2 fixed: 'fast-fail logic' framing replaced with neutral 'Unit runs first ... ordering of remaining phases owned by .github/workflows/ci.yml'. Matches PR #252 actual order.
+- Verdict flipped ⚠️ → ✅. Lockout protocol respected (Leela locked, Fry revised — correct since he owns the AssemblyInfo policy in #256).
+- Lesson: when a doc cites another file, fetch that file at the cited ref before approving. AssemblyInfo on the right branch was the only way to confirm F1 was a real fix and not just a different incorrect citation.
+
+### 2026-05-14: Fact-check — PR #257 (Amy: ci(009) flake-rate workflow) — APPROVE
+- Pulled raw flake-rate.yml via gh api at ref squad/216-ci-flake-rate-measurement; re-validated with python yaml.safe_load (PARSED OK).
+- Verified workflow_dispatch input runs default '5' string, schedule cron '0 7 * * *' (nightly UTC), 5 phases (Unit/Integration/OutOfProcess/Http/Functional, no Azure).
+- Cross-checked phase filter syntax against PR #252's ci.yml diff: 'Category=X' strings match one-for-one.
+- Aggregator confirmed: TRX walked via SelectNodes('//t:UnitTestResult', ) under TeamTest 2010 namespace; Failed/NotExecuted/Other split per test; sorted by total non-pass desc.
+- Both artifacts present (flake-rate-summary, flake-runs-raw, both if: always()), GITHUB_STEP_SUMMARY mirror present. set +e + per-phase exit-codes.txt prevents iteration short-circuit.
+- Workflow is ADDED file (345/0); ci.yml not touched. FR-418 satisfied. Comment posted: #issuecomment-4453761687.
+
+### 2026-05-14 — PR #258 verification (Hermes, spec 009 / #219, TempDirectory helper)
+- ✅ PROCEED (with one wait condition). All substantive claims verified against `gh pr diff 258`.
+- Three real audit hits confirmed pre/post: `ResolveModulePaths_DeduplicatesCaseInsensitively` (Farnsworth's PR #256 flag — fixed `PoshMcp-ResolveModulePaths` name) + two `ProgramTests.ResolveConfigurationPath_*` cases (bare `Path.GetTempPath()` writes of `appsettings.json` / `config.json`).
+- Three representative refactors confirmed: `ModuleDiscoveryStartupOrderingTests` (field `_tempDirectory` preserved as `=> _tempDir.Path` view to keep diff small), `OutOfProcessIntegrationTests` (`_testTempDirHolder` companion), `OutOfProcessPoolHostIntegrationTests` (3 inline pool tests).
+- `OopTestPaths.cs` confirmed NOT in the 8-file diff. Intentional; documented in PR body.
+- `TempDirectory.cs` (+115) and `TempDirectoryTests.cs` (+97, 8 `[Fact]` methods, `[Trait("Category","Unit")]`) verified. Helper contract: `Prefix = "poshmcp-test-"` + `Guid:N`, optional label, `_disposed` guard set BEFORE delete attempt (covers the throwing-delete idempotency case), `s_undeleted` audit bag, `AuditLeftoverDirectories()` cross-run sweep.
+- Independent `Path.GetTempPath` audit across `PoshMcp.Tests/**`: NO newly discovered FR-403 violations. Remaining sites are already-unique GUID paths (eligible for the explicit follow-up sweep), `GetTempFileName()` (OS-unique), or read-only/synthesized paths.
+- Wait condition: `CI / build` job (run 25878951951) and CodeQL `Analyze (csharp)` were still IN_PROGRESS at review time. `Squad CI / test` was already SUCCESS — the strongest signal for a test-only change.
+- Build / test counts (`0 errors`, `64+29 pass`) marked ⚠️ author-attested — not independently re-run; consistent with green `Squad CI / test` but not granular enough to cite per-filter counts.
+- Verdict: `artifacts/cubert-pr258-verdict.md` · Comment: https://github.com/usepowershell/PoshMcp/pull/258#issuecomment-4453769035
+
+### 2026-05-14: Fact-check — PR #259 (Fry: reclassify misfiled Unit tests, Spec 009/#213) — APPROVE
+- Diff is textbook FR-414: 8 file renames (similarity 98–99%), each one line edit (namespace PoshMcp.Tests.Unit.OutOfProcess → PoshMcp.Tests.OutOfProcess). Zero touches to `[Trait]`, `[Fact]`, asserts, setup, fixtures. Aggregate +8/-8 confirms scope.
+- Verified all 8 listed files match the audit table 1:1. `git diff main --stat` on the worktree shows exactly the 8 `{Unit => }/OutOfProcess/` renames, nothing else.
+- Directory hygiene: `PoshMcp.Tests/Unit/OutOfProcess/` is GONE on the PR branch (Test-Path returns false). Farnsworth's hygiene flag clears.
+- Independently grepped retained Unit files for `Process.Start`, `ProcessStartInfo`, `TcpListener`, `HttpListener`, `"pwsh`, `BindAsync`, `Listen(`, `GetTempPath`: `OAuthProxyEndpointsTests`, `WinPsCompatProxyTests`, `ProgramCliBuildCommandTests`, `ServerSessionAwarePowerShellRunspaceTests` are all clean. `ProgramCliConfigCommandsTests` and `ProgramCliScaffoldCommandTests` (NOT named in PR body) hit `GetTempPath` — but inspected context: both wrap it in a nested `TemporaryDirectory` helper with `poshmcp-cli-tests-{Guid.NewGuid():N}` suffix. Matches the "safe pattern" Hermes documented in PR #258. Not a violation; candidate for the follow-up `TempDirectory` migration sweep.
+- Reproduced the Unit tier metric: `dotnet test --filter "Category=Unit"` ran 432/0 in 20s test-only (29.7s wall). Author claimed 432/0 in 39s — count exact, timing well under FR-405 budget (60s).
+- OOP tier metric (155/0/6 skipped) NOT independently re-run — too expensive in this verification window. CI `Squad CI / test` green on head SHA corroborates. Marked ⚠️ in verdict, not a blocker.
+- Verdict: APPROVE, ready to merge. Posted to PR #259.
+- Process learning: PR #256's "grep the file, never infer from folder" rule WORKED again here — Fry's PR body listed `ProgramCli*Tests.cs` collectively as compliant, but only named `ProgramCliBuildCommandTests`. The other two (Config, Scaffold) DO touch `GetTempPath`, just safely. Folder/PR-body claims are not a substitute for grep evidence on each file.
+
+### 2026-05-14: Fact-check — PR #260 (Fry: FR-416 sweep of Functional folder, closes #220) — APPROVE
+
+- All 6 Fry claims verified on branch `squad/220-functional-reclassify` @ `b430a9d` via the existing worktree at `C:\Users\stmuraws\source\github\usepowershell\poshmcp-220`.
+- C1 metadata-only diff: confirmed via `gh pr diff 260` — 2 single-line Trait flips, 1 git mv + namespace flip on the moved file (StdioLoggingTests), +5 lines in TESTING.md. Zero body/assert/setup/data edits.
+- C2 StdioLoggingTests OutOfProcess shape: confirmed lines 31, 35, 62, 67, 69, 70 use `InProcessMcpServer`/`ExternalMcpClient`/`StartAsync` — the OutOfProcess subprocess shape, strictly more specific than Integration.
+- C3 ConfigurationReloadTests real I/O: confirmed `Path.GetTempFileName()` (line 68), `File.WriteAllTextAsync` (line 82), `File.Delete` (line 110).
+- C4 SetupTests partial-class promotion: confirmed FOUR partials touch FS (ShouldParseJsonFileCorrectlyTest, ShouldThrowExceptionWithInvalidJsonTest, ShouldThrowExceptionWithMissingFileTest, ShouldWorkWithConfigurationToToolsListIntegrationTest), and the `[Trait]` lives on the shared declaration in `SetupTestsShared.cs`. Whole-partial promotion is correct per FR-416. Same pattern Fry used in #259.
+- C5 borderline `ShouldHandleGetChildItemCorrectly`: confirmed `[Fact(Skip = "...")]` at line 20 and `Path.GetTempPath()` at line 52 is string-only (variable assignment, no file ops). Leaving Functional is correct.
+- C6 TESTING.md: +5 lines accurately enumerate the 3 reclassifications and the in-process groups that remain Functional.
+- C7 reproducibility: `dotnet test --filter "Category=Functional"` locally returned `Passed: 107, Skipped: 1, Total: 108, Duration: 4 s`. The 1 skip is the borderline. Cheap (~4s) and proves Functional tier stays green after the sweep.
+- Did NOT re-run Unit tier (432/432) or the targeted 18/18 — Fry's PR description records them and they were visible in Steven's recent session terminal output. The clean Functional run + metadata-only diff give high confidence.
+- Lesson — partial-class promotion is the right shape for FR-416 even when it over-classifies a few clean partials. Auditing every partial individually would re-introduce case-by-case judgment, which is exactly what FR-416 forbids.
+- Lesson — when a worktree already exists for the PR, USE IT. Avoids `git checkout` on the main checkout, isolates the build artifacts, and keeps Steven's main checkout on `main`.
+- Posted neutral verdict via `gh pr comment 260 --body-file artifacts/cubert-pr260-verdict.md`. Strict lockout NOT triggered (verdict is APPROVE).
+
+

--- a/.squad/agents/cubert/history.md
+++ b/.squad/agents/cubert/history.md
@@ -1,56 +1,15 @@
 # Cubert — History
 
-## 2026-05-14 — PR #253 re-verify (TESTING.md)
+## 2026-05-14 — Summarized (full text in history-archive.md, archived by Scribe 2026-05-16)
 
-- Fry pushed c12f26d addressing both findings.
-- F1 fixed: dead pointer to PoshMcp.Tests/README.md replaced with inline 'default bucket = Integration' citing PoshMcp.Tests/AssemblyInfo.cs. Verified against squad/212-category-traits-baseline — AssemblyInfo policy block matches verbatim.
-- F2 fixed: 'fast-fail logic' framing replaced with neutral 'Unit runs first ... ordering of remaining phases owned by .github/workflows/ci.yml'. Matches PR #252 actual order.
-- Verdict flipped ⚠️ → ✅. Lockout protocol respected (Leela locked, Fry revised — correct since he owns the AssemblyInfo policy in #256).
-- Lesson: when a doc cites another file, fetch that file at the cited ref before approving. AssemblyInfo on the right branch was the only way to confirm F1 was a real fix and not just a different incorrect citation.
+Five fact-check verdicts (all APPROVE/PROCEED):
+- **PR #253 re-verify** (Leela TESTING.md, Fry revised): F1/F2 fixed; verdict ⚠️→✅. Lesson — when a doc cites another file, fetch it at the cited ref before approving.
+- **PR #257** (Amy flake-rate workflow): added file 345/0; FR-418 satisfied; TRX parsing via TeamTest 2010 namespace.
+- **PR #258** (Hermes TempDirectory helper, spec 009/#219): contract verified; no new FR-403 violations; pattern — `_disposed` guard set BEFORE delete for idempotency.
+- **PR #259** (Fry reclassify Unit/OutOfProcess, #213): textbook FR-414 (8 renames, +8/-8); ProgramCli*Tests grep-clean (PR #256 rule applied again).
+- **PR #260** (Fry FR-416 Functional sweep, #220): 4 partials in SetupTests promote together — partial-class trait scope is whole-class; reproducibility Functional=107/0 in 4s.
 
-### 2026-05-14: Fact-check — PR #257 (Amy: ci(009) flake-rate workflow) — APPROVE
-- Pulled raw flake-rate.yml via gh api at ref squad/216-ci-flake-rate-measurement; re-validated with python yaml.safe_load (PARSED OK).
-- Verified workflow_dispatch input runs default '5' string, schedule cron '0 7 * * *' (nightly UTC), 5 phases (Unit/Integration/OutOfProcess/Http/Functional, no Azure).
-- Cross-checked phase filter syntax against PR #252's ci.yml diff: 'Category=X' strings match one-for-one.
-- Aggregator confirmed: TRX walked via SelectNodes('//t:UnitTestResult', ) under TeamTest 2010 namespace; Failed/NotExecuted/Other split per test; sorted by total non-pass desc.
-- Both artifacts present (flake-rate-summary, flake-runs-raw, both if: always()), GITHUB_STEP_SUMMARY mirror present. set +e + per-phase exit-codes.txt prevents iteration short-circuit.
-- Workflow is ADDED file (345/0); ci.yml not touched. FR-418 satisfied. Comment posted: #issuecomment-4453761687.
-
-### 2026-05-14 — PR #258 verification (Hermes, spec 009 / #219, TempDirectory helper)
-- ✅ PROCEED (with one wait condition). All substantive claims verified against `gh pr diff 258`.
-- Three real audit hits confirmed pre/post: `ResolveModulePaths_DeduplicatesCaseInsensitively` (Farnsworth's PR #256 flag — fixed `PoshMcp-ResolveModulePaths` name) + two `ProgramTests.ResolveConfigurationPath_*` cases (bare `Path.GetTempPath()` writes of `appsettings.json` / `config.json`).
-- Three representative refactors confirmed: `ModuleDiscoveryStartupOrderingTests` (field `_tempDirectory` preserved as `=> _tempDir.Path` view to keep diff small), `OutOfProcessIntegrationTests` (`_testTempDirHolder` companion), `OutOfProcessPoolHostIntegrationTests` (3 inline pool tests).
-- `OopTestPaths.cs` confirmed NOT in the 8-file diff. Intentional; documented in PR body.
-- `TempDirectory.cs` (+115) and `TempDirectoryTests.cs` (+97, 8 `[Fact]` methods, `[Trait("Category","Unit")]`) verified. Helper contract: `Prefix = "poshmcp-test-"` + `Guid:N`, optional label, `_disposed` guard set BEFORE delete attempt (covers the throwing-delete idempotency case), `s_undeleted` audit bag, `AuditLeftoverDirectories()` cross-run sweep.
-- Independent `Path.GetTempPath` audit across `PoshMcp.Tests/**`: NO newly discovered FR-403 violations. Remaining sites are already-unique GUID paths (eligible for the explicit follow-up sweep), `GetTempFileName()` (OS-unique), or read-only/synthesized paths.
-- Wait condition: `CI / build` job (run 25878951951) and CodeQL `Analyze (csharp)` were still IN_PROGRESS at review time. `Squad CI / test` was already SUCCESS — the strongest signal for a test-only change.
-- Build / test counts (`0 errors`, `64+29 pass`) marked ⚠️ author-attested — not independently re-run; consistent with green `Squad CI / test` but not granular enough to cite per-filter counts.
-- Verdict: `artifacts/cubert-pr258-verdict.md` · Comment: https://github.com/usepowershell/PoshMcp/pull/258#issuecomment-4453769035
-
-### 2026-05-14: Fact-check — PR #259 (Fry: reclassify misfiled Unit tests, Spec 009/#213) — APPROVE
-- Diff is textbook FR-414: 8 file renames (similarity 98–99%), each one line edit (namespace PoshMcp.Tests.Unit.OutOfProcess → PoshMcp.Tests.OutOfProcess). Zero touches to `[Trait]`, `[Fact]`, asserts, setup, fixtures. Aggregate +8/-8 confirms scope.
-- Verified all 8 listed files match the audit table 1:1. `git diff main --stat` on the worktree shows exactly the 8 `{Unit => }/OutOfProcess/` renames, nothing else.
-- Directory hygiene: `PoshMcp.Tests/Unit/OutOfProcess/` is GONE on the PR branch (Test-Path returns false). Farnsworth's hygiene flag clears.
-- Independently grepped retained Unit files for `Process.Start`, `ProcessStartInfo`, `TcpListener`, `HttpListener`, `"pwsh`, `BindAsync`, `Listen(`, `GetTempPath`: `OAuthProxyEndpointsTests`, `WinPsCompatProxyTests`, `ProgramCliBuildCommandTests`, `ServerSessionAwarePowerShellRunspaceTests` are all clean. `ProgramCliConfigCommandsTests` and `ProgramCliScaffoldCommandTests` (NOT named in PR body) hit `GetTempPath` — but inspected context: both wrap it in a nested `TemporaryDirectory` helper with `poshmcp-cli-tests-{Guid.NewGuid():N}` suffix. Matches the "safe pattern" Hermes documented in PR #258. Not a violation; candidate for the follow-up `TempDirectory` migration sweep.
-- Reproduced the Unit tier metric: `dotnet test --filter "Category=Unit"` ran 432/0 in 20s test-only (29.7s wall). Author claimed 432/0 in 39s — count exact, timing well under FR-405 budget (60s).
-- OOP tier metric (155/0/6 skipped) NOT independently re-run — too expensive in this verification window. CI `Squad CI / test` green on head SHA corroborates. Marked ⚠️ in verdict, not a blocker.
-- Verdict: APPROVE, ready to merge. Posted to PR #259.
-- Process learning: PR #256's "grep the file, never infer from folder" rule WORKED again here — Fry's PR body listed `ProgramCli*Tests.cs` collectively as compliant, but only named `ProgramCliBuildCommandTests`. The other two (Config, Scaffold) DO touch `GetTempPath`, just safely. Folder/PR-body claims are not a substitute for grep evidence on each file.
-
-### 2026-05-14: Fact-check — PR #260 (Fry: FR-416 sweep of Functional folder, closes #220) — APPROVE
-
-- All 6 Fry claims verified on branch `squad/220-functional-reclassify` @ `b430a9d` via the existing worktree at `C:\Users\stmuraws\source\github\usepowershell\poshmcp-220`.
-- C1 metadata-only diff: confirmed via `gh pr diff 260` — 2 single-line Trait flips, 1 git mv + namespace flip on the moved file (StdioLoggingTests), +5 lines in TESTING.md. Zero body/assert/setup/data edits.
-- C2 StdioLoggingTests OutOfProcess shape: confirmed lines 31, 35, 62, 67, 69, 70 use `InProcessMcpServer`/`ExternalMcpClient`/`StartAsync` — the OutOfProcess subprocess shape, strictly more specific than Integration.
-- C3 ConfigurationReloadTests real I/O: confirmed `Path.GetTempFileName()` (line 68), `File.WriteAllTextAsync` (line 82), `File.Delete` (line 110).
-- C4 SetupTests partial-class promotion: confirmed FOUR partials touch FS (ShouldParseJsonFileCorrectlyTest, ShouldThrowExceptionWithInvalidJsonTest, ShouldThrowExceptionWithMissingFileTest, ShouldWorkWithConfigurationToToolsListIntegrationTest), and the `[Trait]` lives on the shared declaration in `SetupTestsShared.cs`. Whole-partial promotion is correct per FR-416. Same pattern Fry used in #259.
-- C5 borderline `ShouldHandleGetChildItemCorrectly`: confirmed `[Fact(Skip = "...")]` at line 20 and `Path.GetTempPath()` at line 52 is string-only (variable assignment, no file ops). Leaving Functional is correct.
-- C6 TESTING.md: +5 lines accurately enumerate the 3 reclassifications and the in-process groups that remain Functional.
-- C7 reproducibility: `dotnet test --filter "Category=Functional"` locally returned `Passed: 107, Skipped: 1, Total: 108, Duration: 4 s`. The 1 skip is the borderline. Cheap (~4s) and proves Functional tier stays green after the sweep.
-- Did NOT re-run Unit tier (432/432) or the targeted 18/18 — Fry's PR description records them and they were visible in Steven's recent session terminal output. The clean Functional run + metadata-only diff give high confidence.
-- Lesson — partial-class promotion is the right shape for FR-416 even when it over-classifies a few clean partials. Auditing every partial individually would re-introduce case-by-case judgment, which is exactly what FR-416 forbids.
-- Lesson — when a worktree already exists for the PR, USE IT. Avoids `git checkout` on the main checkout, isolates the build artifacts, and keeps Steven's main checkout on `main`.
-- Posted neutral verdict via `gh pr comment 260 --body-file artifacts/cubert-pr260-verdict.md`. Strict lockout NOT triggered (verdict is APPROVE).
+Standing lessons accumulated: (1) grep the file, never infer category from folder; (2) for partial classes, whole class promotes together; (3) when worktree already exists for a PR, USE IT; (4) `gh pr review --approve` rejected for usepowershell-authored PRs — comment-form verdict IS the review.
 
 ## 2026-05-15: Team update (via Scribe)
 **Ralph round 1 — 3 PRs in-flight, may need your review:**
@@ -102,13 +61,7 @@ PRs #269 (Phase 1 ModuleDiscovery), #270 (Phase 2a DoctorService wiring), #271 (
 - Lesson: `CamelCaseToSnakeCase` lives in `PoshMcp.Server/PowerShell/PowerShellAssemblyGenerator.cs:74`. Use this file if a future tutorial needs to demonstrate non-obvious tool-naming (e.g., parameter set suffixes — line 109 appends `_` + snake_case(parameterSetName) for non-default param sets).
 - Lesson: Doctor section headers are owned by `DoctorTextRenderer.cs` (not the JSON DoctorReport). If a tutorial cites a heading exactly, verify against the renderer, not the data shape.
 
-## 2026-05-16 — PR #273 (tutorial series, Leela)
+## 2026-05-16 — PR #273 merged (via Scribe)
 
-- Verdict: proceed. 8 substantive code/contract claims + 8 surface/structural claims, all verified against source on squad/docs-tutorial-series. Comment posted (issuecomment-4467062499). Full verdict at artifacts/cubert-pr273-verdict.md.
-- Key fact dropped to decision inbox: `RequiredRoles` is **any-match** (`AuthorizationHelpers.cs:25`: `requiredRoles.Any(r => user.IsInRole(r))`), while `RequiredScopes` is **all-match** (line 16). Asymmetric and intentional. Tutorial 4 documents this correctly with the right workaround.
-- Verified Docker contract end-to-end: base `ghcr.io/usepowershell/poshmcp/poshmcp:latest` → runtime publishes to `/app/server` (Dockerfile:21,42) → entrypoint runs `/app/server/PoshMcp.dll` (docker-entrypoint.sh:8) → user images COPY to `/app/server/appsettings.json` (examples/Dockerfile.user:42). AllUsers PS module path `/usr/local/share/powershell/Modules` is the standard PowerShell-on-Linux location. `USER root` → COPY → `USER appuser` pattern is the canonical safe-COPY shape for the base image (appuser = UID 1001, nologin shell).
-- `CommandOverrides` is a `Dictionary<string, FunctionOverride>` with `StringComparer.OrdinalIgnoreCase` (PowerShellConfiguration.cs:113) — case-insensitive but NOT format-translating at config-binding time. The runtime `AuthorizationHelpers.GetToolOverride` does snake_case→PSName normalization, so auth checks tolerate either form, BUT `PowerShellAssemblyGenerator` (display properties) only queries by PSName. Universally-correct canonical form for `CommandOverrides` keys is the PowerShell command name. Tutorials get this right.
-- `FunctionOverride.{AllowAnonymous, RequiredScopes, RequiredRoles}` are all nullable (`bool?` / `List<string>?`). Null means "fall through to DefaultPolicy" (ToolAuthorizationFilter.cs:62-63, ToolListAuthorizationFilter.cs:71-72 use `override?.X ?? defaultPolicy.X`). Worth remembering: setting an override to `[]` (empty list, not null) means "policy says no roles required" — an explicit "allow anyone authenticated" override, NOT a fall-through. Subtle but important.
-- Lesson: `CamelCaseToSnakeCase` lives in `PoshMcp.Server/PowerShell/PowerShellAssemblyGenerator.cs:74`. If a future tutorial needs to demonstrate non-obvious tool-naming (parameter set suffixes — line 109 appends `_` + snake_case(parameterSetName) for non-default param sets), this is the file.
-- Lesson: Doctor section headers are owned by `DoctorTextRenderer.cs` (not the JSON `DoctorReport`). When a tutorial cites a heading exactly, verify against the renderer, not the data shape.
+PR #273 squash-merged to `main`. Polish pass by Leela addressed Farnsworth's 5 non-blocking asks; re-verified clean (`artifacts/cubert-pr273-reverify.md`). No factual drift introduced.
 

--- a/.squad/agents/farnsworth/history-archive.md
+++ b/.squad/agents/farnsworth/history-archive.md
@@ -1261,3 +1261,182 @@ OOP flake (`Lifecycle_Start_Ping_Setup_Shutdown_Restart` STATUS_ACCESS_VIOLATION
 MeterListener test pattern is the right shape (filter on MeterName + instrument name, copy tags into owned dict because ReadOnlySpan doesn't outlive the callback, cache MethodInfo for reflection). Sets a clean precedent for future McpMetrics instrument tests.
 - 2026-05-13: PR #246 (Amy — issue #232, FR-572 spec-010 cold-start regression gate). Methodology parity confirmed: same BDN config (InvocationCount=1, MaxIterationCount=10), same filter, same machine, same scenario class. Direct .exe launch in run-6 is functionally equivalent to `dotnet run -c Release`. Toolchain drift minor (SDK 10.0.107 → 10.0.108). Regression ~11–12% Mean across all three modes (Single +11.74% / Pool +12.08% / ProcessPool +10.66%); P95 and P99 track Mean within ±2pp — uniform overhead, not mode-specific. Spec 010 attribution clean: `git log 16878b8..48db59a -- PoshMcp.Server PoshMcp.Benchmarks` returns exactly the 7 spec-010 wave merges (#235, #238, #239, #240, #241, #244, #245), zero unrelated changes. COMPARISON.md is solid template material — keep the paired `run-N` + COMPARISON.md pattern for future regression gates. Verdict: ✅ APPROVE (comment posted; EMU restriction prevents formal review).
 
+
+---
+# Archived 2026-05-16 (Scribe) — 2026-05-13/14 PR review entries
+
+## Learnings - 2026-05-13 - PR #247 review (issue #234, spec 010 step 11)
+
+### Verdict
+APPROVE. Documentation for FR-500/FR-510 description precedence chains in docs/articles/exposing-tools.md plus README cross-link.
+
+### What I cross-checked and what passed
+- **Vocabulary parity**: Doc literals (synopsis/description/syntax/name and helpParameter/helpMessage/validateSet/typeFallback) match IToolDescriptionSourceTracker.cs ToString() lines 152-165 verbatim. This is the property we want — doctor JSON, OTel `step` tag, and prose are all one phrase.
+- **Resolver behavior**: HelpAwareToolMetadataSource.cs ResolveToolDescription early-returns at each rung; the doc's "tries each step in order, stops at first non-empty" framing is structurally accurate.
+- **Step 3 string format**: Code emits `$"{CommandName} {ParameterSetSyntax}"`. Doc shows `"Get-FixtureBare [[-Anything] <string>] [<CommonParameters>]"` — matches.
+- **ValidateSet prefixes**: Code line 111 uses `"Each item is one of: "` vs `"One of: "` based on `ValidateSetAppliesToArrayElement`. Doc strings match verbatim, including punctuation/spacing.
+- **TypeFallback**: `$"Parameter of type {typeName}"` matches doc's `"Parameter of type System.String"`.
+- **Synopsis-equals-name filter**: The StringComparison.Ordinal guard in the code is correctly described as "not equal to the command name".
+- **#242 callout**: Honest framing — what works (resolver + doctor), what doesn't (inputSchema plumbing), tracking link, what authors should do today, what changes when fix ships. NO fix date promised.
+- **Cross-link**: README anchor `#description-precedence` resolves to `## Description Precedence` heading in both GitHub and DocFX renderers.
+- **HelpParityFixture mapping**: Every fixture function the doc references exists in HelpParityFixture.psm1 with the matching shape.
+
+### Doc review patterns worth keeping
+- For a multi-step resolver, **table + tiny per-step example** beats prose. Anchoring step names to the literal wire vocabulary makes the doc dual-purpose: human reading + searchability across doctor output and metrics.
+- **In-line "Known issue" callout** under the affected section (not at bottom) for partially-shipped features. Format: what works / what doesn't / link / today's guidance / what changes on fix. The "no module change required" line is what makes the callout safe to ship — authors aren't asked to wait.
+- **README defers to article**, doesn't restate the chain. Single-link cross-link from a one-line bullet is the right hook.
+- For doc PRs touching behavior I've reviewed code-side, cross-checking literal strings (prefixes, format strings, enum-to-wire names) catches drift faster than re-reading the prose.
+
+### Process note
+Worktree-local strategy meant I could `gh pr view` and read implementation files in the same session without cross-branch confusion. Resolved everything from c:\Users\stmuraws\source\github\usepowershell\poshmcp-234.
+### 2026-05-14 — Reviewed PR #253 (Leela — TESTING.md, branch squad/214-testing-md-commands)
+
+**Verdict:** APPROVE with two non-blocking nits. Posted via gh pr comment (#issuecomment-4453556321). Architectural review only; Cubert handles fact-check.
+
+**Strongest aspect:** Doc is authored against the spec FR contract, not against parallel-PR implementation choices. Default-bucket *name* deferred to PoshMcp.Tests/README.md (set by #212), CI phase order deferred to .github/workflows/ci.yml (set by #215). TESTING.md commits only to "default bucket is not Unit" and "category X reproduces phase X locally" — so it can merge in any order relative to #212/#215 without stranding a false reference. Reviewer notes call out the two re-verification points explicitly. This is the right authoring discipline for parallel work streams.
+
+**Location:** Repo root — correct. Joins README/CONTRIBUTING/SECURITY/DOCKER as a contributor-facing top-level doc. Burying under docs/ would have hidden it behind the DocFX site (which targets end-users, not contributors).
+
+**README integration:** Two-entry-point split (quick-start in README, deep-dive in TESTING.md) — same pattern as PR #210 OOP docs (configuration.md brief + advanced.md deep-dive). No category-table duplication. README diff also flips  + "--filter \"FullyQualifiedName~Unit\"" +  →  + "--filter \"Category=Unit\"" +  aligning the public surface to the trait contract.
+
+**FR coverage:** FR-408 ✓ explicit table. FR-413 ✓ documented in Azure caveats AND repeated in Troubleshooting (justified — Troubleshooting is where operators actually hit the symptom). FR-417 ✓ has its own section, defers bucket name correctly. Bonus coverage of FR-411/412/416/418 in caveats even though not strictly required.
+
+**Two non-blocking nits:** (1) Integration row "Spawns  + "pwsh" + : Yes (in-process runspaces)" — in-process runspaces don't spawn  + "pwsh.exe" + , parenthetical disambiguates but stricter reading is "No". (2) Flake-rate troubleshooting uses cmd  + "or /l" +  syntax — most contributors run PowerShell or bash; either show all three forms or pick bash to match the doc's other code fences.
+
+**Pattern noted:** When a docs PR ships AHEAD of (or in parallel with) the implementation PRs it documents, defer all *named* implementation details (bucket name, phase order, runner config) to the source-of-truth file owned by the implementation PR, and commit only to the *contract* in your doc. This keeps the doc correct under any landing order. Apply this to future docs-first PRs in multi-PR specs.
+
+### 2026-05-14 - Reviewed PR #256 (Fry - Spec 009 Category traits baseline)
+
+**Verdict:** REJECT (request changes). Posted via gh pr comment (#issuecomment-4453570148). Reassigned to **Bender** (NOT Fry - reviewer-rejection lockout).
+
+**Architectural framing:** Class-level [Trait("Category", "Unit")] IS a reclassification, not "honest tagging." It's an active claim that every method on the class satisfies FR-401 (no pwsh) / FR-402 (no port) / FR-403 (no shared temp). The PR's framing - "no test reclassification, deferred to #213" - falls apart for Unit/OutOfProcess/* because tagging those classes Unit is making the false claim NOW, not deferring it.
+
+**Spot-check method (the bit that found the problem):** When PR description says "honest tagging only" but applies traits by folder, audit the FOLDER the spec edge case explicitly names. Spec 009 names Unit/OutOfProcess/* and Unit/ProgramCli* by name. Three minutes of grep confirmed:
+- OutOfProcessCancellationTests constructs new OutOfProcessHost(pwshPath, ...) + StartAsync -> spawns pwsh (FR-401).
+- OutOfProcessHostConcurrencyTests runs new HttpListener() on 127.0.0.1 ephemeral port (FR-402).
+- OutOfProcessCommandExecutorTests has both StartAsync_ThenDisposeAsync_FullLifecycle (spawns pwsh) AND ResolveModulePaths_* using Path.Combine(Path.GetTempPath(), "PoshMcp-ResolveModulePaths") - non-Guid-unique shared temp (FR-403).
+
+**Class-level trait aggregation hazard:** xUnit class-level traits apply to every test method on the class. Even files where SOME methods are pure constructor-validation Unit tests (OutOfProcessHostTests, OutOfProcessSubprocessPoolTests first 2 each) cannot wear Unit if any sibling method violates FR-401/402/403. Class-level category MUST reflect the class's most-resource-intensive method. Fix: tag those classes OutOfProcess. Pure validation classes can stay Unit.
+
+**Downstream harm if shipped as-is:** PR's headline 'Unit 424' count includes the violators. Once that count is canonical, contributors and CI both treat it as the fast tier - but dotnet test --filter Category=Unit against that set will fail FR-404 (< 60s) and FR-405 (zero flakes across 5 runs) because pwsh-spawn / port-bind work is still inside the filter.
+
+**What's right (kept for context):** AssemblyInfo.cs FR-417 default = Integration (never Unit) - correct. Three pre-existing non-canonical class-level traits cleanly replaced (McpPrompts, McpResources, OutOfProcessModules). Method-level non-canonical traits explicitly deferred - good scope discipline. scripts/add-category-traits.ps1 is idempotent, partial-class aware, doc-comment stripping, refuses unmapped classes - right shape for a baseline tool. FR-415 determinism check (counts reproduced 3x) is the right gate for a metadata change. 92 files / +404 / -3 / draft - appropriately scoped.
+
+**Reassignment rationale:** Bender owns the OOP production code (Spec 004 Pool / cancellation work, PRs #200, #207). Bender is structurally immune to the folder-name-as-category trap - knows from writing the code which classes spawn pwsh and which don't. Hermes (Spec 004 PR #201) was the alternative, but Bender's PR #207 cancellation work is closer in time and scope to the audit needed.
+
+**Pattern noted (capture for TESTING.md / #214):** Class-level category traits on mixed-content test classes are a one-bit summary of an N-shape file. When the auditor (script OR human) only sees the folder, the bit defaults to "whatever the folder says." Corrective rule for #213: the class-level category MUST reflect the class's most-resource-intensive method, not the folder. If a class genuinely needs both Unit and OutOfProcess methods, split the class - don't compromise the trait.
+
+### 2026-05-14 — PR #258 review (Hermes, spec 009 / #219)
+- ✅ APPROVED. `TempDirectory : IDisposable` helper, prefix `poshmcp-test-` + `Guid:N`, best-effort recursive delete, never-throw-on-dispose contract verified (bare `catch { }` swallows all non-fatal exceptions; failed deletes route to `s_undeleted` for diagnostic `GetUndeletedDirectories()`).
+- Composes cleanly with `SubprocessTeardown` from PR #255 — same `Shared/` namespace, same `IDisposable` + best-effort + never-throw shape. Two helpers, one shared-helpers idiom.
+- Audit hooks land #216's CI diagnostic seam: `AuditLeftoverDirectories()` sweeps `poshmcp-test-*` from temp path; no further plumbing needed for phased-CI "leaked dirs?" check. Worth referencing in #216's design.
+- Coverage scope: 3 real audit hits (`ResolveModulePaths_DeduplicatesCaseInsensitively` from my PR #256 flag + 2 `ResolveConfigurationPath_*` cases writing bare appsettings.json/config.json into temp root) + 3 representative refactors. Whole-suite migration explicitly deferred — appropriate, mechanical churn against now-canonical pattern.
+- `OopTestPaths` left alone: defensible under FR-407 (serial execution prevents the fixed `OopE2EProbe` name from racing). Caveat for the record: if any consumer mutates state in that fixed dir and a later test expects clean slate, serial execution stops being sufficient cover. Flagged for whatever follow-up audits `OopTestPaths`.
+- Comment posted: https://github.com/usepowershell/PoshMcp/pull/258#issuecomment-4453765946
+
+### 2026-05-14 — PR #257 review (Amy, ci(009): flake-rate workflow)
+
+**Verdict: APPROVE.**
+
+- Separate workflow file (vs. extending ci.yml) is correct — different shape (loop+aggregate vs. single-pass), independent trigger surface (workflow_dispatch+nightly cron), independent runtime budget.
+- N=5 default with workflow_dispatch.inputs.runs override resolved via ${{ github.event.inputs.runs || '5' }}. Loop uses set +e + per-phase exit codes captured to exit-codes.txt; loop ends with explicit xit 0 so aggregator owns gating.
+- Phasing Unit→Integration→OOP→Http→Functional matches PR #252 one-for-one. Azure correctly excluded (no creds in scheduled runs, would only add noise). FR-407 no-parallelism invariant preserved (single job, sequential bash loop).
+- **Measurement vs. gating divergence is deliberate and correct.** Within an iteration, all phases run regardless of earlier failure — production CI halts on first failure, flake measurement wants max signal. A test that's "always green" only because production halts before reaching it is exactly the kind of flake this workflow surfaces.
+- Aggregator robustness verified: missing flake-runs/ → stub summary; corrupt TRX → try/catch+continue; missing exit-codes lines → - placeholder; iter sort uses [int] cast so run-10 sorts after run-9; if: always() on aggregator + uploads. XmlNamespaceManager bound to TeamTest 2010 schema (correct — TRX uses default namespace).
+- Aggregate flake rate definition (non-pass instances / total invocations) is correct: one test failing 3/5 weighs more than three tests each failing 1/5.
+-  1MB cap only at risk in catastrophic worst case (every test flaked every iter), at which point the workflow has bigger problems.
+- TRX path collisions: none (per-iter subdir + stable phase filenames).
+- Idempotent on rerun (rebuilds summary from scratch each time).
+- Minor non-blocker: no concurrency: group set — overlapping manual+nightly would run in parallel. Low probability; flag for next touch.
+
+Reusable lessons:
+1. **Measurement vs. gating semantics differ.** Flake-rate workflows should NOT mirror production CI's fail-fast — they want max signal. Halting on first phase failure hides flakes in later phases. set +e + capture-then-decide is the right shape.
+2. **TRX parsing requires XmlNamespaceManager.** TRX uses default namespace http://microsoft.com/schemas/VisualStudio/TeamTest/2010; dotted-property access silently returns empty. Select-Xml / SelectNodes with namespace manager is correct.
+3. **Numeric directory sort.** 
+un-1, run-2, ..., run-10 sorts lexicographically wrong; Sort-Object { [int](.Name -replace '^run-','') } is the fix.
+4. **Per-iteration TRX subdirs prevent collision** without needing rename-after-write logic. Stable filenames inside per-iter dirs is cleaner than timestamped filenames.
+5. **if: always() on summary + upload steps** is non-negotiable for measurement workflows — you need the partial data when the run blew up, that's often where the signal is.
+
+### 2026-05-14 — PR #258 review (Hermes, spec 009 / #219)
+- ✅ APPROVED. `TempDirectory : IDisposable` helper, prefix `poshmcp-test-` + `Guid:N`, best-effort recursive delete, never-throw-on-dispose contract verified (bare `catch { }` swallows all non-fatal exceptions; failed deletes route to `s_undeleted` for diagnostic `GetUndeletedDirectories()`).
+- Composes cleanly with `SubprocessTeardown` from PR #255 — same `Shared/` namespace, same `IDisposable` + best-effort + never-throw shape. Two helpers, one shared-helpers idiom.
+- Audit hooks land #216's CI diagnostic seam: `AuditLeftoverDirectories()` sweeps `poshmcp-test-*` from temp path; no further plumbing needed for phased-CI "leaked dirs?" check. Worth referencing in #216's design.
+- Coverage scope: 3 real audit hits (`ResolveModulePaths_DeduplicatesCaseInsensitively` from my PR #256 flag + 2 `ResolveConfigurationPath_*` cases writing bare appsettings.json/config.json into temp root) + 3 representative refactors. Whole-suite migration explicitly deferred — appropriate, mechanical churn against now-canonical pattern.
+- `OopTestPaths` left alone: defensible under FR-407 (serial execution prevents the fixed `OopE2EProbe` name from racing). Caveat for the record: if any consumer mutates state in that fixed dir and a later test expects clean slate, serial execution stops being sufficient cover. Flagged for whatever follow-up audits `OopTestPaths`.
+- Comment posted: https://github.com/usepowershell/PoshMcp/pull/258#issuecomment-4453765946
+
+### 2026-05-14 — PR #252 review (Amy — ci(009): category-scoped phases) — already complete
+
+Ralph routed this to me, but the architectural review was already posted as a PR comment (artifacts/farnsworth-pr252-review.md from a prior session). Cubert's fact-check is also already on the PR. Verdict stands: APPROVE. Tried to formalize via gh pr review --approve to flip GitHub UI to a green review state but failed — usepowershell bot account authored the PR so it cannot self-approve. The comment-form approval is the team accepted pattern (matches PR #255 precedent). No new findings; nothing to redo. The PR is unblocked and ready for Amy to flip out of draft and merge.
+
+**Lesson:** Before doing review work, check the PR existing comments/reviews — Ralph queue can re-route work already done in a prior session. One `gh pr view 252 --json reviews,comments` would have caught this in the first 5 seconds. Make this the first move on any "review PR #N" task.
+
+### 2026-05-14 — Reviewed PR #259 (Fry — reclassify misfiled Unit/OutOfProcess tests, Spec 009 FR-414, closes #213)
+
+**Verdict:** APPROVE. Posted via gh pr comment (#issuecomment-4455131167). Artifact: `artifacts/farnsworth-pr259-review.md`.
+
+**Cleanest possible reclassification PR.** 8 files, +1/-1 each, single namespace line edit per file (`PoshMcp.Tests.Unit.OutOfProcess` → `PoshMcp.Tests.OutOfProcess`). `git mv` similarity 98–99%. Mechanically impossible to have changed assertions or test bodies given the +1/-1 shape — the review reduces to confirming the diff really is what the description claims it is.
+
+**Trait-vs-folder check applied (the PR #256 lesson).** Grepped each retained Unit file (`OAuthProxyEndpointsTests`, `WinPsCompatProxyTests`, `ProgramCliBuildCommandTests`, `ServerSessionAwarePowerShellRunspaceTests`) for the actual `[Trait("Category", ...)]` attribute rather than inferring from folder layout. All carry `[Trait("Category", "Unit")]` correctly. None match `Process.Start`, `ProcessStartInfo`, `TcpListener`, `HttpListener`, `"pwsh`, `GetTempPath`, or port-binding patterns. The misfiling really was directory-only — the metadata was already correct.
+
+**Audit table is accurate.** PR description's "files audited and confirmed compliant" section matches actual contents of `PoshMcp.Tests/Unit/` on the PR branch. Justifications hold up: NoOpEndpointRouteBuilder stub for OAuth (no real listener), in-process `Program.Main` invocation with `TemporaryDirectory` + `CurrentDirectoryScope` for ProgramCli (PR #258 isolation helpers), in-process `PowerShell.Create()` for WinPsCompat (runspace ≠ subprocess), pure mocks for ServerSessionAware.
+
+**Acceptance for #213 fully satisfied:** Unit category 0 process-spawning / 0 port-binding / 0 shared-temp; audit table present and accurate; no assertions modified.
+
+**Tier metrics align:** Unit 432/0 in 39s (well under 60s FR-405 budget), OOP 155/0/6 with first-run flake clean on rerun (matches the historical OOP-tier flakiness profile from PR #255 — pwsh subprocess spawn timing, not regression).
+
+**Non-blocking observation:** `PoshMcp.Tests/Unit/OutOfProcess/` directory should be empty post-merge — flagged as a hygiene check, not a gate.
+
+**Pattern to remember (codified in the review for future reclassification PRs):** When a PR carries the FR-414 "metadata-only" guarantee, review reduces to three mechanical checks — (1) `gh pr diff` shows only namespace/folder lines, no `+/-` outside import/namespace blocks; (2) audit table matches diff one-for-one; (3) retained files grep-clean for forbidden patterns under the new boundary, NEVER inferred from folder layout (PR #256 lesson). All three hold → PR is safe to land. This is the third Spec 009 PR (after #256 trait-tagging and #258 isolation helpers) where the "grep the file, never infer from folder" rule has been the deciding mechanic.
+
+### 2026-05-14 — Reviewed PR #260 (Fry — FR-416 sweep of Functional/, spec 009 closing PR, closes #220)
+
+**Verdict:** APPROVE. Posted via gh pr comment (#issuecomment-4455307819). Artifact: `artifacts/farnsworth-pr260-review.md`. This is the closing PR of spec 009.
+
+**Three-check playbook (from #259) applied cleanly:**
+1. `gh pr diff 260` — exactly four changes, all metadata or doc: two `[Trait]` flips, one `git mv` (98% similarity) + namespace + trait flip, one TESTING.md additive paragraph. No `[Fact]` bodies, `Assert.*`, ctor/setup, or fixtures touched. FR-414 clean.
+2. PR body audit table is one-for-one with the diff: three reclassifications listed, three trait changes in diff, one folder move listed, one `git mv` in diff.
+3. Grep against retained `Functional/*.cs` for FR-416 violation patterns (`File.*`, `Path.GetTempFileName`, `Process.Start`, `HttpClient`, `TcpListener`, `InProcessMcpServer`, `ExternalMcpClient`, `StartAsync(`) — every hit resolves to either a file already promoted in this PR or a TODO comment in `McpPromptsTests`/`McpResourcesTests` (placeholder facts).
+
+**Partial-class promotion policy decision codified.** When `[Trait("Category", ...)]` lives on a single declaration of a `partial class` and any partial touches external resources, the **whole class promotes together**. Three options were available: (1) promote the whole partial class, (2) split the partial into two separate classes, (3) per-method `[Trait]` overrides. Within the FR-414 metadata-only constraint, (1) is the only correct move — (2) is structural refactor (out of scope) and (3) relies on flaky xUnit per-method override semantics on partials. The over-classification of the no-IO partials in `SetupTests` (`ShouldFilterCorrectlyWithExcludePatternsTest`, `ShouldHandleNonExistentFunctionGracefullyTest`, `ShouldHaveEmptyDefaultValuesTest`, `ShouldReturnEmptyListWithEmptyConfigurationTest`, `ShouldReturnToolsWithValidConfigurationTest`, `ShouldWorkWithDefaultParameterlessOverloadTest`) is a known cost worth a follow-up issue if the team later wants surgical split, but **not blocking**. Recording as a team policy: see decisions inbox drop.
+
+**Borderline calls confirmed:**
+- `ShouldHandleGetChildItemCorrectlyTest` stays Functional. `Path.GetTempPath()` returns a string with zero filesystem access; the test is permanently `[Fact(Skip=...)]`. Skip-gated string ops do not cross the FR-416 boundary.
+- `McpPromptsTests`/`McpResourcesTests` stay Functional — the `InProcessMcpServer` references are `// TODO:` comments only; the actual facts are `Assert.True(true)` placeholders. Will need re-audit when the placeholders are filled in (and they likely flip to OutOfProcess at that time).
+- `StdioLoggingTests` move to `OutOfProcess/StdioLoggingTests.cs` — correct. Was already mistagged `Integration` on the `Functional/` path (existing folder/trait mismatch); subprocess spawn via `InProcessMcpServer` + `ExternalMcpClient` is textbook OutOfProcess shape, strictly more specific than Integration.
+
+**Patterns to remember:**
+- **Partial-class trait scope.** `[Trait]` on a `partial class` declaration applies to the whole class; xUnit will not let you per-method override that reliably across partials. When applying FR-416 to a partial class, the trigger is **any** partial touching external resources, and the result is **the whole class** moving together. Document this trade-off in the PR body so reviewers can verify the audit and the cost is explicit.
+- **Grep both raw IO and project-specific helpers.** First-pass grep on `Process.Start|pwsh` would have missed `StdioLoggingTests` because the codebase wraps subprocess spawning in `InProcessMcpServer`/`ExternalMcpClient`/`StartAsync`. Always sweep both raw IO patterns AND test-helper abstractions used in the codebase. Fry called this out independently in her #220 audit — worth elevating to a standing checklist for future Spec-009-style sweeps.
+- **TODO-comment grep hits are not violations.** `Select-String -Pattern 'InProcessMcpServer'` will hit comments. Always inspect context (`-Context 1,1`) before treating a hit as an FR-416 violation. McpPrompts/McpResources are the canonical example: real `InProcessMcpServer` use is in TODO blocks for facts that don't yet exist.
+- **Spec 009 closeout.** With #260 approved, all eight FR-416 / FR-414 reclassification PRs in the spec 009 wave are landed or under final review. The lessons accumulated across #213 / #253 / #255 / #256 / #259 / #260 — folder name is not the trait, partials promote together, grep both raw and helper IO patterns — should be migrated into a skill (`categorization-trait-review`) for the next wave.
+
+
+
+---
+# Archived 2026-05-16 (Scribe) — PR #273 review full text (now merged)
+
+### 2026-05-16 — PR #273 review (Leela — 4-part tutorial series, branch squad/docs-tutorial-series)
+
+**Verdict:** APPROVE. Posted via `gh pr comment` (#issuecomment-4467060959). Artifact: `artifacts/farnsworth-pr273-review.md`. Self-approval blocked under usepowershell identity — comment-form per #252/#269/#271 precedent.
+
+**What I cross-checked architecturally:**
+- `Authentication.Schemes.ApiKey.Keys` dictionary-key-IS-the-secret: matches `ApiKeyAuthenticationHandler.HandleAuthenticateAsync` `Options.Keys.TryGetValue(apiKey, ...)` at L32. Tutorial 3 calls this out explicitly — single most-misread part of the auth surface.
+- Role-claim minting chain: `foreach (var role in keyDef.Roles) claims.Add(new Claim(ClaimTypes.Role, role))` (L62-63) → `HasRequiredRoles` any-match (`requiredRoles.Any(r => user.IsInRole(r))`, AuthorizationHelpers L23). Tutorial 4 narrative matches and hedges the any-match drift risk explicitly.
+- `ToolListAuthorizationFilter.CanAccessTool` (L55-78): AllowAnonymous → RequireAuthentication → scope+role gates. Tutorial 4 step 6 reader-hides-admin-tool claim is structurally correct.
+- Base image contract: `/usr/local/share/powershell/Modules` and `/app/server/appsettings.json` match `examples/Dockerfile.user`; HTTP default matches `docker-entrypoint.sh` L9 (`POSHMCP_TRANSPORT:-http`). No invented paths.
+- `DefaultScheme = "Bearer"` default ([AuthenticationConfiguration.cs L8](PoshMcp.Server/Authentication/AuthenticationConfiguration.cs#L8)) — tutorials 3/4 override correctly to ApiKey but don't explain the override. Flagged as one-sentence ask.
+
+**Non-blocking asks routed to Cubert (NOT Leela — but lockout doesn't apply here, APPROVE verdict):**
+1. Add `poshmcp doctor` demo + `moduleImports` section walkthrough to tutorial 2 (spec 011 just shipped — this series is the canonical place to demonstrate the new doctor section).
+2. One-sentence `DefaultScheme` callout in tutorial 3.
+3. One-sentence `Modules` vs `CommandNames` callout in tutorial 2.
+4. Step-6a "no key at all" boundary beat in tutorial 4 (currently only happy paths shown).
+5. `examples/Dockerfile.user` drift note in tutorial 2 Dockerfile section.
+
+**Pattern noted (captured to decision drop):** Tutorials/walkthroughs touching `Modules` or `IncludePatterns` should always demonstrate `poshmcp doctor` and call out the v0.14.0 `moduleImports` section. Tutorial 4 step 8 already does this for the Authentication section — same pattern should propagate. Will flag in future doc reviews.
+
+**Pattern noted (review discipline):** For doc PRs that ground claims in code, the high-value review move is mapping each tutorial-named config property to its handler/options class and verifying the spelling and semantics line up. Caught the dictionary-key-IS-secret pattern, the role-claim minting loop, and the ToolList filter ordering as three places where Leela's prose is exactly faithful to code (not paraphrased). When tutorials get this right at code-grounded depth, the architectural review reduces to "does the progression and boundary coverage hold up?" — which here, it does.
+
+**Process discipline (from PR #252 lesson):** First move was `gh pr view 273 --json reviews,comments` to confirm no prior verdict in the queue. Comments and reviews both empty (Cubert running in parallel but hadn't posted yet). Clean to proceed.
+

--- a/.squad/agents/farnsworth/history.md
+++ b/.squad/agents/farnsworth/history.md
@@ -22,152 +22,19 @@
 
 **Process note (auth):** `gh auth status` precheck before posting confirmed `usepowershell` (keyring) was active vs. `stmuraws_microsoft` inactive. Mandatory per `.squad/decisions.md` L31-36 — without it, the approval comment would post under the wrong identity.
 
-## Learnings - 2026-05-13 - PR #247 review (issue #234, spec 010 step 11)
+## 2026-05-13 / 2026-05-14 — Summarized (full text in history-archive.md, archived by Scribe 2026-05-16)
 
-### Verdict
-APPROVE. Documentation for FR-500/FR-510 description precedence chains in docs/articles/exposing-tools.md plus README cross-link.
+Spec 009 review wave + #247 docs:
+- **PR #247** (Hermes, FR-500/510 description precedence docs) — APPROVE. Doc literals verified verbatim against `IToolDescriptionSourceTracker` (synopsis/description/syntax/name + helpParameter/helpMessage/validateSet/typeFallback). Lesson: for multi-step resolver docs, **table + tiny per-step example + literal wire vocabulary** beats prose.
+- **PR #253** (Leela, TESTING.md) — APPROVE with 2 non-blocking nits. Lesson: when a docs PR ships ahead of impl PRs, defer all *named* details to the source-of-truth file; commit only to the *contract*.
+- **PR #256** (Fry, class-level Category traits baseline) — REJECT (reassigned to Bender). Found Unit/OutOfProcess/* classes that spawn pwsh / bind ports / share temp. Lesson: **grep the file for forbidden patterns, never infer from folder.** Class-level trait MUST reflect the class''s most-resource-intensive method.
+- **PR #257** (Amy, flake-rate workflow) — APPROVE. Lesson: measurement vs gating semantics differ — flake measurement wants `set +e` + capture-then-decide, NOT production fail-fast.
+- **PR #258** (Hermes, TempDirectory helper) — APPROVE. Composes with PR #255 SubprocessTeardown (same `Shared/` IDisposable + best-effort + never-throw idiom). Audit hooks land #216 CI diagnostic seam.
+- **PR #252** (Amy, category-scoped phases) — APPROVE. Already complete from prior session — Ralph re-routed; lesson: **before doing review work, `gh pr view N --json reviews,comments` to check existing verdicts.**
+- **PR #259** (Fry, reclassify misfiled Unit/OutOfProcess, FR-414) — APPROVE. Cleanest possible reclassification (8 namespace flips, +1/-1 each, 98–99% similarity). The "grep, never infer from folder" rule applied for the third time.
+- **PR #260** (Fry, FR-416 Functional sweep, spec 009 closing PR) — APPROVE. Codified partial-class promotion policy: **any partial touching external resources → whole class promotes together.** Spec 009 closed.
 
-### What I cross-checked and what passed
-- **Vocabulary parity**: Doc literals (synopsis/description/syntax/name and helpParameter/helpMessage/validateSet/typeFallback) match IToolDescriptionSourceTracker.cs ToString() lines 152-165 verbatim. This is the property we want — doctor JSON, OTel `step` tag, and prose are all one phrase.
-- **Resolver behavior**: HelpAwareToolMetadataSource.cs ResolveToolDescription early-returns at each rung; the doc's "tries each step in order, stops at first non-empty" framing is structurally accurate.
-- **Step 3 string format**: Code emits `$"{CommandName} {ParameterSetSyntax}"`. Doc shows `"Get-FixtureBare [[-Anything] <string>] [<CommonParameters>]"` — matches.
-- **ValidateSet prefixes**: Code line 111 uses `"Each item is one of: "` vs `"One of: "` based on `ValidateSetAppliesToArrayElement`. Doc strings match verbatim, including punctuation/spacing.
-- **TypeFallback**: `$"Parameter of type {typeName}"` matches doc's `"Parameter of type System.String"`.
-- **Synopsis-equals-name filter**: The StringComparison.Ordinal guard in the code is correctly described as "not equal to the command name".
-- **#242 callout**: Honest framing — what works (resolver + doctor), what doesn't (inputSchema plumbing), tracking link, what authors should do today, what changes when fix ships. NO fix date promised.
-- **Cross-link**: README anchor `#description-precedence` resolves to `## Description Precedence` heading in both GitHub and DocFX renderers.
-- **HelpParityFixture mapping**: Every fixture function the doc references exists in HelpParityFixture.psm1 with the matching shape.
-
-### Doc review patterns worth keeping
-- For a multi-step resolver, **table + tiny per-step example** beats prose. Anchoring step names to the literal wire vocabulary makes the doc dual-purpose: human reading + searchability across doctor output and metrics.
-- **In-line "Known issue" callout** under the affected section (not at bottom) for partially-shipped features. Format: what works / what doesn't / link / today's guidance / what changes on fix. The "no module change required" line is what makes the callout safe to ship — authors aren't asked to wait.
-- **README defers to article**, doesn't restate the chain. Single-link cross-link from a one-line bullet is the right hook.
-- For doc PRs touching behavior I've reviewed code-side, cross-checking literal strings (prefixes, format strings, enum-to-wire names) catches drift faster than re-reading the prose.
-
-### Process note
-Worktree-local strategy meant I could `gh pr view` and read implementation files in the same session without cross-branch confusion. Resolved everything from c:\Users\stmuraws\source\github\usepowershell\poshmcp-234.
-### 2026-05-14 — Reviewed PR #253 (Leela — TESTING.md, branch squad/214-testing-md-commands)
-
-**Verdict:** APPROVE with two non-blocking nits. Posted via gh pr comment (#issuecomment-4453556321). Architectural review only; Cubert handles fact-check.
-
-**Strongest aspect:** Doc is authored against the spec FR contract, not against parallel-PR implementation choices. Default-bucket *name* deferred to PoshMcp.Tests/README.md (set by #212), CI phase order deferred to .github/workflows/ci.yml (set by #215). TESTING.md commits only to "default bucket is not Unit" and "category X reproduces phase X locally" — so it can merge in any order relative to #212/#215 without stranding a false reference. Reviewer notes call out the two re-verification points explicitly. This is the right authoring discipline for parallel work streams.
-
-**Location:** Repo root — correct. Joins README/CONTRIBUTING/SECURITY/DOCKER as a contributor-facing top-level doc. Burying under docs/ would have hidden it behind the DocFX site (which targets end-users, not contributors).
-
-**README integration:** Two-entry-point split (quick-start in README, deep-dive in TESTING.md) — same pattern as PR #210 OOP docs (configuration.md brief + advanced.md deep-dive). No category-table duplication. README diff also flips  + "--filter \"FullyQualifiedName~Unit\"" +  →  + "--filter \"Category=Unit\"" +  aligning the public surface to the trait contract.
-
-**FR coverage:** FR-408 ✓ explicit table. FR-413 ✓ documented in Azure caveats AND repeated in Troubleshooting (justified — Troubleshooting is where operators actually hit the symptom). FR-417 ✓ has its own section, defers bucket name correctly. Bonus coverage of FR-411/412/416/418 in caveats even though not strictly required.
-
-**Two non-blocking nits:** (1) Integration row "Spawns  + "pwsh" + : Yes (in-process runspaces)" — in-process runspaces don't spawn  + "pwsh.exe" + , parenthetical disambiguates but stricter reading is "No". (2) Flake-rate troubleshooting uses cmd  + "or /l" +  syntax — most contributors run PowerShell or bash; either show all three forms or pick bash to match the doc's other code fences.
-
-**Pattern noted:** When a docs PR ships AHEAD of (or in parallel with) the implementation PRs it documents, defer all *named* implementation details (bucket name, phase order, runner config) to the source-of-truth file owned by the implementation PR, and commit only to the *contract* in your doc. This keeps the doc correct under any landing order. Apply this to future docs-first PRs in multi-PR specs.
-
-### 2026-05-14 - Reviewed PR #256 (Fry - Spec 009 Category traits baseline)
-
-**Verdict:** REJECT (request changes). Posted via gh pr comment (#issuecomment-4453570148). Reassigned to **Bender** (NOT Fry - reviewer-rejection lockout).
-
-**Architectural framing:** Class-level [Trait("Category", "Unit")] IS a reclassification, not "honest tagging." It's an active claim that every method on the class satisfies FR-401 (no pwsh) / FR-402 (no port) / FR-403 (no shared temp). The PR's framing - "no test reclassification, deferred to #213" - falls apart for Unit/OutOfProcess/* because tagging those classes Unit is making the false claim NOW, not deferring it.
-
-**Spot-check method (the bit that found the problem):** When PR description says "honest tagging only" but applies traits by folder, audit the FOLDER the spec edge case explicitly names. Spec 009 names Unit/OutOfProcess/* and Unit/ProgramCli* by name. Three minutes of grep confirmed:
-- OutOfProcessCancellationTests constructs new OutOfProcessHost(pwshPath, ...) + StartAsync -> spawns pwsh (FR-401).
-- OutOfProcessHostConcurrencyTests runs new HttpListener() on 127.0.0.1 ephemeral port (FR-402).
-- OutOfProcessCommandExecutorTests has both StartAsync_ThenDisposeAsync_FullLifecycle (spawns pwsh) AND ResolveModulePaths_* using Path.Combine(Path.GetTempPath(), "PoshMcp-ResolveModulePaths") - non-Guid-unique shared temp (FR-403).
-
-**Class-level trait aggregation hazard:** xUnit class-level traits apply to every test method on the class. Even files where SOME methods are pure constructor-validation Unit tests (OutOfProcessHostTests, OutOfProcessSubprocessPoolTests first 2 each) cannot wear Unit if any sibling method violates FR-401/402/403. Class-level category MUST reflect the class's most-resource-intensive method. Fix: tag those classes OutOfProcess. Pure validation classes can stay Unit.
-
-**Downstream harm if shipped as-is:** PR's headline 'Unit 424' count includes the violators. Once that count is canonical, contributors and CI both treat it as the fast tier - but dotnet test --filter Category=Unit against that set will fail FR-404 (< 60s) and FR-405 (zero flakes across 5 runs) because pwsh-spawn / port-bind work is still inside the filter.
-
-**What's right (kept for context):** AssemblyInfo.cs FR-417 default = Integration (never Unit) - correct. Three pre-existing non-canonical class-level traits cleanly replaced (McpPrompts, McpResources, OutOfProcessModules). Method-level non-canonical traits explicitly deferred - good scope discipline. scripts/add-category-traits.ps1 is idempotent, partial-class aware, doc-comment stripping, refuses unmapped classes - right shape for a baseline tool. FR-415 determinism check (counts reproduced 3x) is the right gate for a metadata change. 92 files / +404 / -3 / draft - appropriately scoped.
-
-**Reassignment rationale:** Bender owns the OOP production code (Spec 004 Pool / cancellation work, PRs #200, #207). Bender is structurally immune to the folder-name-as-category trap - knows from writing the code which classes spawn pwsh and which don't. Hermes (Spec 004 PR #201) was the alternative, but Bender's PR #207 cancellation work is closer in time and scope to the audit needed.
-
-**Pattern noted (capture for TESTING.md / #214):** Class-level category traits on mixed-content test classes are a one-bit summary of an N-shape file. When the auditor (script OR human) only sees the folder, the bit defaults to "whatever the folder says." Corrective rule for #213: the class-level category MUST reflect the class's most-resource-intensive method, not the folder. If a class genuinely needs both Unit and OutOfProcess methods, split the class - don't compromise the trait.
-
-### 2026-05-14 — PR #258 review (Hermes, spec 009 / #219)
-- ✅ APPROVED. `TempDirectory : IDisposable` helper, prefix `poshmcp-test-` + `Guid:N`, best-effort recursive delete, never-throw-on-dispose contract verified (bare `catch { }` swallows all non-fatal exceptions; failed deletes route to `s_undeleted` for diagnostic `GetUndeletedDirectories()`).
-- Composes cleanly with `SubprocessTeardown` from PR #255 — same `Shared/` namespace, same `IDisposable` + best-effort + never-throw shape. Two helpers, one shared-helpers idiom.
-- Audit hooks land #216's CI diagnostic seam: `AuditLeftoverDirectories()` sweeps `poshmcp-test-*` from temp path; no further plumbing needed for phased-CI "leaked dirs?" check. Worth referencing in #216's design.
-- Coverage scope: 3 real audit hits (`ResolveModulePaths_DeduplicatesCaseInsensitively` from my PR #256 flag + 2 `ResolveConfigurationPath_*` cases writing bare appsettings.json/config.json into temp root) + 3 representative refactors. Whole-suite migration explicitly deferred — appropriate, mechanical churn against now-canonical pattern.
-- `OopTestPaths` left alone: defensible under FR-407 (serial execution prevents the fixed `OopE2EProbe` name from racing). Caveat for the record: if any consumer mutates state in that fixed dir and a later test expects clean slate, serial execution stops being sufficient cover. Flagged for whatever follow-up audits `OopTestPaths`.
-- Comment posted: https://github.com/usepowershell/PoshMcp/pull/258#issuecomment-4453765946
-
-### 2026-05-14 — PR #257 review (Amy, ci(009): flake-rate workflow)
-
-**Verdict: APPROVE.**
-
-- Separate workflow file (vs. extending ci.yml) is correct — different shape (loop+aggregate vs. single-pass), independent trigger surface (workflow_dispatch+nightly cron), independent runtime budget.
-- N=5 default with workflow_dispatch.inputs.runs override resolved via ${{ github.event.inputs.runs || '5' }}. Loop uses set +e + per-phase exit codes captured to exit-codes.txt; loop ends with explicit xit 0 so aggregator owns gating.
-- Phasing Unit→Integration→OOP→Http→Functional matches PR #252 one-for-one. Azure correctly excluded (no creds in scheduled runs, would only add noise). FR-407 no-parallelism invariant preserved (single job, sequential bash loop).
-- **Measurement vs. gating divergence is deliberate and correct.** Within an iteration, all phases run regardless of earlier failure — production CI halts on first failure, flake measurement wants max signal. A test that's "always green" only because production halts before reaching it is exactly the kind of flake this workflow surfaces.
-- Aggregator robustness verified: missing flake-runs/ → stub summary; corrupt TRX → try/catch+continue; missing exit-codes lines → - placeholder; iter sort uses [int] cast so run-10 sorts after run-9; if: always() on aggregator + uploads. XmlNamespaceManager bound to TeamTest 2010 schema (correct — TRX uses default namespace).
-- Aggregate flake rate definition (non-pass instances / total invocations) is correct: one test failing 3/5 weighs more than three tests each failing 1/5.
--  1MB cap only at risk in catastrophic worst case (every test flaked every iter), at which point the workflow has bigger problems.
-- TRX path collisions: none (per-iter subdir + stable phase filenames).
-- Idempotent on rerun (rebuilds summary from scratch each time).
-- Minor non-blocker: no concurrency: group set — overlapping manual+nightly would run in parallel. Low probability; flag for next touch.
-
-Reusable lessons:
-1. **Measurement vs. gating semantics differ.** Flake-rate workflows should NOT mirror production CI's fail-fast — they want max signal. Halting on first phase failure hides flakes in later phases. set +e + capture-then-decide is the right shape.
-2. **TRX parsing requires XmlNamespaceManager.** TRX uses default namespace http://microsoft.com/schemas/VisualStudio/TeamTest/2010; dotted-property access silently returns empty. Select-Xml / SelectNodes with namespace manager is correct.
-3. **Numeric directory sort.** 
-un-1, run-2, ..., run-10 sorts lexicographically wrong; Sort-Object { [int](.Name -replace '^run-','') } is the fix.
-4. **Per-iteration TRX subdirs prevent collision** without needing rename-after-write logic. Stable filenames inside per-iter dirs is cleaner than timestamped filenames.
-5. **if: always() on summary + upload steps** is non-negotiable for measurement workflows — you need the partial data when the run blew up, that's often where the signal is.
-
-### 2026-05-14 — PR #258 review (Hermes, spec 009 / #219)
-- ✅ APPROVED. `TempDirectory : IDisposable` helper, prefix `poshmcp-test-` + `Guid:N`, best-effort recursive delete, never-throw-on-dispose contract verified (bare `catch { }` swallows all non-fatal exceptions; failed deletes route to `s_undeleted` for diagnostic `GetUndeletedDirectories()`).
-- Composes cleanly with `SubprocessTeardown` from PR #255 — same `Shared/` namespace, same `IDisposable` + best-effort + never-throw shape. Two helpers, one shared-helpers idiom.
-- Audit hooks land #216's CI diagnostic seam: `AuditLeftoverDirectories()` sweeps `poshmcp-test-*` from temp path; no further plumbing needed for phased-CI "leaked dirs?" check. Worth referencing in #216's design.
-- Coverage scope: 3 real audit hits (`ResolveModulePaths_DeduplicatesCaseInsensitively` from my PR #256 flag + 2 `ResolveConfigurationPath_*` cases writing bare appsettings.json/config.json into temp root) + 3 representative refactors. Whole-suite migration explicitly deferred — appropriate, mechanical churn against now-canonical pattern.
-- `OopTestPaths` left alone: defensible under FR-407 (serial execution prevents the fixed `OopE2EProbe` name from racing). Caveat for the record: if any consumer mutates state in that fixed dir and a later test expects clean slate, serial execution stops being sufficient cover. Flagged for whatever follow-up audits `OopTestPaths`.
-- Comment posted: https://github.com/usepowershell/PoshMcp/pull/258#issuecomment-4453765946
-
-### 2026-05-14 — PR #252 review (Amy — ci(009): category-scoped phases) — already complete
-
-Ralph routed this to me, but the architectural review was already posted as a PR comment (artifacts/farnsworth-pr252-review.md from a prior session). Cubert's fact-check is also already on the PR. Verdict stands: APPROVE. Tried to formalize via gh pr review --approve to flip GitHub UI to a green review state but failed — usepowershell bot account authored the PR so it cannot self-approve. The comment-form approval is the team accepted pattern (matches PR #255 precedent). No new findings; nothing to redo. The PR is unblocked and ready for Amy to flip out of draft and merge.
-
-**Lesson:** Before doing review work, check the PR existing comments/reviews — Ralph queue can re-route work already done in a prior session. One `gh pr view 252 --json reviews,comments` would have caught this in the first 5 seconds. Make this the first move on any "review PR #N" task.
-
-### 2026-05-14 — Reviewed PR #259 (Fry — reclassify misfiled Unit/OutOfProcess tests, Spec 009 FR-414, closes #213)
-
-**Verdict:** APPROVE. Posted via gh pr comment (#issuecomment-4455131167). Artifact: `artifacts/farnsworth-pr259-review.md`.
-
-**Cleanest possible reclassification PR.** 8 files, +1/-1 each, single namespace line edit per file (`PoshMcp.Tests.Unit.OutOfProcess` → `PoshMcp.Tests.OutOfProcess`). `git mv` similarity 98–99%. Mechanically impossible to have changed assertions or test bodies given the +1/-1 shape — the review reduces to confirming the diff really is what the description claims it is.
-
-**Trait-vs-folder check applied (the PR #256 lesson).** Grepped each retained Unit file (`OAuthProxyEndpointsTests`, `WinPsCompatProxyTests`, `ProgramCliBuildCommandTests`, `ServerSessionAwarePowerShellRunspaceTests`) for the actual `[Trait("Category", ...)]` attribute rather than inferring from folder layout. All carry `[Trait("Category", "Unit")]` correctly. None match `Process.Start`, `ProcessStartInfo`, `TcpListener`, `HttpListener`, `"pwsh`, `GetTempPath`, or port-binding patterns. The misfiling really was directory-only — the metadata was already correct.
-
-**Audit table is accurate.** PR description's "files audited and confirmed compliant" section matches actual contents of `PoshMcp.Tests/Unit/` on the PR branch. Justifications hold up: NoOpEndpointRouteBuilder stub for OAuth (no real listener), in-process `Program.Main` invocation with `TemporaryDirectory` + `CurrentDirectoryScope` for ProgramCli (PR #258 isolation helpers), in-process `PowerShell.Create()` for WinPsCompat (runspace ≠ subprocess), pure mocks for ServerSessionAware.
-
-**Acceptance for #213 fully satisfied:** Unit category 0 process-spawning / 0 port-binding / 0 shared-temp; audit table present and accurate; no assertions modified.
-
-**Tier metrics align:** Unit 432/0 in 39s (well under 60s FR-405 budget), OOP 155/0/6 with first-run flake clean on rerun (matches the historical OOP-tier flakiness profile from PR #255 — pwsh subprocess spawn timing, not regression).
-
-**Non-blocking observation:** `PoshMcp.Tests/Unit/OutOfProcess/` directory should be empty post-merge — flagged as a hygiene check, not a gate.
-
-**Pattern to remember (codified in the review for future reclassification PRs):** When a PR carries the FR-414 "metadata-only" guarantee, review reduces to three mechanical checks — (1) `gh pr diff` shows only namespace/folder lines, no `+/-` outside import/namespace blocks; (2) audit table matches diff one-for-one; (3) retained files grep-clean for forbidden patterns under the new boundary, NEVER inferred from folder layout (PR #256 lesson). All three hold → PR is safe to land. This is the third Spec 009 PR (after #256 trait-tagging and #258 isolation helpers) where the "grep the file, never infer from folder" rule has been the deciding mechanic.
-
-### 2026-05-14 — Reviewed PR #260 (Fry — FR-416 sweep of Functional/, spec 009 closing PR, closes #220)
-
-**Verdict:** APPROVE. Posted via gh pr comment (#issuecomment-4455307819). Artifact: `artifacts/farnsworth-pr260-review.md`. This is the closing PR of spec 009.
-
-**Three-check playbook (from #259) applied cleanly:**
-1. `gh pr diff 260` — exactly four changes, all metadata or doc: two `[Trait]` flips, one `git mv` (98% similarity) + namespace + trait flip, one TESTING.md additive paragraph. No `[Fact]` bodies, `Assert.*`, ctor/setup, or fixtures touched. FR-414 clean.
-2. PR body audit table is one-for-one with the diff: three reclassifications listed, three trait changes in diff, one folder move listed, one `git mv` in diff.
-3. Grep against retained `Functional/*.cs` for FR-416 violation patterns (`File.*`, `Path.GetTempFileName`, `Process.Start`, `HttpClient`, `TcpListener`, `InProcessMcpServer`, `ExternalMcpClient`, `StartAsync(`) — every hit resolves to either a file already promoted in this PR or a TODO comment in `McpPromptsTests`/`McpResourcesTests` (placeholder facts).
-
-**Partial-class promotion policy decision codified.** When `[Trait("Category", ...)]` lives on a single declaration of a `partial class` and any partial touches external resources, the **whole class promotes together**. Three options were available: (1) promote the whole partial class, (2) split the partial into two separate classes, (3) per-method `[Trait]` overrides. Within the FR-414 metadata-only constraint, (1) is the only correct move — (2) is structural refactor (out of scope) and (3) relies on flaky xUnit per-method override semantics on partials. The over-classification of the no-IO partials in `SetupTests` (`ShouldFilterCorrectlyWithExcludePatternsTest`, `ShouldHandleNonExistentFunctionGracefullyTest`, `ShouldHaveEmptyDefaultValuesTest`, `ShouldReturnEmptyListWithEmptyConfigurationTest`, `ShouldReturnToolsWithValidConfigurationTest`, `ShouldWorkWithDefaultParameterlessOverloadTest`) is a known cost worth a follow-up issue if the team later wants surgical split, but **not blocking**. Recording as a team policy: see decisions inbox drop.
-
-**Borderline calls confirmed:**
-- `ShouldHandleGetChildItemCorrectlyTest` stays Functional. `Path.GetTempPath()` returns a string with zero filesystem access; the test is permanently `[Fact(Skip=...)]`. Skip-gated string ops do not cross the FR-416 boundary.
-- `McpPromptsTests`/`McpResourcesTests` stay Functional — the `InProcessMcpServer` references are `// TODO:` comments only; the actual facts are `Assert.True(true)` placeholders. Will need re-audit when the placeholders are filled in (and they likely flip to OutOfProcess at that time).
-- `StdioLoggingTests` move to `OutOfProcess/StdioLoggingTests.cs` — correct. Was already mistagged `Integration` on the `Functional/` path (existing folder/trait mismatch); subprocess spawn via `InProcessMcpServer` + `ExternalMcpClient` is textbook OutOfProcess shape, strictly more specific than Integration.
-
-**Patterns to remember:**
-- **Partial-class trait scope.** `[Trait]` on a `partial class` declaration applies to the whole class; xUnit will not let you per-method override that reliably across partials. When applying FR-416 to a partial class, the trigger is **any** partial touching external resources, and the result is **the whole class** moving together. Document this trade-off in the PR body so reviewers can verify the audit and the cost is explicit.
-- **Grep both raw IO and project-specific helpers.** First-pass grep on `Process.Start|pwsh` would have missed `StdioLoggingTests` because the codebase wraps subprocess spawning in `InProcessMcpServer`/`ExternalMcpClient`/`StartAsync`. Always sweep both raw IO patterns AND test-helper abstractions used in the codebase. Fry called this out independently in her #220 audit — worth elevating to a standing checklist for future Spec-009-style sweeps.
-- **TODO-comment grep hits are not violations.** `Select-String -Pattern 'InProcessMcpServer'` will hit comments. Always inspect context (`-Context 1,1`) before treating a hit as an FR-416 violation. McpPrompts/McpResources are the canonical example: real `InProcessMcpServer` use is in TODO blocks for facts that don't yet exist.
-- **Spec 009 closeout.** With #260 approved, all eight FR-416 / FR-414 reclassification PRs in the spec 009 wave are landed or under final review. The lessons accumulated across #213 / #253 / #255 / #256 / #259 / #260 — folder name is not the trait, partials promote together, grep both raw and helper IO patterns — should be migrated into a skill (`categorization-trait-review`) for the next wave.
-
+Standing patterns codified: (1) grep the file, never infer from folder; (2) partial classes promote whole-class; (3) always grep both raw IO AND test-helper abstractions (`InProcessMcpServer`/`ExternalMcpClient`); (4) check existing reviews before doing review work; (5) self-approval blocked under `usepowershell` identity — comment-form verdict + artifact file is the team accepted pattern.
 ## 2026-05-15: Team update (via Scribe)
 **Ralph round 1 — 3 PRs in-flight, may need your review:**
 - **PR #266** (Bender, issue #261): Doctor pool display sentinel — EffectiveProcessPoolSize / EffectiveMinHealthyForStartup promoted to `string`, returning `"n/a (<mode> mode)"` when inert. Files: `DoctorService.cs`, `DoctorReport.cs`, `DoctorTextRenderer.cs` + Unit tests.
@@ -206,26 +73,10 @@ Ralph routed this to me, but the architectural review was already posted as a PR
 PRs #269 (Phase 1 ModuleDiscovery), #270 (Phase 2a DoctorService wiring), #271 (Phase 2b OOP wire-format parity) all merged to `main` on 2026-05-15. Issue #263 closed. #272 tracks per-tool source attribution refinement separately.
 
 
-### 2026-05-16 — PR #273 review (Leela — 4-part tutorial series, branch squad/docs-tutorial-series)
+## 2026-05-16 — PR #273 review + merge (Leela — 4-part tutorial series)
 
-**Verdict:** APPROVE. Posted via `gh pr comment` (#issuecomment-4467060959). Artifact: `artifacts/farnsworth-pr273-review.md`. Self-approval blocked under usepowershell identity — comment-form per #252/#269/#271 precedent.
+**Verdict:** APPROVE → MERGED. Comment posted (#issuecomment-4467060959); full review text archived 2026-05-16.
 
-**What I cross-checked architecturally:**
-- `Authentication.Schemes.ApiKey.Keys` dictionary-key-IS-the-secret: matches `ApiKeyAuthenticationHandler.HandleAuthenticateAsync` `Options.Keys.TryGetValue(apiKey, ...)` at L32. Tutorial 3 calls this out explicitly — single most-misread part of the auth surface.
-- Role-claim minting chain: `foreach (var role in keyDef.Roles) claims.Add(new Claim(ClaimTypes.Role, role))` (L62-63) → `HasRequiredRoles` any-match (`requiredRoles.Any(r => user.IsInRole(r))`, AuthorizationHelpers L23). Tutorial 4 narrative matches and hedges the any-match drift risk explicitly.
-- `ToolListAuthorizationFilter.CanAccessTool` (L55-78): AllowAnonymous → RequireAuthentication → scope+role gates. Tutorial 4 step 6 reader-hides-admin-tool claim is structurally correct.
-- Base image contract: `/usr/local/share/powershell/Modules` and `/app/server/appsettings.json` match `examples/Dockerfile.user`; HTTP default matches `docker-entrypoint.sh` L9 (`POSHMCP_TRANSPORT:-http`). No invented paths.
-- `DefaultScheme = "Bearer"` default ([AuthenticationConfiguration.cs L8](PoshMcp.Server/Authentication/AuthenticationConfiguration.cs#L8)) — tutorials 3/4 override correctly to ApiKey but don't explain the override. Flagged as one-sentence ask.
+Code-grounded review passed: ApiKey dictionary-key-is-secret (`ApiKeyAuthenticationHandler.cs:32`), role-claim minting chain through `AuthorizationHelpers.HasRequiredRoles` any-match (L23), `ToolListAuthorizationFilter.CanAccessTool` ordering (L55-78), Docker base image contract (paths + `appuser` UID 1001), `DefaultScheme="Bearer"` default ([AuthenticationConfiguration.cs:8](PoshMcp.Server/Authentication/AuthenticationConfiguration.cs#L8)). All 5 non-blocking polish asks (doctor demo + DefaultScheme callout + Modules-vs-CommandNames callout + no-key boundary beat + Dockerfile.user drift note) landed by Leela in polish pass; Cubert re-verified clean. Squash-merged to ``main``.
 
-**Non-blocking asks routed to Cubert (NOT Leela — but lockout doesn't apply here, APPROVE verdict):**
-1. Add `poshmcp doctor` demo + `moduleImports` section walkthrough to tutorial 2 (spec 011 just shipped — this series is the canonical place to demonstrate the new doctor section).
-2. One-sentence `DefaultScheme` callout in tutorial 3.
-3. One-sentence `Modules` vs `CommandNames` callout in tutorial 2.
-4. Step-6a "no key at all" boundary beat in tutorial 4 (currently only happy paths shown).
-5. `examples/Dockerfile.user` drift note in tutorial 2 Dockerfile section.
-
-**Pattern noted (captured to decision drop):** Tutorials/walkthroughs touching `Modules` or `IncludePatterns` should always demonstrate `poshmcp doctor` and call out the v0.14.0 `moduleImports` section. Tutorial 4 step 8 already does this for the Authentication section — same pattern should propagate. Will flag in future doc reviews.
-
-**Pattern noted (review discipline):** For doc PRs that ground claims in code, the high-value review move is mapping each tutorial-named config property to its handler/options class and verifying the spelling and semantics line up. Caught the dictionary-key-IS-secret pattern, the role-claim minting loop, and the ToolList filter ordering as three places where Leela's prose is exactly faithful to code (not paraphrased). When tutorials get this right at code-grounded depth, the architectural review reduces to "does the progression and boundary coverage hold up?" — which here, it does.
-
-**Process discipline (from PR #252 lesson):** First move was `gh pr view 273 --json reviews,comments` to confirm no prior verdict in the queue. Comments and reviews both empty (Cubert running in parallel but hadn't posted yet). Clean to proceed.
+Patterns codified: (1) tutorials touching `Modules`/`IncludePatterns` should always demonstrate `poshmcp doctor` + v0.14.0 `moduleImports` section; (2) for code-grounded doc PRs, map each named config property to its handler/options class and verify spelling + semantics; (3) check `gh pr view N --json reviews,comments` first to avoid double-verdict races.

--- a/.squad/agents/leela/history.md
+++ b/.squad/agents/leela/history.md
@@ -67,3 +67,7 @@ Spec 009 (Test Suite Consistency and Fast Unit Tier) is functionally complete. F
 ### Tutorial polish workflow
 - Inserting a doctor-demo step mid-tutorial needs three small rituals: insert the step, renumber every later step, and update `What you learned` to mention any new field surface. Easy to forget the last one.
 - Two focused commits per polish landing reads cleaner in PR history than one omnibus commit — reviewers can scan each commit's scope from the subject line.
+
+## 2026-05-16 — PR #273 merged
+
+4-part tutorial series + polish pass squash-merged to ``main`` today. Three decisions captured in ``decisions.md`` (tutorial location, doctor-after-setup pattern, ``RequiredRoles`` any-match asymmetry).

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -3,6 +3,31 @@
 ## Recent Decisions
 > Older entries archived to `decisions-archive.md` (entries >7d removed when file >= 50KB).
 
+### 2026-05-16: Tutorial series location (PR #273)
+**By:** Leela (Developer Advocate), requested by Steven
+**What:** New `docs/articles/tutorials/` subdirectory hosts the 4-part progressive tutorial series. Series indexed at `tutorials/index.md`; navigation added under a new "Tutorials" section in `docs/toc.yml` between Getting Started and the User Guide. No `docfx.json` change needed — `articles/**/*.md` glob auto-picks-up the subdirectory.
+**Why:** Keeps tutorials grouped and easy to expand later (next series, e.g. OAuth/Entra ID end-to-end, can drop into the same folder). Sentence-case heading "Tutorials" matches the rest of the toc.
+
+---
+
+### 2026-05-16: Doc tutorials should demonstrate `poshmcp doctor` after setup steps
+**By:** Farnsworth (Lead/Architect) — captured during PR #273 review
+**What:** Tutorials, getting-started guides, and any prose docs that walk a reader through a working-config setup should include a `poshmcp doctor` (or `docker exec <container> poshmcp doctor`) verification step. Specifically: any tutorial that exercises `PowerShellConfiguration.Modules` or `IncludePatterns` should call out the `moduleImports` section of the doctor report (shipped in v0.14.0 / spec 011) as the canonical "did this actually work?" inspection.
+**Why:** Doctor is the only operator-facing surface that resolves config-as-written → effective behavior. Without it, tutorial readers learn the config shape but not the verification idiom — and when their config silently misbehaves (typo in module name, pattern that matches zero commands), they have no muscle memory for where to look. The new `moduleImports` section was built precisely to close this gap; doc series should reflect it.
+**Scope:** Applies to future doc PRs touching tutorials, getting-started, configuration-walkthrough articles. Reviewers (Farnsworth, Cubert) should flag missing doctor-verification steps in such PRs. Does NOT apply to API reference docs or pure conceptual articles.
+**Pair pattern:** Tutorial 4 in PR #273 already follows this pattern for the Authentication doctor section (`docker exec poshmcp-roles poshmcp doctor` → inspect Authentication section). Tutorials 2 and 3 should adopt the same pattern for the new `moduleImports` section.
+
+---
+
+### 2026-05-16: `RequiredRoles` is any-match; `RequiredScopes` is all-match (asymmetric)
+**By:** Cubert — verifying PR #273 tutorial 4
+**What:** `AuthorizationHelpers.HasRequiredRoles` uses `requiredRoles.Any(r => user.IsInRole(r))` — a caller satisfies the policy if they hold **any one** of the required roles. In contrast, `HasRequiredScopes` uses `requiredScopes.All(...)` — caller must hold **all** required scopes.
+**Why:** This asymmetry is intentional but easy to miss. Tutorial 4 documents the any-match behavior and recommends "split into multiple overrides" if all-of-N role semantics are needed. Future tutorials, examples, and reviewers should preserve this distinction explicitly when explaining authorization config.
+**Citation:** `PoshMcp.Server/Authentication/AuthorizationHelpers.cs:11-25`
+**Scope:** Team-wide. Affects any docs, examples, or features that talk about `RequiredRoles`/`RequiredScopes` semantics.
+
+---
+
 ### 2026-05-15: Spec 011 Phase 2 — OOP wire-format parity for moduleImports (PR #271, closes #268)
 **By:** Hermes (PowerShell Expert) — requested by Steven via Squad Coordinator
 **What:** Phase 2 extends the OOP discover wire format so the C# server can build the doctor `moduleImports` section from data the OOP host produced — achieving SC-263-3 (byte-identical JSON across `InProcess` and `OutOfProcess` modes) without re-running `Get-Module -ListAvailable` in the parent process. Additive wire fields: `RemoteToolSchema.SourceModule` / `SourcePattern` / `SourceDetail` (nullable strings, FR-263-9), plus a new top-level optional `RemoteModuleImportsPayload` on the discover response carrying per-module probe data and per-pattern match data. `oop-host.ps1` and `oop-host-pool.ps1` populate both. The pool wraps script-block return as `PSCustomObject {Schemas, ModuleImports}` with a defensive bare-array fallback.

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -31,26 +31,24 @@
   - name: Session Management
     href: articles/session-management.md
     
-- name: Authentication & Security
-  items:
-  - name: Entra ID Authentication
-    href: articles/authentication.md
-  - name: Security Best Practices
-    href: articles/security.md
-    
-- name: Deployment
-  items:
-  - name: Docker Deployment
-    href: articles/docker.md
-  - name: Environment Customization
-    href: articles/environment.md
-  - name: Azure Integration
-    href: articles/azure-integration.md
-  - name: Application Insights
-    href: articles/application-insights.md
-    
 - name: Advanced Topics
   items:
+  - name: Authentication & Security
+    items:
+    - name: Entra ID Authentication
+      href: articles/authentication.md
+    - name: Security Best Practices
+      href: articles/security.md
+  - name: Deployment
+    items:
+    - name: Docker Deployment
+      href: articles/docker.md
+    - name: Environment Customization
+      href: articles/environment.md
+    - name: Azure Integration
+      href: articles/azure-integration.md
+    - name: Application Insights
+      href: articles/application-insights.md
   - name: Advanced Configuration
     href: articles/advanced.md
   - name: AI Assistant Integration

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -7,6 +7,8 @@
 - name: Tutorials
   href: articles/tutorials/index.md
   items:
+  - name: Overview
+    href: articles/tutorials/index.md
   - name: 1. Local stdio MCP server
     href: articles/tutorials/01-local-stdio-server.md
   - name: 2. Docker HTTP with custom functions


### PR DESCRIPTION
Simplifies top-level docs nav by nesting Authentication & Security and Deployment groups under Advanced Topics.

**Before:** Home / Getting Started / Tutorials / User Guide / Authentication & Security / Deployment / Advanced Topics / Support / Release Notes
**After:** Home / Getting Started / Tutorials / User Guide / Advanced Topics / Support / Release Notes

All leaf articles preserved. Used flat-nest (sub-section groups) to keep Auth+Security pairing and Deployment grouping intact.

Requested by Steven.