### PR TITLE
feat: tighten noun resource registration and links

### DIFF
--- a/.squad/agents/scribe/history.md
+++ b/.squad/agents/scribe/history.md
@@ -33,6 +33,7 @@ PoshMcp dynamically transforms PowerShell scripts, cmdlets, and modules into sec
 - 2026-04-24: When workflow/script build behavior is corrected by another agent, merge the inbox proposal into one concise canonical decision and create matching per-agent orchestration logs for traceability.
 - 2026-04-24: For version bump and packaging batches, preserve cross-agent continuity by logging three anchors together: canonical decision merge (with artifact path), one per-agent orchestration entry, and one short session log.
 - 2026-05-19: When `decisions.md` is still above the 50 KB gate, check whether any entries older than the retention cutoff actually remain before attempting a second archive pass. If only recent entries are left, merge the inbox, clear it, and record that no additional archival candidates existed.
+- 2026-05-19: If release agents already updated their own history files and those files are dirty, do not reopen them during Scribe closeout. Add only new squad artifacts in clean files, then commit a path-scoped `.squad/` slice.
 - 2026-05-02: Cut release v0.9.17 following release process principles: clean build verified, version updated in PoshMcp.csproj, committed with context (token diagnostics and idle session timeout), tagged, and pushed. Remote accepted both commit and tag successfully.
 
 ## 2026-05-16: Issue #272 spawn — IToolImportSourceTracker implementation

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -3,6 +3,17 @@
 ## Recent Decisions
 > Older entries archived to `decisions-archive.md` (entries >7d removed when file >= 50KB).
 
+### 2026-05-19: Next release line should be 0.15.0
+**By:** Leela (Developer Advocate)
+
+**Decision:** Treat the next release from current `main` as `0.15.0`, not `0.14.3`.
+
+**Why:** The repo is currently ahead of `v0.14.2` with additive spec 012 noun-resource work: new opt-in configuration (`EnableNounResources`, `NounResourceOverrides`), new MCP runtime behavior (`resources/list`, `resources/read`, appended resource-link blocks), new doctor output (`nounResources` / `Noun Resources`), and new integration/unit coverage. That is feature-level surface area, not a patch-only change.
+
+**Consequences:** Release notes and changelog prep for the next cut should target `0.15.0`. The version file and tag/publish steps remain for Amy's release flow.
+
+---
+
 ### 2026-05-19: Noun-derived resource documentation belongs in the existing behavior and configuration guides
 **By:** Leela (Developer Advocate)
 **Artifacts:** `docs/articles/resources-and-prompts.md`, `docs/articles/configuration.md`

--- a/.squad/log/2026-05-19T00-00-00Z-v0.15.0-release.md
+++ b/.squad/log/2026-05-19T00-00-00Z-v0.15.0-release.md
@@ -1,0 +1,19 @@
+# Session log — v0.15.0 release
+
+**Timestamp:** 2026-05-19T00:00:00Z
+**Requested by:** Steven Murawski
+
+## Summary
+
+Shipped v0.15.0 from release-prep commit `a9f262a891afb50e977e132f003588e0f2ef4758` after release notes, changelog, version bump, and CI gates were all in place.
+
+- **Leela:** Determined the next release line should be `0.15.0`, drafted and finalized `docs/release-notes/0.15.0.md`, aligned `CHANGELOG.md`, and updated `docs/toc.yml`.
+- **Amy:** Cut the scoped release-prep commit `a9f262a` (`chore(release): v0.15.0`), kept unrelated local changes out of the release commit, watched the required GitHub Actions gates, then created and pushed annotated tag `v0.15.0`.
+- **Validation observed:** Local release-prep quality gates passed before push (`dotnet format PoshMcp.sln --verify-no-changes`, `dotnet test PoshMcp.sln` with `914` passed, `0` failed). Remote checks for `submit-nuget`, `Analyze (csharp)`, `Analyze (python)`, `Analyze (actions)`, `deploy`, `build`, `release`, and `Build & Publish Preview NuGet Package` completed with `success` before tag publication.
+- **Non-blocking note:** GitHub Actions reported Node.js 20 deprecation annotations for marketplace actions during CI completion; release shipment was not blocked.
+
+## Scribe actions
+- Merged 1 release decision from `.squad/decisions/inbox/` into `.squad/decisions.md`.
+- Wrote 2 orchestration-log entries for Leela and Amy.
+- Wrote this session log.
+- Left pre-existing dirty agent history files untouched and committed only the new `.squad/` slice.

--- a/.squad/orchestration-log/2026-05-19T00-00-00Z-amy-v0.15.0-release.md
+++ b/.squad/orchestration-log/2026-05-19T00-00-00Z-amy-v0.15.0-release.md
@@ -1,0 +1,21 @@
+# 2026-05-19T00-00-00Z — amy
+
+**Routed to:** Amy (DevOps / Release)
+**Why chosen:** Version bump, release commit construction, CI gate observation, and remote tag publication for v0.15.0 are Amy's release lane.
+**Mode:** background
+**Requested by:** Steven Murawski
+
+## Inputs read
+- `PoshMcp.Server/PoshMcp.csproj`
+- `CHANGELOG.md`
+- `docs/release-notes/0.15.0.md`
+- `docs/toc.yml`
+- Working tree status and remote CI state for commit `a9f262a891afb50e977e132f003588e0f2ef4758`
+
+## Outputs produced
+- Release-prep commit `a9f262a` (`chore(release): v0.15.0`) on `origin/main`
+- Annotated tag `v0.15.0` pushed to `origin`
+- `.squad/agents/amy/history.md` — release prep and ship notes
+
+## Outcome
+Release v0.15.0 shipped after the final required GitHub Actions checks completed successfully. The annotated remote tag points at the intended release commit.

--- a/.squad/orchestration-log/2026-05-19T00-00-00Z-leela-v0.15.0-release.md
+++ b/.squad/orchestration-log/2026-05-19T00-00-00Z-leela-v0.15.0-release.md
@@ -1,0 +1,21 @@
+# 2026-05-19T00-00-00Z — leela
+
+**Routed to:** Leela (Developer Advocate)
+**Why chosen:** Release-notes and changelog framing for the v0.15.0 cut needed docs ownership and version-line judgment.
+**Mode:** background
+**Requested by:** Steven Murawski
+
+## Inputs read
+- `CHANGELOG.md`
+- `docs/release-notes/`
+- `docs/toc.yml`
+- Repo release state relative to `v0.14.2`
+
+## Outputs produced
+- `docs/release-notes/0.15.0.md` — drafted and finalized for the v0.15.0 release.
+- `CHANGELOG.md` — release entries aligned for 0.15.0 prep.
+- `docs/toc.yml` — release notes navigation updated.
+- `.squad/decisions/inbox/2026-05-19-leela-release-version-0.15.0.md` — release-line decision for Scribe merge.
+
+## Outcome
+Release-notes gate completed. The next release line was set to `0.15.0`, release notes were ready, and the release metadata was in place for Amy's cut.

--- a/PoshMcp.Server/Diagnostics/DoctorService.cs
+++ b/PoshMcp.Server/Diagnostics/DoctorService.cs
@@ -96,6 +96,7 @@ internal static class DoctorService
         var helpAwareSource = new HelpAwareToolMetadataSource();
         try
         {
+            DiscoveredNounRegistryCapture.Reset();
             tools = await discoverToolsFunc(config, loggerFactory, logger, settings.FinalConfigPath, helpAwareSource, descriptionSourceTracker, importSourceTracker);
         }
         catch (Exception ex)
@@ -138,7 +139,8 @@ internal static class DoctorService
             tools: tools,
             authConfig: authConfig,
             allowConfigurationFileAccess: configurationLoaded,
-            importSourceTracker: importSourceTracker);
+            importSourceTracker: importSourceTracker,
+            nounRegistry: DiscoveredNounRegistryCapture.Current);
 
         report = report with
         {
@@ -162,7 +164,7 @@ internal static class DoctorService
             },
             OutOfProcess = BuildOutOfProcessSection(config, settings.FinalConfigPath, loggerFactory),
             ModuleImports = BuildModuleImportsSection(config, tools, OopModuleImportsCapture.Current, logger, importSourceTracker),
-            NounResources = BuildNounResourcesSection(config, null),
+            NounResources = BuildNounResourcesSection(config, DiscoveredNounRegistryCapture.Current),
             ConfigurationErrors = [.. report.ConfigurationErrors, .. configurationErrors],
         };
 

--- a/PoshMcp.Server/McpResources/DiscoveredNounRegistryCapture.cs
+++ b/PoshMcp.Server/McpResources/DiscoveredNounRegistryCapture.cs
@@ -1,0 +1,31 @@
+using System.Threading;
+
+namespace PoshMcp.Server.McpResources;
+
+/// <summary>
+/// Captures the eligibility-aware <see cref="NounRegistry"/> discovered for the
+/// current async flow so CLI doctor can reuse the live noun-resource surface
+/// without widening the discovery return contract.
+/// </summary>
+/// <remarks>
+/// <para><c>McpToolSetupService.DiscoverToolsAsync</c> only returns the materialized
+/// tool list, but doctor noun-resource reporting also needs the registry produced
+/// from command metadata during discovery. This capture preserves that registry for
+/// the current async flow until <c>DoctorService.BuildDoctorReportForCliAsync</c>
+/// consumes it.</para>
+/// <para>Callers should reset before discovery to avoid reusing a stale registry on
+/// subsequent discovery attempts in the same async flow.</para>
+/// </remarks>
+internal static class DiscoveredNounRegistryCapture
+{
+    private static readonly AsyncLocal<NounRegistry?> _current = new();
+
+    /// <summary>Reads the captured registry for the current async flow.</summary>
+    public static NounRegistry? Current => _current.Value;
+
+    /// <summary>Stores the discovered registry for the current async flow.</summary>
+    public static void Set(NounRegistry? nounRegistry) => _current.Value = nounRegistry;
+
+    /// <summary>Clears the captured registry for the current async flow.</summary>
+    public static void Reset() => _current.Value = null;
+}

--- a/PoshMcp.Server/McpResources/NounRegistry.cs
+++ b/PoshMcp.Server/McpResources/NounRegistry.cs
@@ -42,14 +42,40 @@ public sealed class NounRegistry
     /// <param name="logger">Logger; receives a warning for each resource name conflict.</param>
     public static NounRegistry Build(IEnumerable<string> discoveredCommandNames, ILogger logger)
     {
-        var commands = discoveredCommandNames.ToList();
+        ArgumentNullException.ThrowIfNull(discoveredCommandNames);
+
+        return Build(
+            discoveredCommandNames.Select(commandName => new NounCommandCandidate(commandName, CanInvokeWithoutRequiredUserParameters: true)),
+            logger);
+    }
+
+    /// <summary>
+    /// Builds an immutable <see cref="NounRegistry"/> from the given discovered command candidates.
+    /// Commands must be supplied in discovery order; first-writer-wins for resource name conflicts.
+    /// A derived noun resource is created only when the backing <c>Get-*</c> command can be
+    /// invoked without required user parameters.
+    /// </summary>
+    /// <param name="discoveredCommands">
+    /// Full list of discovered PowerShell commands in priority order with noun-resource eligibility metadata.
+    /// </param>
+    /// <param name="logger">Logger; receives a warning for each resource name conflict.</param>
+    public static NounRegistry Build(IEnumerable<NounCommandCandidate> discoveredCommands, ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(discoveredCommands);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        var commands = discoveredCommands.ToList();
 
         // resource_name → winning (non-conflicted) NounEntry
         var claimedByResourceName = new Dictionary<string, NounEntry>(StringComparer.OrdinalIgnoreCase);
         var allEntries = new List<NounEntry>();
 
-        foreach (var cmd in commands)
+        foreach (var command in commands)
         {
+            if (!command.CanInvokeWithoutRequiredUserParameters)
+                continue;
+
+            var cmd = command.CommandName;
             var noun = ExtractNounFromCommandName(cmd);
             if (noun is null)
                 continue;
@@ -158,3 +184,14 @@ public sealed record NounEntry(
     string Uri,
     string CanonicalGetCommand,
     bool IsConflicted);
+
+/// <summary>
+/// Metadata for a discovered PowerShell command relevant to noun-resource derivation.
+/// </summary>
+/// <param name="CommandName">The discovered PowerShell command name.</param>
+/// <param name="CanInvokeWithoutRequiredUserParameters">
+/// <c>true</c> when at least one parameter set can be invoked without required user parameters.
+/// </param>
+public sealed record NounCommandCandidate(
+    string CommandName,
+    bool CanInvokeWithoutRequiredUserParameters);

--- a/PoshMcp.Server/McpResources/ResourceLinkInjector.cs
+++ b/PoshMcp.Server/McpResources/ResourceLinkInjector.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
+using PoshMcp.Server.PowerShell;
 
 namespace PoshMcp.Server.McpResources;
 
@@ -16,43 +18,69 @@ namespace PoshMcp.Server.McpResources;
 /// </summary>
 internal static class ResourceLinkInjector
 {
+    private static readonly JsonSerializerOptions ResourceLinkJsonOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
     /// <summary>
     /// Wraps tools in the list with resource link injection for any tool whose noun has a
-    /// non-conflicted <see cref="NounEntry"/> in the registry.
+    /// non-conflicted <see cref="NounEntry"/> in the registry or has an explicit associated resource.
     /// Returns a new list; does not mutate the input.
     /// </summary>
     /// <param name="tools">The list of tools to process.</param>
     /// <param name="registry">The noun registry to look up entries.</param>
+    /// <param name="commandOverrides">The effective per-command overrides.</param>
+    /// <param name="resourcesConfig">The configured static/custom resources.</param>
     /// <param name="logger">Logger for diagnostics.</param>
     public static List<McpServerTool> WrapToolsWithResourceLinks(
         List<McpServerTool> tools,
-        EffectiveNounResourceRegistry registry,
+        EffectiveNounResourceRegistry? registry,
+        IReadOnlyDictionary<string, FunctionOverride> commandOverrides,
+        McpResourcesConfiguration resourcesConfig,
         ILogger logger)
     {
         ArgumentNullException.ThrowIfNull(tools);
-        ArgumentNullException.ThrowIfNull(registry);
+        ArgumentNullException.ThrowIfNull(commandOverrides);
+        ArgumentNullException.ThrowIfNull(resourcesConfig);
         ArgumentNullException.ThrowIfNull(logger);
 
+        var exposedResourcesByUri = BuildExposedResourceLookup(resourcesConfig, registry);
         var result = new List<McpServerTool>(tools.Count);
         var wrappedCount = 0;
 
         foreach (var tool in tools)
         {
-            var noun = ExtractNounFromToolTitle(tool);
-            if (noun is null)
+            var commandName = ExtractCommandNameFromToolTitle(tool);
+            if (commandName is null)
             {
                 result.Add(tool);
                 continue;
             }
 
-            var entry = registry.GetEntry(noun);
-            if (entry is null)
+            var explicitResource = ResolveAssociatedResource(
+                commandName,
+                commandOverrides,
+                exposedResourcesByUri,
+                logger);
+
+            EffectiveNounResourceEntry? nounEntry = null;
+            if (registry is not null)
+            {
+                var noun = NounRegistry.ExtractNounFromCommandName(commandName);
+                if (noun is not null)
+                {
+                    nounEntry = registry.GetEntry(noun);
+                }
+            }
+
+            if (explicitResource is null && nounEntry is null)
             {
                 result.Add(tool);
                 continue;
             }
 
-            result.Add(new ResourceLinkInjectorTool(tool, entry));
+            result.Add(new ResourceLinkInjectorTool(tool, explicitResource, nounEntry));
             wrappedCount++;
         }
 
@@ -63,17 +91,141 @@ internal static class ResourceLinkInjector
         return result;
     }
 
-    private static string? ExtractNounFromToolTitle(McpServerTool tool)
+    private static Dictionary<string, ResourceLinkTarget> BuildExposedResourceLookup(
+        McpResourcesConfiguration resourcesConfig,
+        EffectiveNounResourceRegistry? registry)
+    {
+        var lookup = new Dictionary<string, ResourceLinkTarget>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var resource in resourcesConfig.Resources)
+        {
+            if (string.IsNullOrWhiteSpace(resource.Uri))
+            {
+                continue;
+            }
+
+            lookup.TryAdd(
+                resource.Uri,
+                new ResourceLinkTarget(
+                    resource.Uri,
+                    DeriveResourceName(resource.Uri, resource.Name),
+                    resource.Description ?? resource.Name ?? resource.Uri,
+                    null));
+        }
+
+        if (registry is not null)
+        {
+            foreach (var nounEntry in registry.AllEntries)
+            {
+                lookup.TryAdd(
+                    nounEntry.Uri,
+                    new ResourceLinkTarget(
+                        nounEntry.Uri,
+                        nounEntry.ResourceName,
+                        nounEntry.Description,
+                        nounEntry.Noun));
+            }
+        }
+
+        return lookup;
+    }
+
+    private static ResourceLinkTarget? ResolveAssociatedResource(
+        string commandName,
+        IReadOnlyDictionary<string, FunctionOverride> commandOverrides,
+        IReadOnlyDictionary<string, ResourceLinkTarget> exposedResourcesByUri,
+        ILogger logger)
+    {
+        if (!commandOverrides.TryGetValue(commandName, out var commandOverride) ||
+            string.IsNullOrWhiteSpace(commandOverride.AssociatedResourceUri))
+        {
+            return null;
+        }
+
+        var associatedResourceUri = commandOverride.AssociatedResourceUri.Trim();
+        if (exposedResourcesByUri.TryGetValue(associatedResourceUri, out var target))
+        {
+            return target;
+        }
+
+        logger.LogWarning(
+            "Command override AssociatedResourceUri {AssociatedResourceUri} for {CommandName} does not resolve to an exposed MCP resource. Falling back to noun-derived resource-link injection when available.",
+            associatedResourceUri,
+            commandName);
+        return null;
+    }
+
+    private static string? ExtractCommandNameFromToolTitle(McpServerTool tool)
     {
         string? title;
         try { title = tool.ProtocolTool.Title; }
         catch { return null; }
 
         if (string.IsNullOrWhiteSpace(title))
+        {
             return null;
+        }
 
-        return NounRegistry.ExtractNounFromCommandName(title);
+        return title;
     }
+
+    private static string DeriveResourceName(string uri, string? fallbackName)
+    {
+        if (Uri.TryCreate(uri, UriKind.Absolute, out var parsed))
+        {
+            var absolutePath = parsed.AbsolutePath.Trim('/');
+            if (!string.IsNullOrWhiteSpace(absolutePath))
+            {
+                var segments = absolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+                if (segments.Length > 0)
+                {
+                    return segments[^1];
+                }
+            }
+        }
+
+        var lastSlash = uri.LastIndexOf('/');
+        if (lastSlash >= 0 && lastSlash < uri.Length - 1)
+        {
+            return uri[(lastSlash + 1)..];
+        }
+
+        return string.IsNullOrWhiteSpace(fallbackName) ? uri : fallbackName;
+    }
+
+    internal static EmbeddedResourceBlock CreateResourceLinkBlock(
+        string uri,
+        string resourceName,
+        string? noun,
+        string relationship,
+        string description)
+    {
+        return new EmbeddedResourceBlock
+        {
+            Resource = new TextResourceContents
+            {
+                Uri = uri,
+                MimeType = "application/json+mcp-resource-link",
+                Text = JsonSerializer.Serialize(new
+                {
+                    resourceLink = new
+                    {
+                        uri,
+                        resourceName,
+                        noun,
+                        relationship,
+                        description,
+                    }
+                }, ResourceLinkJsonOptions)
+            }
+        };
+    }
+
+    internal sealed record ResourceLinkTarget(
+        string Uri,
+        string ResourceName,
+        string Description,
+        string? Noun);
 }
 
 /// <summary>
@@ -82,12 +234,17 @@ internal static class ResourceLinkInjector
 /// </summary>
 internal sealed class ResourceLinkInjectorTool : DelegatingMcpServerTool
 {
-    private readonly EffectiveNounResourceEntry _nounEntry;
+    private readonly ResourceLinkInjector.ResourceLinkTarget? _explicitResource;
+    private readonly EffectiveNounResourceEntry? _nounEntry;
 
-    public ResourceLinkInjectorTool(McpServerTool innerTool, EffectiveNounResourceEntry nounEntry)
+    public ResourceLinkInjectorTool(
+        McpServerTool innerTool,
+        ResourceLinkInjector.ResourceLinkTarget? explicitResource,
+        EffectiveNounResourceEntry? nounEntry)
         : base(innerTool)
     {
-        _nounEntry = nounEntry ?? throw new ArgumentNullException(nameof(nounEntry));
+        _explicitResource = explicitResource;
+        _nounEntry = nounEntry;
     }
 
     public override async ValueTask<CallToolResult> InvokeAsync(
@@ -96,27 +253,30 @@ internal sealed class ResourceLinkInjectorTool : DelegatingMcpServerTool
     {
         var result = await base.InvokeAsync(request, cancellationToken);
 
-        if (result.IsError != true && !_nounEntry.DisableResourceLinkBlock)
+        if (result.IsError == true)
         {
-            result.Content.Add(new EmbeddedResourceBlock
-            {
-                Resource = new TextResourceContents
-                {
-                    Uri = _nounEntry.Uri,
-                    MimeType = "application/json+mcp-resource-link",
-                    Text = JsonSerializer.Serialize(new
-                    {
-                        resourceLink = new
-                        {
-                            uri = _nounEntry.Uri,
-                            resourceName = _nounEntry.ResourceName,
-                            noun = _nounEntry.Noun,
-                            relationship = "subject",
-                            description = _nounEntry.Description,
-                        }
-                    })
-                }
-            });
+            return result;
+        }
+
+        if (_explicitResource is not null)
+        {
+            result.Content.Add(ResourceLinkInjector.CreateResourceLinkBlock(
+                _explicitResource.Uri,
+                _explicitResource.ResourceName,
+                _explicitResource.Noun,
+                "context",
+                _explicitResource.Description));
+            return result;
+        }
+
+        if (_nounEntry is not null && !_nounEntry.DisableResourceLinkBlock)
+        {
+            result.Content.Add(ResourceLinkInjector.CreateResourceLinkBlock(
+                _nounEntry.Uri,
+                _nounEntry.ResourceName,
+                _nounEntry.Noun,
+                "subject",
+                _nounEntry.Description));
         }
 
         return result;

--- a/PoshMcp.Server/McpToolFactoryV2.cs
+++ b/PoshMcp.Server/McpToolFactoryV2.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
+using PoshMcp.Server.McpResources;
 using PoshMcp.Server.Observability;
 using PoshMcp.Server.PowerShell;
 using PoshMcp.Server.PowerShell.OutOfProcess;
@@ -45,6 +46,8 @@ public class McpToolFactoryV2
     private readonly IToolImportSourceTracker? _importSourceTracker;
     private readonly PowerShellHelpResolver _helpResolver = new();
     private static McpMetrics? _metrics;
+
+    internal NounRegistry? LastDiscoveredNounRegistry { get; private set; }
 
     /// <summary>
     /// Sets the metrics instance for OpenTelemetry instrumentation
@@ -450,6 +453,7 @@ public class McpToolFactoryV2
                 logger.LogInformationWithCorrelation("Starting MCP tools generation using dynamic assembly approach");
                 LogToolGenerationStart(logger, config);
                 _importSourceTracker?.Reset();
+                LastDiscoveredNounRegistry = null;
 
                 if (config.RuntimeMode == RuntimeMode.OutOfProcess)
                 {
@@ -457,6 +461,7 @@ public class McpToolFactoryV2
                 }
 
                 var commands = ValidateAndGetCommands(config, logger);
+                LastDiscoveredNounRegistry = BuildNounRegistry(commands, logger);
                 if (!commands.Any()) return new List<McpServerTool>();
 
                 // Resolve Get-Help once per command (FR-570) so both the command-level
@@ -489,10 +494,12 @@ public class McpToolFactoryV2
         if (schemas.Count == 0)
         {
             logger.LogWarning("Out-of-process discovery returned no tool schemas");
+            LastDiscoveredNounRegistry = BuildNounRegistry(schemas, logger);
             return new List<McpServerTool>();
         }
 
         RecordRemoteImportSources(schemas, _importSourceTracker);
+        LastDiscoveredNounRegistry = BuildNounRegistry(schemas, logger);
         var remoteParameterDescriptions = BuildRemoteParameterDescriptionMap(schemas, _toolMetadataSource, _descriptionSourceTracker);
         _outOfProcessAssemblyGenerator.GenerateAssembly(schemas, remoteParameterDescriptions, logger);
         var generatedInstance = _outOfProcessAssemblyGenerator.GetGeneratedInstance(logger);
@@ -501,6 +508,56 @@ public class McpToolFactoryV2
         var tools = CreateMcpToolsFromMethods(generatedMethods, generatedInstance, methodToCommandMap, logger);
         LogToolGenerationResults(tools, logger);
         return tools;
+    }
+
+    private static NounRegistry BuildNounRegistry(IEnumerable<CommandInfo> commands, ILogger logger)
+    {
+        return NounRegistry.Build(
+            commands.Select(command => new NounCommandCandidate(
+                command.Name,
+                CanInvokeWithoutRequiredUserParameters(command))),
+            logger);
+    }
+
+    private static NounRegistry BuildNounRegistry(IReadOnlyList<RemoteToolSchema> schemas, ILogger logger)
+    {
+        return NounRegistry.Build(
+            schemas
+                .Where(schema => schema is not null && !string.IsNullOrWhiteSpace(schema.Name))
+                .GroupBy(schema => schema.Name, StringComparer.OrdinalIgnoreCase)
+                .Select(group => new NounCommandCandidate(
+                    group.Key,
+                    group.Any(CanInvokeWithoutRequiredUserParameters))),
+            logger);
+    }
+
+    private static bool CanInvokeWithoutRequiredUserParameters(CommandInfo command)
+    {
+        if (command.ParameterSets is { Count: > 0 })
+        {
+            return command.ParameterSets.Any(CanInvokeWithoutRequiredUserParameters);
+        }
+
+        return !command.Parameters
+            .Where(parameter => !PowerShellParameterUtils.IsCommonParameter(parameter.Key))
+            .Any(parameter => parameter.Value.Attributes
+                .OfType<ParameterAttribute>()
+                .Any(attribute => attribute.Mandatory));
+    }
+
+    private static bool CanInvokeWithoutRequiredUserParameters(CommandParameterSetInfo parameterSet)
+    {
+        return !parameterSet.Parameters
+            .Where(parameter => !PowerShellParameterUtils.IsCommonParameter(parameter.Name))
+            .Any(parameter => parameter.IsMandatory);
+    }
+
+    private static bool CanInvokeWithoutRequiredUserParameters(RemoteToolSchema schema)
+    {
+        return schema.Parameters is null
+            || !schema.Parameters
+                .Where(parameter => !PowerShellParameterUtils.IsCommonParameter(parameter.Name))
+                .Any(parameter => parameter.IsMandatory);
     }
 
     private static void LogToolGenerationStart(ILogger logger, PowerShellConfiguration config)

--- a/PoshMcp.Server/PowerShell/ConfigurationReloadTools.cs
+++ b/PoshMcp.Server/PowerShell/ConfigurationReloadTools.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Server;
+using PoshMcp.Server.McpResources;
 
 namespace PoshMcp.Server.PowerShell;
 
@@ -22,6 +23,7 @@ public class ConfigurationReloadTools
     private readonly string? _effectiveMcpPath;
     private readonly Func<List<McpServerTool>> _registeredToolsProvider;
     private readonly IToolImportSourceTracker? _importSourceTracker;
+    private readonly Func<NounRegistry?>? _nounRegistryProvider;
     private readonly ILogger<ConfigurationReloadTools> _logger;
 
     public ConfigurationReloadTools(
@@ -37,7 +39,8 @@ public class ConfigurationReloadTools
             null,
             static () => new List<McpServerTool>(),
             logger,
-            importSourceTracker: null)
+                importSourceTracker: null,
+                nounRegistryProvider: null)
     {
     }
 
@@ -51,7 +54,8 @@ public class ConfigurationReloadTools
         string? effectiveMcpPath,
         Func<List<McpServerTool>> registeredToolsProvider,
         ILogger<ConfigurationReloadTools> logger,
-        IToolImportSourceTracker? importSourceTracker = null)
+        IToolImportSourceTracker? importSourceTracker = null,
+        Func<NounRegistry?>? nounRegistryProvider = null)
     {
         _reloadService = reloadService ?? throw new ArgumentNullException(nameof(reloadService));
         _configurationPath = configurationPath ?? string.Empty;
@@ -62,6 +66,7 @@ public class ConfigurationReloadTools
         _effectiveMcpPath = effectiveMcpPath;
         _registeredToolsProvider = registeredToolsProvider ?? throw new ArgumentNullException(nameof(registeredToolsProvider));
         _importSourceTracker = importSourceTracker;
+        _nounRegistryProvider = nounRegistryProvider;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -214,7 +219,8 @@ public class ConfigurationReloadTools
                 effectiveMcpPathSource: "runtime",
                 config: currentConfig,
                 tools: _registeredToolsProvider(),
-                importSourceTracker: _importSourceTracker);
+                importSourceTracker: _importSourceTracker,
+                nounRegistry: _nounRegistryProvider?.Invoke());
 
             return await Task.FromResult(DoctorService.BuildDoctorJson(report));
         }

--- a/PoshMcp.Server/PowerShell/PerformanceConfiguration.cs
+++ b/PoshMcp.Server/PowerShell/PerformanceConfiguration.cs
@@ -30,6 +30,12 @@ public class PerformanceConfiguration
 public class FunctionOverride
 {
     /// <summary>
+    /// Explicit MCP resource URI to associate with successful results for this command.
+    /// When null or empty, noun-derived link injection behavior is used.
+    /// </summary>
+    public string? AssociatedResourceUri { get; set; }
+
+    /// <summary>
     /// Explicit list of property names to select. Takes priority over DefaultDisplayPropertySet.
     /// When null, the type's DefaultDisplayPropertySet is used (if UseDefaultDisplayProperties is true).
     /// </summary>

--- a/PoshMcp.Server/Server/HttpServerHost.cs
+++ b/PoshMcp.Server/Server/HttpServerHost.cs
@@ -106,29 +106,22 @@ internal static class HttpServerHost
 
         logger.LogInformation("Using configuration source: {ConfigurationPath}", ConfigurationHelpers.DescribeConfigurationPath(finalConfigPath));
 
-        var tools = await McpToolSetupService.SetupHttpMcpToolsAsync(bootstrapLoggerFactory, config, logger, finalConfigPath, configurationPathSource, sharedSessionRunspace, executorLease?.Executor, sharedHttpContextAccessor);
+        var toolSetup = await McpToolSetupService.SetupHttpMcpToolsAsync(bootstrapLoggerFactory, config, logger, finalConfigPath, configurationPathSource, sharedSessionRunspace, executorLease?.Executor, sharedHttpContextAccessor);
+        var tools = toolSetup.Tools;
         var resourcesConfig = ConfigurationLoader.LoadMcpResourcesConfiguration(finalConfigPath, logger);
         var resourcesConfigDirectory = Path.GetDirectoryName(finalConfigPath) ?? ".";
         var resourceLogger = bootstrapLoggerFactory.CreateLogger<McpResourceHandler>();
         var resourceHandler = new McpResourceHandler(resourcesConfig, sharedSessionRunspace, resourcesConfigDirectory, resourceLogger);
 
         McpNounResourceHandler? nounHandler = null;
-        if (config.EnableNounResources)
+        if (toolSetup.EffectiveNounResourceRegistry is not null)
         {
-            var commandNames = tools
-                .Select(t => { try { return t.ProtocolTool.Title; } catch { return null; } })
-                .Where(n => !string.IsNullOrWhiteSpace(n))
-                .Cast<string>();
-            var nounRegistry = NounRegistry.Build(commandNames, bootstrapLoggerFactory.CreateLogger("NounRegistry"));
-            var effectiveNounRegistry = EffectiveNounResourceRegistry.Build(nounRegistry, config.NounResourceOverrides);
             var nounExecutor = executorLease?.Executor;
             nounHandler = new McpNounResourceHandler(
-                effectiveNounRegistry,
+                toolSetup.EffectiveNounResourceRegistry,
                 nounExecutor is null ? sharedSessionRunspace : null,
                 nounExecutor,
                 bootstrapLoggerFactory.CreateLogger<McpNounResourceHandler>());
-            tools = ResourceLinkInjector.WrapToolsWithResourceLinks(
-                tools, effectiveNounRegistry, bootstrapLoggerFactory.CreateLogger("ResourceLinkInjector"));
         }
 
         var authConfigValue = authRootConfig.GetSection("Authentication").Get<PoshMcp.Server.Authentication.AuthenticationConfiguration>() ?? new();

--- a/PoshMcp.Server/Server/McpToolSetupService.cs
+++ b/PoshMcp.Server/Server/McpToolSetupService.cs
@@ -65,7 +65,7 @@ internal static class McpToolSetupService
         logger.LogInformation("Registered set-result-caching tool (always enabled)");
 
         AddConfigurationGuidanceToolToList(tools, config, finalConfigPath, "stdio", config.RuntimeMode.ToString(), null, loggerFactory);
-        AddConfigurationTroubleshootingToolToList(tools, config, finalConfigPath, "stdio", null, config.RuntimeMode.ToString(), null, logger, importSourceTracker: importSourceTracker);
+        AddConfigurationTroubleshootingToolToList(tools, config, finalConfigPath, "stdio", null, config.RuntimeMode.ToString(), null, logger, importSourceTracker: importSourceTracker, nounRegistryProvider: () => toolFactory.LastDiscoveredNounRegistry);
 
         var effectiveNounRegistry = BuildEffectiveNounResourceRegistry(toolFactory, config, loggerFactory);
         var effectiveCommandOverrides = config.GetEffectiveCommandOverrides();
@@ -123,7 +123,7 @@ internal static class McpToolSetupService
         logger.LogInformation("Registered set-result-caching tool (always enabled)");
 
         AddConfigurationGuidanceToolToList(tools, config, finalConfigPath, "http", config.RuntimeMode.ToString(), null, loggerFactory);
-        AddConfigurationTroubleshootingToolToList(tools, config, finalConfigPath, "http", null, config.RuntimeMode.ToString(), null, logger, httpContextAccessor, importSourceTracker);
+        AddConfigurationTroubleshootingToolToList(tools, config, finalConfigPath, "http", null, config.RuntimeMode.ToString(), null, logger, httpContextAccessor, importSourceTracker, () => toolFactory.LastDiscoveredNounRegistry);
 
         var effectiveNounRegistry = BuildEffectiveNounResourceRegistry(toolFactory, config, loggerFactory);
         var effectiveCommandOverrides = config.GetEffectiveCommandOverrides();
@@ -159,9 +159,11 @@ internal static class McpToolSetupService
         // capture from a prior discovery in this async flow before starting
         // a new lease, so a fresh discovery starts from a clean slate.
         OopModuleImportsCapture.Reset();
+        DiscoveredNounRegistryCapture.Reset();
         await using var executorLease = await StartOutOfProcessExecutorIfNeededAsync(config, loggerFactory, logger, configurationPath);
         var toolFactory = CreateToolFactory(config, executorLease?.Executor, runspace: null, toolMetadataSource, descriptionSourceTracker, importSourceTracker);
         var tools = await toolFactory.GetToolsListAsync(config, logger);
+        DiscoveredNounRegistryCapture.Set(toolFactory.LastDiscoveredNounRegistry);
         // Spec 011 FR-263-2 / FR-263-10: capture the executor's
         // LastModuleImports payload BEFORE the lease disposes (the
         // executor is gone after this method returns). DoctorService
@@ -171,7 +173,7 @@ internal static class McpToolSetupService
             OopModuleImportsCapture.Set(executorLease.Executor.LastModuleImports);
         }
         AddConfigurationGuidanceToolToList(tools, config, configurationPath, "stdio", config.RuntimeMode.ToString(), null, loggerFactory);
-        AddConfigurationTroubleshootingToolToList(tools, config, configurationPath, "stdio", null, config.RuntimeMode.ToString(), null, logger);
+        AddConfigurationTroubleshootingToolToList(tools, config, configurationPath, "stdio", null, config.RuntimeMode.ToString(), null, logger, nounRegistryProvider: () => toolFactory.LastDiscoveredNounRegistry);
         return tools;
     }
 
@@ -354,7 +356,8 @@ internal static class McpToolSetupService
             effectiveMcpPath,
             registeredToolsProvider,
             reloadToolsLogger,
-            importSourceTracker);
+            importSourceTracker,
+            nounRegistryProvider: () => toolFactory.LastDiscoveredNounRegistry);
     }
 
     /// <summary>
@@ -447,7 +450,8 @@ internal static class McpToolSetupService
         ILogger logger,
         AuthenticationConfiguration? authConfig = null,
         Func<System.Security.Claims.ClaimsPrincipal?>? identityProvider = null,
-        IToolImportSourceTracker? importSourceTracker = null)
+        IToolImportSourceTracker? importSourceTracker = null,
+        Func<NounRegistry?>? nounRegistryProvider = null)
     {
         try
         {
@@ -493,7 +497,8 @@ internal static class McpToolSetupService
                 authConfig: authConfig,
                 currentIdentity: identityProvider?.Invoke(),
                 allowConfigurationFileAccess: false,
-                importSourceTracker: importSourceTracker);
+                importSourceTracker: importSourceTracker,
+                nounRegistry: nounRegistryProvider?.Invoke());
 
             if (configurationErrors.Count > 0)
             {
@@ -535,7 +540,8 @@ internal static class McpToolSetupService
         ILogger logger,
         AuthenticationConfiguration? authConfig = null,
         Func<System.Security.Claims.ClaimsPrincipal?>? identityProvider = null,
-        IToolImportSourceTracker? importSourceTracker = null)
+        IToolImportSourceTracker? importSourceTracker = null,
+        Func<NounRegistry?>? nounRegistryProvider = null)
     {
         Func<CancellationToken, Task<string>> troubleshootingDelegate = cancellationToken =>
             Task.FromResult(BuildConfigurationTroubleshootingJson(
@@ -548,7 +554,8 @@ internal static class McpToolSetupService
                 logger,
                 authConfig,
                 identityProvider,
-                importSourceTracker));
+                importSourceTracker,
+                nounRegistryProvider));
 
         return McpServerTool.Create(troubleshootingDelegate, new McpServerToolCreateOptions
         {
@@ -576,7 +583,8 @@ internal static class McpToolSetupService
         string? effectiveMcpPath,
         ILogger logger,
         IHttpContextAccessor? httpContextAccessor = null,
-        IToolImportSourceTracker? importSourceTracker = null)
+        IToolImportSourceTracker? importSourceTracker = null,
+        Func<NounRegistry?>? nounRegistryProvider = null)
     {
         if (!config.EnableConfigurationTroubleshootingTool)
         {
@@ -596,7 +604,8 @@ internal static class McpToolSetupService
             logger,
             authConfig: null,
             identityProvider: identityProvider,
-            importSourceTracker: importSourceTracker));
+            importSourceTracker: importSourceTracker,
+            nounRegistryProvider: nounRegistryProvider));
     }
 
     /// <summary>

--- a/PoshMcp.Server/Server/McpToolSetupService.cs
+++ b/PoshMcp.Server/Server/McpToolSetupService.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using PoshMcp.Server.Authentication;
+using PoshMcp.Server.McpResources;
 using PoshMcp.Server.PowerShell;
 using PoshMcp.Server.PowerShell.OutOfProcess;
 
@@ -20,11 +21,15 @@ namespace PoshMcp;
 /// </summary>
 internal static class McpToolSetupService
 {
+    internal sealed record ToolSetupResult(
+        List<McpServerTool> Tools,
+        EffectiveNounResourceRegistry? EffectiveNounResourceRegistry);
+
     /// <summary>
     /// Sets up MCP tools for Stdio transport mode.
     /// Creates tool factory, discovers tools, and sets up configuration management tools.
     /// </summary>
-    internal static async Task<List<McpServerTool>> SetupMcpToolsAsync(
+    internal static async Task<ToolSetupResult> SetupMcpToolsAsync(
         ILoggerFactory loggerFactory,
         PowerShellConfiguration config,
         ILogger logger,
@@ -62,14 +67,27 @@ internal static class McpToolSetupService
         AddConfigurationGuidanceToolToList(tools, config, finalConfigPath, "stdio", config.RuntimeMode.ToString(), null, loggerFactory);
         AddConfigurationTroubleshootingToolToList(tools, config, finalConfigPath, "stdio", null, config.RuntimeMode.ToString(), null, logger, importSourceTracker: importSourceTracker);
 
-        return tools;
+        var effectiveNounRegistry = BuildEffectiveNounResourceRegistry(toolFactory, config, loggerFactory);
+        var effectiveCommandOverrides = config.GetEffectiveCommandOverrides();
+        if (effectiveNounRegistry is not null || effectiveCommandOverrides.Values.Any(o => !string.IsNullOrWhiteSpace(o.AssociatedResourceUri)))
+        {
+            var resourcesConfig = ConfigurationLoader.LoadMcpResourcesConfiguration(finalConfigPath, logger);
+            tools = ResourceLinkInjector.WrapToolsWithResourceLinks(
+                tools,
+                effectiveNounRegistry,
+                effectiveCommandOverrides,
+                resourcesConfig,
+                loggerFactory.CreateLogger("ResourceLinkInjector"));
+        }
+
+        return new ToolSetupResult(tools, effectiveNounRegistry);
     }
 
     /// <summary>
     /// Sets up MCP tools for HTTP transport mode.
     /// Similar to SetupMcpToolsAsync but with session-aware runspace and HTTP context support.
     /// </summary>
-    internal static async Task<List<McpServerTool>> SetupHttpMcpToolsAsync(
+    internal static async Task<ToolSetupResult> SetupHttpMcpToolsAsync(
         ILoggerFactory loggerFactory,
         PowerShellConfiguration config,
         ILogger logger,
@@ -107,7 +125,20 @@ internal static class McpToolSetupService
         AddConfigurationGuidanceToolToList(tools, config, finalConfigPath, "http", config.RuntimeMode.ToString(), null, loggerFactory);
         AddConfigurationTroubleshootingToolToList(tools, config, finalConfigPath, "http", null, config.RuntimeMode.ToString(), null, logger, httpContextAccessor, importSourceTracker);
 
-        return tools;
+        var effectiveNounRegistry = BuildEffectiveNounResourceRegistry(toolFactory, config, loggerFactory);
+        var effectiveCommandOverrides = config.GetEffectiveCommandOverrides();
+        if (effectiveNounRegistry is not null || effectiveCommandOverrides.Values.Any(o => !string.IsNullOrWhiteSpace(o.AssociatedResourceUri)))
+        {
+            var resourcesConfig = ConfigurationLoader.LoadMcpResourcesConfiguration(finalConfigPath, logger);
+            tools = ResourceLinkInjector.WrapToolsWithResourceLinks(
+                tools,
+                effectiveNounRegistry,
+                effectiveCommandOverrides,
+                resourcesConfig,
+                loggerFactory.CreateLogger("ResourceLinkInjector"));
+        }
+
+        return new ToolSetupResult(tools, effectiveNounRegistry);
     }
 
     /// <summary>
@@ -142,6 +173,22 @@ internal static class McpToolSetupService
         AddConfigurationGuidanceToolToList(tools, config, configurationPath, "stdio", config.RuntimeMode.ToString(), null, loggerFactory);
         AddConfigurationTroubleshootingToolToList(tools, config, configurationPath, "stdio", null, config.RuntimeMode.ToString(), null, logger);
         return tools;
+    }
+
+    private static EffectiveNounResourceRegistry? BuildEffectiveNounResourceRegistry(
+        McpToolFactoryV2 toolFactory,
+        PowerShellConfiguration config,
+        ILoggerFactory loggerFactory)
+    {
+        if (!config.EnableNounResources)
+        {
+            return null;
+        }
+
+        var nounRegistry = toolFactory.LastDiscoveredNounRegistry
+            ?? NounRegistry.Build(Array.Empty<string>(), loggerFactory.CreateLogger("NounRegistry"));
+
+        return EffectiveNounResourceRegistry.Build(nounRegistry, config.NounResourceOverrides);
     }
 
     /// <summary>

--- a/PoshMcp.Server/Server/StdioServerHost.cs
+++ b/PoshMcp.Server/Server/StdioServerHost.cs
@@ -58,11 +58,12 @@ internal static class StdioServerHost
         var config = ConfigurationLoader.LoadPowerShellConfiguration(finalConfigPath, logger, runtimeModeOverride);
         var resourcesConfig = ConfigurationLoader.LoadMcpResourcesConfiguration(finalConfigPath, logger);
         await using var executorLease = await McpToolSetupService.StartOutOfProcessExecutorIfNeededAsync(config, loggerFactory, logger, finalConfigPath);
-        var tools = await McpToolSetupService.SetupMcpToolsAsync(loggerFactory, config, logger, finalConfigPath, configurationPathSource ?? McpToolSetupService.InferConfigurationPathSource(finalConfigPath), executorLease?.Executor);
+        var toolSetup = await McpToolSetupService.SetupMcpToolsAsync(loggerFactory, config, logger, finalConfigPath, configurationPathSource ?? McpToolSetupService.InferConfigurationPathSource(finalConfigPath), executorLease?.Executor);
+        var tools = toolSetup.Tools;
         var promptsConfig = ConfigurationLoader.LoadPromptsConfiguration(finalConfigPath);
         var configDirectory = Path.GetDirectoryName(finalConfigPath) ?? Directory.GetCurrentDirectory();
         var promptHandler = new McpPromptHandler(promptsConfig, configDirectory, loggerFactory.CreateLogger<McpPromptHandler>());
-        ConfigureServerServices(builder, tools, resourcesConfig, finalConfigPath, loggerFactory, promptHandler, config, executorLease?.Executor);
+        ConfigureServerServices(builder, tools, resourcesConfig, finalConfigPath, loggerFactory, promptHandler, config, executorLease?.Executor, toolSetup.EffectiveNounResourceRegistry);
         await builder.Build().RunAsync();
     }
 
@@ -128,12 +129,13 @@ internal static class StdioServerHost
         ILoggerFactory loggerFactory,
         McpPromptHandler promptHandler,
         PowerShellConfiguration? psConfig = null,
-        ICommandExecutor? commandExecutor = null)
+        ICommandExecutor? commandExecutor = null,
+        EffectiveNounResourceRegistry? effectiveNounResourceRegistry = null)
     {
         ConfigureJsonSerializerOptions(builder);
         ConfigureOpenTelemetry(builder, isStdioMode: true);
         ConfigureApplicationInsights(builder.Services, builder.Configuration, isStdioMode: true);
-        RegisterMcpServerServices(builder, tools, resourcesConfig, configFilePath, loggerFactory, promptHandler, psConfig, commandExecutor);
+        RegisterMcpServerServices(builder, tools, resourcesConfig, configFilePath, loggerFactory, promptHandler, psConfig, commandExecutor, effectiveNounResourceRegistry);
         RegisterCleanupServices(builder);
     }
 
@@ -261,7 +263,8 @@ internal static class StdioServerHost
         ILoggerFactory loggerFactory,
         McpPromptHandler promptHandler,
         PowerShellConfiguration? psConfig = null,
-        ICommandExecutor? commandExecutor = null)
+        ICommandExecutor? commandExecutor = null,
+        EffectiveNounResourceRegistry? effectiveNounResourceRegistry = null)
     {
         var runspace = new SingletonPowerShellRunspace();
         var configDirectory = Path.GetDirectoryName(configFilePath) ?? ".";
@@ -270,21 +273,13 @@ internal static class StdioServerHost
 
         McpNounResourceHandler? nounHandler = null;
         var toolsToRegister = tools;
-        if (psConfig?.EnableNounResources == true)
+        if (psConfig?.EnableNounResources == true && effectiveNounResourceRegistry is not null)
         {
-            var commandNames = tools
-                .Select(t => { try { return t.ProtocolTool.Title; } catch { return null; } })
-                .Where(n => !string.IsNullOrWhiteSpace(n))
-                .Cast<string>();
-            var nounRegistry = NounRegistry.Build(commandNames, loggerFactory.CreateLogger("NounRegistry"));
-            var effectiveNounRegistry = EffectiveNounResourceRegistry.Build(nounRegistry, psConfig.NounResourceOverrides);
             nounHandler = new McpNounResourceHandler(
-                effectiveNounRegistry,
+            effectiveNounResourceRegistry,
                 commandExecutor is null ? runspace : null,
                 commandExecutor,
                 loggerFactory.CreateLogger<McpNounResourceHandler>());
-            toolsToRegister = ResourceLinkInjector.WrapToolsWithResourceLinks(
-                tools, effectiveNounRegistry, loggerFactory.CreateLogger("ResourceLinkInjector"));
         }
 
         var mcpBuilder = builder.Services

--- a/PoshMcp.Tests/Fixtures/Modules/NounResourceFixture/NounResourceFixture.psd1
+++ b/PoshMcp.Tests/Fixtures/Modules/NounResourceFixture/NounResourceFixture.psd1
@@ -9,6 +9,8 @@
         'Get-NounResourceFixture',
         'Assert-NounResourceFixture',
         'Get-NounResourceFixtureError',
+        'Get-RequiredFixture',
+        'Assert-RequiredFixture',
         'Assert-NoGetFixture'
     )
     CmdletsToExport   = @()

--- a/PoshMcp.Tests/Fixtures/Modules/NounResourceFixture/NounResourceFixture.psm1
+++ b/PoshMcp.Tests/Fixtures/Modules/NounResourceFixture/NounResourceFixture.psm1
@@ -46,6 +46,34 @@ function Get-NounResourceFixtureError {
 
 <#
 .SYNOPSIS
+Get command with a required user parameter; exercises noun-resource tightening so
+RequiredFixture does not become a derived resource.
+#>
+function Get-RequiredFixture {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+    [pscustomobject]@{ Name = $Name; Status = 'required' }
+}
+
+<#
+.SYNOPSIS
+Non-Get sibling command for the RequiredFixture noun; exercises the no-link path
+when the matching Get-* command requires user parameters.
+#>
+function Assert-RequiredFixture {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]$InputValue = 'default'
+    )
+    [pscustomobject]@{ Value = $InputValue; Status = 'asserted' }
+}
+
+<#
+.SYNOPSIS
 Non-Get command whose noun (NoGetFixture) has no Get-NoGetFixture counterpart
 in the configured command set; exercises FR-NR-10 (non-resourceable noun
 receives no resourceLinkBlock).
@@ -63,4 +91,6 @@ Export-ModuleMember -Function `
     Get-NounResourceFixture, `
     Assert-NounResourceFixture, `
     Get-NounResourceFixtureError, `
+    Get-RequiredFixture, `
+    Assert-RequiredFixture, `
     Assert-NoGetFixture

--- a/PoshMcp.Tests/Functional/ConfigurationReload/ConfigurationReloadTests.cs
+++ b/PoshMcp.Tests/Functional/ConfigurationReload/ConfigurationReloadTests.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using PoshMcp.Server.McpResources;
 using PoshMcp.Server.PowerShell;
 using Xunit;
 using Xunit.Abstractions;
@@ -255,6 +258,51 @@ public class ConfigurationReloadTests : PowerShellTestBase
         Assert.Equal(SettingsResolver.EnvSource, resultObj["runtimeSettings"]?["configurationPath"]?["source"]?.GetValue<string>());
         Assert.Equal("environment-only", resultObj["runtimeSettings"]?["configurationMode"]?["value"]?.GetValue<string>());
         Assert.Equal(SettingsResolver.EnvSource, resultObj["runtimeSettings"]?["configurationMode"]?["source"]?.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task ConfigurationReloadTools_GetStatus_UsesProvidedNounRegistry_ForNounResourcesParity()
+    {
+        var config = new PowerShellConfiguration
+        {
+            EnableNounResources = true,
+            FunctionNames = new List<string> { "Get-FixtureEligible", "Get-FixtureNeedsId" }
+        };
+
+        var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Information));
+        var serviceLogger = loggerFactory.CreateLogger<PowerShellConfigurationReloadService>();
+        var toolFactory = new McpToolFactoryV2();
+        var reloadService = new PowerShellConfigurationReloadService(serviceLogger, toolFactory, config, "/test/path");
+
+        var suppliedRegistry = NounRegistry.Build(["Get-FixtureEligible"], NullLogger.Instance);
+        var toolsLogger = loggerFactory.CreateLogger<ConfigurationReloadTools>();
+        var reloadTools = new ConfigurationReloadTools(
+            reloadService,
+            "/test/path",
+            SettingsResolver.CwdSource,
+            "stdio",
+            null,
+            config.RuntimeMode.ToString(),
+            null,
+            static () => new List<ModelContextProtocol.Server.McpServerTool>(),
+            toolsLogger,
+            nounRegistryProvider: () => suppliedRegistry);
+
+        var result = await reloadTools.GetConfigurationStatus(CancellationToken.None);
+
+        var resultObj = JsonNode.Parse(result)?.AsObject();
+        Assert.NotNull(resultObj);
+        var registeredResources = resultObj!["nounResources"]?["registeredResources"]?.AsArray();
+        Assert.NotNull(registeredResources);
+        var nouns = registeredResources!
+            .Select(node => node?["noun"]?.GetValue<string>())
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Cast<string>()
+            .ToArray();
+
+        Assert.Single(nouns);
+        Assert.Contains("FixtureEligible", nouns);
+        Assert.DoesNotContain("FixtureNeedsId", nouns);
     }
 
     [Fact]

--- a/PoshMcp.Tests/Integration/NounResourceHandlerAndLinkIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/NounResourceHandlerAndLinkIntegrationTests.cs
@@ -23,8 +23,11 @@ namespace PoshMcp.Tests.Integration;
 public class NounResourceHandlerAndLinkIntegrationTests : PowerShellTestBase, IAsyncLifetime
 {
     private const string FixtureResourceUri = "poshmcp://resources/noun_resource_fixture";
+    private const string RequiredFixtureResourceUri = "poshmcp://resources/required_fixture";
     private const string OverrideFixtureResourceName = "fixture_override";
     private const string OverrideFixtureResourceUri = "poshmcp://resources/fixture_override";
+    private const string AssociatedStaticResourceName = "command_context";
+    private const string AssociatedStaticResourceUri = "poshmcp://resources/command_context";
     private const string MissingResourceUri = "poshmcp://resources/does_not_exist";
 
     private InProcessMcpServer? _server;
@@ -121,7 +124,7 @@ public class NounResourceHandlerAndLinkIntegrationTests : PowerShellTestBase, IA
 
         var content = response["result"]?["content"] as JArray;
         Assert.NotNull(content);
-        AssertHasExactResourceLinkBlock(content!, FixtureResourceUri, "noun_resource_fixture");
+        AssertHasExactResourceLinkBlock(content!, FixtureResourceUri, "noun_resource_fixture", expectedNoun: "NounResourceFixture");
     }
 
     [Fact]
@@ -137,7 +140,7 @@ public class NounResourceHandlerAndLinkIntegrationTests : PowerShellTestBase, IA
 
         var content = response["result"]?["content"] as JArray;
         Assert.NotNull(content);
-        AssertHasExactResourceLinkBlock(content!, FixtureResourceUri, "noun_resource_fixture");
+        AssertHasExactResourceLinkBlock(content!, FixtureResourceUri, "noun_resource_fixture", expectedNoun: "NounResourceFixture");
     }
 
     [Fact]
@@ -166,7 +169,8 @@ public class NounResourceHandlerAndLinkIntegrationTests : PowerShellTestBase, IA
         AssertHasExactResourceLinkBlock(
             content!,
             "poshmcp://resources/noun_resource_fixture_error",
-            "noun_resource_fixture_error");
+            "noun_resource_fixture_error",
+            expectedNoun: "NounResourceFixtureError");
     }
 
     [Fact]
@@ -184,6 +188,35 @@ public class NounResourceHandlerAndLinkIntegrationTests : PowerShellTestBase, IA
         Assert.NotNull(content);
         Assert.False(HasAnyResourceLinkBlock(content!),
             $"Non-resourceable noun should not include resource-link block. Response: {response}");
+    }
+
+    [Fact]
+    public async Task RequiredParameterGetCommand_DoesNotListReadOrInjectDerivedResource()
+    {
+        var client = _client ?? throw new InvalidOperationException("Client not initialized");
+
+        var listResponse = await client.SendListResourcesAsync();
+
+        Assert.Null(listResponse["error"]);
+        var resources = listResponse["result"]?["resources"] as JArray;
+        Assert.NotNull(resources);
+        Assert.Null(FindResourceByUri(resources!, RequiredFixtureResourceUri));
+
+        var readResponse = await client.SendReadResourceAsync(RequiredFixtureResourceUri);
+        var readError = readResponse["error"] as JObject;
+        Assert.NotNull(readError);
+        Assert.Contains("Resource not found", readError!["message"]?.ToString() ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+
+        var toolName = await ResolveToolNameAsync(client, "Assert-RequiredFixture");
+        var toolResponse = await client.SendToolCallAsync(toolName, new { });
+
+        Assert.Null(toolResponse["error"]);
+        Assert.NotEqual(true, toolResponse["result"]?["isError"]?.Value<bool>());
+
+        var content = toolResponse["result"]?["content"] as JArray;
+        Assert.NotNull(content);
+        Assert.False(HasAnyResourceLinkBlock(content!),
+            $"Required-parameter Get-* noun should not include a resource-link block. Response: {toolResponse}");
     }
 
     [Fact]
@@ -299,7 +332,177 @@ public class NounResourceHandlerAndLinkIntegrationTests : PowerShellTestBase, IA
             Assert.Null(toolResponse["error"]);
             var content = toolResponse["result"]?["content"] as JArray;
             Assert.NotNull(content);
-            AssertHasExactResourceLinkBlock(content!, OverrideFixtureResourceUri, OverrideFixtureResourceName);
+            AssertHasExactResourceLinkBlock(content!, OverrideFixtureResourceUri, OverrideFixtureResourceName, expectedNoun: "NounResourceFixture");
+        });
+    }
+
+    [Fact]
+    public async Task ToolCall_ExplicitAssociatedStaticResource_InjectsWithoutNounResources()
+    {
+        const string commandOverridesJson = """
+{
+    "Assert-NoGetFixture": {
+        "AssociatedResourceUri": "poshmcp://resources/command_context"
+    }
+}
+""";
+
+        const string resourcesJson = """
+[
+    {
+        "Uri": "poshmcp://resources/command_context",
+        "Name": "Command Context",
+        "Description": "Static command context resource",
+        "MimeType": "text/plain",
+        "Source": "command",
+        "Command": "'command-context'"
+    }
+]
+""";
+
+        using var fixture = new NounResourceFixtureConfig(
+            enableNounResources: false,
+            commandOverridesJson: commandOverridesJson,
+            resourcesJson: resourcesJson);
+
+        await ExecuteWithFixtureAsync(fixture, async client =>
+        {
+            var toolName = await ResolveToolNameAsync(client, "Assert-NoGetFixture");
+
+            var response = await client.SendToolCallAsync(toolName, new { });
+
+            Assert.Null(response["error"]);
+            Assert.NotEqual(true, response["result"]?["isError"]?.Value<bool>());
+
+            var content = response["result"]?["content"] as JArray;
+            Assert.NotNull(content);
+            AssertHasExactResourceLinkBlock(
+                content!,
+                AssociatedStaticResourceUri,
+                AssociatedStaticResourceName,
+                expectedRelationship: "context");
+        });
+    }
+
+    [Fact]
+    public async Task ToolCall_ExplicitAssociatedStaticResource_OverridesImplicitNounDerivedLink()
+    {
+        const string commandOverridesJson = """
+{
+    "Assert-NounResourceFixture": {
+        "AssociatedResourceUri": "poshmcp://resources/command_context"
+    }
+}
+""";
+
+        const string resourcesJson = """
+[
+    {
+        "Uri": "poshmcp://resources/command_context",
+        "Name": "Command Context",
+        "Description": "Static command context resource",
+        "MimeType": "text/plain",
+        "Source": "command",
+        "Command": "'command-context'"
+    }
+]
+""";
+
+        using var fixture = new NounResourceFixtureConfig(
+            commandOverridesJson: commandOverridesJson,
+            resourcesJson: resourcesJson);
+
+        await ExecuteWithFixtureAsync(fixture, async client =>
+        {
+            var toolName = await ResolveToolNameAsync(client, "Assert-NounResourceFixture");
+
+            var response = await client.SendToolCallAsync(toolName, new { });
+
+            Assert.Null(response["error"]);
+            Assert.NotEqual(true, response["result"]?["isError"]?.Value<bool>());
+
+            var content = response["result"]?["content"] as JArray;
+            Assert.NotNull(content);
+            AssertHasExactResourceLinkBlock(
+                content!,
+                AssociatedStaticResourceUri,
+                AssociatedStaticResourceName,
+                expectedRelationship: "context");
+        });
+    }
+
+    [Fact]
+    public async Task ToolCall_ExplicitAssociatedResource_IgnoresDisableResourceLinkBlock_OnNounTarget()
+    {
+        const string commandOverridesJson = """
+{
+    "Assert-NounResourceFixture": {
+        "AssociatedResourceUri": "poshmcp://resources/noun_resource_fixture"
+    }
+}
+""";
+
+        const string nounOverrideJson = """
+{
+    "noun_resource_fixture": {
+        "DisableResourceLinkBlock": true
+    }
+}
+""";
+
+        using var fixture = new NounResourceFixtureConfig(
+            nounResourceOverridesJson: nounOverrideJson,
+            commandOverridesJson: commandOverridesJson);
+
+        await ExecuteWithFixtureAsync(fixture, async client =>
+        {
+            var toolName = await ResolveToolNameAsync(client, "Assert-NounResourceFixture");
+
+            var response = await client.SendToolCallAsync(toolName, new { });
+
+            Assert.Null(response["error"]);
+            Assert.NotEqual(true, response["result"]?["isError"]?.Value<bool>());
+
+            var content = response["result"]?["content"] as JArray;
+            Assert.NotNull(content);
+            AssertHasExactResourceLinkBlock(
+                content!,
+                FixtureResourceUri,
+                "noun_resource_fixture",
+                expectedRelationship: "context",
+                expectedNoun: "NounResourceFixture");
+        });
+    }
+
+    [Fact]
+    public async Task ToolCall_InvalidAssociatedResourceUri_FallsBackToImplicitNounDerivedLink()
+    {
+        const string commandOverridesJson = """
+{
+    "Assert-NounResourceFixture": {
+        "AssociatedResourceUri": "poshmcp://resources/not_exposed"
+    }
+}
+""";
+
+        using var fixture = new NounResourceFixtureConfig(commandOverridesJson: commandOverridesJson);
+
+        await ExecuteWithFixtureAsync(fixture, async client =>
+        {
+            var toolName = await ResolveToolNameAsync(client, "Assert-NounResourceFixture");
+
+            var response = await client.SendToolCallAsync(toolName, new { });
+
+            Assert.Null(response["error"]);
+            Assert.NotEqual(true, response["result"]?["isError"]?.Value<bool>());
+
+            var content = response["result"]?["content"] as JArray;
+            Assert.NotNull(content);
+            AssertHasExactResourceLinkBlock(
+                content!,
+                FixtureResourceUri,
+                "noun_resource_fixture",
+                expectedNoun: "NounResourceFixture");
         });
     }
 
@@ -332,9 +535,41 @@ public class NounResourceHandlerAndLinkIntegrationTests : PowerShellTestBase, IA
         return false;
     }
 
-    private static void AssertHasExactResourceLinkBlock(JArray content, string expectedUri, string expectedResourceName)
+    private static int CountResourceLinkBlocks(JArray content)
+    {
+        var count = 0;
+
+        foreach (var block in content.OfType<JObject>())
+        {
+            if (!string.Equals(block["type"]?.ToString(), "resource", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var resource = block["resource"] as JObject;
+            if (resource is null)
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrWhiteSpace(resource["uri"]?.ToString()))
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static void AssertHasExactResourceLinkBlock(
+        JArray content,
+        string expectedUri,
+        string expectedResourceName,
+        string expectedRelationship = "subject",
+        string? expectedNoun = null)
     {
         Assert.True(content.Count > 0, "Expected tool result to contain at least one content block.");
+        Assert.Equal(1, CountResourceLinkBlocks(content));
 
         var lastBlock = content[^1] as JObject;
         Assert.NotNull(lastBlock);
@@ -353,8 +588,16 @@ public class NounResourceHandlerAndLinkIntegrationTests : PowerShellTestBase, IA
         Assert.NotNull(resourceLink);
         Assert.Equal(expectedUri, resourceLink!["uri"]?.ToString());
         Assert.Equal(expectedResourceName, resourceLink["resourceName"]?.ToString());
-        Assert.False(string.IsNullOrWhiteSpace(resourceLink["noun"]?.ToString()));
-        Assert.Equal("subject", resourceLink["relationship"]?.ToString());
+        if (expectedNoun is null)
+        {
+            Assert.Null(resourceLink["noun"]);
+        }
+        else
+        {
+            Assert.Equal(expectedNoun, resourceLink["noun"]?.ToString());
+        }
+
+        Assert.Equal(expectedRelationship, resourceLink["relationship"]?.ToString());
         Assert.False(string.IsNullOrWhiteSpace(resourceLink["description"]?.ToString()));
     }
 
@@ -411,7 +654,11 @@ public class NounResourceHandlerAndLinkIntegrationTests : PowerShellTestBase, IA
         private readonly string _configDir;
         private readonly string? _previousModulePath;
 
-        public NounResourceFixtureConfig(bool enableNounResources = true, string? nounResourceOverridesJson = null)
+        public NounResourceFixtureConfig(
+            bool enableNounResources = true,
+            string? nounResourceOverridesJson = null,
+            string? commandOverridesJson = null,
+            string? resourcesJson = null)
         {
             var repoRoot = ResolveWorkspaceRoot();
             var moduleRoot = Path.Combine(repoRoot, "PoshMcp.Tests", "Fixtures", "Modules");
@@ -434,6 +681,12 @@ public class NounResourceHandlerAndLinkIntegrationTests : PowerShellTestBase, IA
             var nounResourceOverridesBlock = string.IsNullOrWhiteSpace(nounResourceOverridesJson)
                 ? string.Empty
                 : $",\n    \"NounResourceOverrides\": {nounResourceOverridesJson}";
+            var commandOverridesBlock = string.IsNullOrWhiteSpace(commandOverridesJson)
+                ? string.Empty
+                : $",\n    \"CommandOverrides\": {commandOverridesJson}";
+            var resourcesBlock = string.IsNullOrWhiteSpace(resourcesJson)
+                ? string.Empty
+                : $",\n  \"McpResources\": {{\n    \"Resources\": {resourcesJson}\n  }}";
 
             var json = $$"""
 {
@@ -442,12 +695,14 @@ public class NounResourceHandlerAndLinkIntegrationTests : PowerShellTestBase, IA
       "Get-NounResourceFixture",
       "Assert-NounResourceFixture",
       "Get-NounResourceFixtureError",
+            "Get-RequiredFixture",
+            "Assert-RequiredFixture",
       "Assert-NoGetFixture"
     ],
     "Modules": ["NounResourceFixture"],
     "IncludePatterns": [],
     "ExcludePatterns": [],
-        "EnableNounResources": {{enableNounResources.ToString().ToLowerInvariant()}}{{nounResourceOverridesBlock}}
+    "EnableNounResources": {{enableNounResources.ToString().ToLowerInvariant()}}{{nounResourceOverridesBlock}}{{commandOverridesBlock}}
   },
   "Authentication": {
     "Enabled": false,
@@ -458,7 +713,7 @@ public class NounResourceHandlerAndLinkIntegrationTests : PowerShellTestBase, IA
       "RequiredRoles": []
     },
     "Schemes": {}
-  }
+    }{{resourcesBlock}}
 }
 """;
 

--- a/PoshMcp.Tests/Unit/Diagnostics/DoctorNounResourcesTests.cs
+++ b/PoshMcp.Tests/Unit/Diagnostics/DoctorNounResourcesTests.cs
@@ -83,6 +83,43 @@ public class DoctorNounResourcesTests
         Assert.DoesNotContain("noun_resource_fixture (Get-NounResourceFixture)", output);
     }
 
+    [Fact]
+    public void BuildDoctorReportFromConfig_UsesSuppliedNounRegistry_ForEligibilityAwareParity()
+    {
+        var config = new PowerShellConfiguration
+        {
+            EnableNounResources = true,
+            CommandNames = new()
+            {
+                "Get-FixtureEligible",
+                "Get-FixtureNeedsId"
+            }
+        };
+
+        var suppliedRegistry = NounRegistry.Build(["Get-FixtureEligible"], NullLogger.Instance);
+
+        var report = DoctorService.BuildDoctorReportFromConfig(
+            configurationPath: "/test/path",
+            configurationPathSource: "test",
+            effectiveLogLevel: "Information",
+            effectiveLogLevelSource: "test",
+            effectiveTransport: "stdio",
+            effectiveTransportSource: "test",
+            effectiveSessionMode: null,
+            effectiveSessionModeSource: "test",
+            effectiveRuntimeMode: "InProcess",
+            effectiveRuntimeModeSource: "test",
+            effectiveMcpPath: null,
+            effectiveMcpPathSource: "test",
+            config: config,
+            tools: [],
+            nounRegistry: suppliedRegistry);
+
+        var registered = Assert.Single(report.NounResources.RegisteredResources);
+        Assert.Equal("FixtureEligible", registered.Noun);
+        Assert.DoesNotContain(report.NounResources.RegisteredResources, entry => entry.Noun == "FixtureNeedsId");
+    }
+
     private static DoctorReport BuildMinimalReport() =>
         new()
         {

--- a/PoshMcp.Tests/Unit/McpResources/NounRegistryTests.cs
+++ b/PoshMcp.Tests/Unit/McpResources/NounRegistryTests.cs
@@ -67,9 +67,21 @@ public class NounRegistryTests
     }
 
     [Fact]
+    public void Build_WithGetCommandRequiringUserParameters_DoesNotRegisterEntry()
+    {
+        var registry = NounRegistry.Build(
+            [new NounCommandCandidate("Get-Foo", CanInvokeWithoutRequiredUserParameters: false)],
+            NullLogger.Instance);
+
+        Assert.Empty(registry.AllEntries);
+        Assert.Null(registry.GetEntry("Foo"));
+        Assert.Null(registry.GetEntryByResourceName("foo"));
+    }
+
+    [Fact]
     public void Build_WithEmptyCommandList_ReturnsEmptyRegistry()
     {
-        var registry = NounRegistry.Build([], NullLogger.Instance);
+        var registry = NounRegistry.Build(Array.Empty<string>(), NullLogger.Instance);
 
         Assert.Empty(registry.AllEntries);
         Assert.Null(registry.GetEntry("Foo"));

--- a/PoshMcp.Tests/Unit/McpResources/ResourceLinkInjectorTests.cs
+++ b/PoshMcp.Tests/Unit/McpResources/ResourceLinkInjectorTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Server;
+using PoshMcp.Server.McpResources;
+using PoshMcp.Server.PowerShell;
+using Xunit;
+
+namespace PoshMcp.Tests.Unit.McpResources;
+
+[Trait("Category", "Unit")]
+public class ResourceLinkInjectorTests
+{
+    [Fact]
+    public void WrapToolsWithResourceLinks_InvalidAssociatedResourceUri_LogsWarning_AndKeepsNounFallbackWrapped()
+    {
+        var logger = new ListLogger();
+        var nounRegistry = EffectiveNounResourceRegistry.Build(
+            NounRegistry.Build(
+                new[] { "Get-NounResourceFixture", "Assert-NounResourceFixture" },
+                logger),
+            overrides: null);
+
+        var tool = MakeTool("assert_noun_resource_fixture", "Assert-NounResourceFixture");
+        var commandOverrides = new Dictionary<string, FunctionOverride>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Assert-NounResourceFixture"] = new() { AssociatedResourceUri = "poshmcp://resources/not-exposed" }
+        };
+
+        var wrappedTools = ResourceLinkInjector.WrapToolsWithResourceLinks(
+            new List<McpServerTool> { tool },
+            nounRegistry,
+            commandOverrides,
+            new McpResourcesConfiguration(),
+            logger);
+
+        Assert.Single(wrappedTools);
+        Assert.NotSame(tool, wrappedTools[0]);
+        Assert.Contains(
+            logger.Entries,
+            entry => entry.Level == LogLevel.Warning
+                && entry.Message.Contains("AssociatedResourceUri", StringComparison.OrdinalIgnoreCase)
+                && entry.Message.Contains("Assert-NounResourceFixture", StringComparison.OrdinalIgnoreCase)
+                && entry.Message.Contains("poshmcp://resources/not-exposed", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static McpServerTool MakeTool(string toolName, string commandName)
+    {
+        var stub = new Func<string>(() => "stub");
+        return McpServerTool.Create(stub, new McpServerToolCreateOptions
+        {
+            Name = toolName,
+            Title = commandName,
+            Description = "stub",
+        });
+    }
+
+    private sealed class ListLogger : ILogger
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = new();
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((logLevel, formatter(state, exception)));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static NullScope Instance { get; } = new();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/PoshMcp.Tests/Unit/PerformanceConfigurationTests.cs
+++ b/PoshMcp.Tests/Unit/PerformanceConfigurationTests.cs
@@ -300,6 +300,7 @@ public class PerformanceConfigurationTests : PowerShellTestBase
     "PowerShellConfiguration": {
         "FunctionOverrides": {
             "Get-Process": {
+                "AssociatedResourceUri": "poshmcp://resources/legacy-process",
                 "RequiredRoles": ["legacy"]
             }
         }
@@ -314,6 +315,7 @@ public class PerformanceConfigurationTests : PowerShellTestBase
 
         var effectiveOverrides = powerShellConfig.GetEffectiveCommandOverrides();
         Assert.True(effectiveOverrides.ContainsKey("Get-Process"));
+        Assert.Equal("poshmcp://resources/legacy-process", effectiveOverrides["Get-Process"].AssociatedResourceUri);
         Assert.Equal("legacy", effectiveOverrides["Get-Process"].RequiredRoles![0]);
     }
 
@@ -325,11 +327,13 @@ public class PerformanceConfigurationTests : PowerShellTestBase
     "PowerShellConfiguration": {
         "FunctionOverrides": {
             "Get-Process": {
+                "AssociatedResourceUri": "poshmcp://resources/legacy-process",
                 "RequiredRoles": ["legacy"]
             }
         },
         "CommandOverrides": {
             "Get-Process": {
+                "AssociatedResourceUri": "poshmcp://resources/command-process",
                 "RequiredRoles": ["command"]
             }
         }
@@ -344,6 +348,7 @@ public class PerformanceConfigurationTests : PowerShellTestBase
 
         var effectiveOverrides = powerShellConfig.GetEffectiveCommandOverrides();
         Assert.True(effectiveOverrides.ContainsKey("Get-Process"));
+        Assert.Equal("poshmcp://resources/command-process", effectiveOverrides["Get-Process"].AssociatedResourceUri);
         Assert.Equal("command", effectiveOverrides["Get-Process"].RequiredRoles![0]);
     }
 }

--- a/PoshMcp.Tests/Unit/ProgramTests.cs
+++ b/PoshMcp.Tests/Unit/ProgramTests.cs
@@ -1,4 +1,7 @@
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.Server;
+using PoshMcp.Server.McpResources;
 using PoshMcp.Server.PowerShell;
 using PoshMcp.Tests.Shared;
 using System;
@@ -288,6 +291,48 @@ public class ProgramTests : PowerShellTestBase
             {
                 File.Delete(tempConfig);
             }
+        }
+    }
+
+    [Fact]
+    public async Task BuildDoctorReportForCliAsync_UsesCapturedNounRegistry_ForNounResourcesParity()
+    {
+        var tempFile = Path.GetTempFileName();
+        var configJson = @"{
+  ""PowerShellConfiguration"": {
+    ""EnableNounResources"": true,
+    ""FunctionNames"": [""Get-FixtureEligible"", ""Get-FixtureNeedsId""]
+  }
+}";
+        File.WriteAllText(tempFile, configJson);
+
+        try
+        {
+            var settings = new ResolvedCommandSettings(
+                new ResolvedSetting(tempFile, "test"),
+                tempFile,
+                new ResolvedSetting("Information", "test"),
+                new ResolvedSetting("stdio", "test"),
+                new ResolvedSetting(null, "test"),
+                new ResolvedSetting("InProcess", "test"),
+                new ResolvedSetting(null, "test"));
+
+            var report = await DoctorService.BuildDoctorReportForCliAsync(
+                settings,
+                static (_, _, _, _, _, _, _) =>
+                {
+                    DiscoveredNounRegistryCapture.Set(NounRegistry.Build(["Get-FixtureEligible"], NullLogger.Instance));
+                    return Task.FromResult(new List<McpServerTool>());
+                });
+
+            var registered = Assert.Single(report.NounResources.RegisteredResources);
+            Assert.Equal("FixtureEligible", registered.Noun);
+            Assert.DoesNotContain(report.NounResources.RegisteredResources, entry => entry.Noun == "FixtureNeedsId");
+        }
+        finally
+        {
+            DiscoveredNounRegistryCapture.Reset();
+            File.Delete(tempFile);
         }
     }
 

--- a/docs/articles/configuration.md
+++ b/docs/articles/configuration.md
@@ -103,7 +103,7 @@ Behavior:
 - `PowerShellConfiguration.CommandOverrides.<Command>.AssociatedResourceUri` (or legacy `FunctionOverrides.<Command>.AssociatedResourceUri`) overrides the implicit noun-derived link target for that command when the URI resolves to an exposed MCP resource.
 - `CommandOverrides` still take precedence over legacy `FunctionOverrides` when both define `AssociatedResourceUri` for the same command.
 - Explicit `AssociatedResourceUri` links are appended with `relationship: "context"` and are not suppressed by `DisableResourceLinkBlock`; that flag only suppresses the implicit noun-derived fallback.
-- If `AssociatedResourceUri` is absent or invalid, PoshMcp falls back to the existing implicit noun-derived link behavior when available. Invalid or unresolvable URIs log a warning during startup and do not fail configuration load.
+- If `AssociatedResourceUri` is absent or does not resolve for a discovered command override during tool setup, PoshMcp falls back to the existing implicit noun-derived link behavior when available. In that case, PoshMcp logs a warning and continues; it does not perform generic configuration-load validation for `AssociatedResourceUri` values.
 
 Example:
 

--- a/docs/articles/configuration.md
+++ b/docs/articles/configuration.md
@@ -95,11 +95,29 @@ Edit `appsettings.json`:
 Behavior:
 
 - `EnableNounResources` defaults to `false`.
-- A noun is resourceable only when the discovered command set contains a matching `Get-{Noun}` command.
+- A noun is resourceable only when the discovered command set contains a matching `Get-{Noun}` command and that command has at least one parameter set with no required user parameters.
 - The default resource name is the noun converted to snake_case, and the default URI is `poshmcp://resources/{resource_name}`.
 - `NounResourceOverrides` is keyed by the default derived resource name.
 - `Disabled: true` suppresses the derived resource and skips tool-result resource links for that noun.
 - `DisableResourceLinkBlock: true` keeps the resource available in `resources/list` and `resources/read`, but skips the appended `application/json+mcp-resource-link` block on tool results.
+- `PowerShellConfiguration.CommandOverrides.<Command>.AssociatedResourceUri` (or legacy `FunctionOverrides.<Command>.AssociatedResourceUri`) overrides the implicit noun-derived link target for that command when the URI resolves to an exposed MCP resource.
+- `CommandOverrides` still take precedence over legacy `FunctionOverrides` when both define `AssociatedResourceUri` for the same command.
+- Explicit `AssociatedResourceUri` links are appended with `relationship: "context"` and are not suppressed by `DisableResourceLinkBlock`; that flag only suppresses the implicit noun-derived fallback.
+- If `AssociatedResourceUri` is absent or invalid, PoshMcp falls back to the existing implicit noun-derived link behavior when available. Invalid or unresolvable URIs log a warning during startup and do not fail configuration load.
+
+Example:
+
+```json
+{
+  "PowerShellConfiguration": {
+    "CommandOverrides": {
+      "Invoke-Deployment": {
+        "AssociatedResourceUri": "poshmcp://resources/deployment-guide"
+      }
+    }
+  }
+}
+```
 
 Use `poshmcp doctor` to verify the effective noun-resource surface. When the feature is enabled, doctor reports registered resources, conflicts, and suppressed nouns in the `Noun Resources` section.
 

--- a/docs/articles/resources-and-prompts.md
+++ b/docs/articles/resources-and-prompts.md
@@ -146,7 +146,7 @@ This block is not appended when:
 
 When `AssociatedResourceUri` is set on a command override, PoshMcp first tries to resolve that URI against the exposed resource surface. If it resolves, PoshMcp appends exactly one `application/json+mcp-resource-link` block for that target with `relationship: "context"`, even when the noun override has `DisableResourceLinkBlock: true`.
 
-If `AssociatedResourceUri` is missing or does not resolve to an exposed resource, PoshMcp falls back to the implicit noun-derived behavior above. Invalid or unresolvable URIs produce a startup warning and are otherwise ignored.
+If `AssociatedResourceUri` is missing or does not resolve to an exposed resource for a discovered command override during tool setup, PoshMcp falls back to the implicit noun-derived behavior above. That unresolved override path logs a warning and is otherwise ignored; PoshMcp does not perform generic startup validation of `AssociatedResourceUri` values.
 
 Example:
 

--- a/docs/articles/resources-and-prompts.md
+++ b/docs/articles/resources-and-prompts.md
@@ -82,7 +82,7 @@ Add resources to `appsettings.json`:
 
 When `PowerShellConfiguration.EnableNounResources` is `true`, PoshMcp can derive additional MCP resources from the discovered PowerShell command set.
 
-A noun becomes resourceable only when a matching `Get-{Noun}` command exists. When that happens, PoshMcp:
+A noun becomes resourceable only when a matching `Get-{Noun}` command exists and at least one of its parameter sets can run without required user parameters. When that happens, PoshMcp:
 
 - derives a snake_case resource name from the noun
 - registers a `poshmcp://resources/{resource_name}` resource in `resources/list`
@@ -90,7 +90,7 @@ A noun becomes resourceable only when a matching `Get-{Noun}` command exists. Wh
 
 For example, `Get-NounResourceFixture` produces a resource named `noun_resource_fixture` at `poshmcp://resources/noun_resource_fixture`.
 
-If a noun does not have a matching `Get-*` command, PoshMcp does not list or read a derived resource for it.
+If a noun does not have a matching `Get-*` command, or the matching `Get-*` command requires user input for every parameter set, PoshMcp does not list or read a derived resource for it.
 
 Configure the feature in `appsettings.json`:
 
@@ -115,6 +115,11 @@ Override keys use the default derived resource name. Each override can:
 - change `ResourceName`, `Uri`, or `Description`
 - set `DisableResourceLinkBlock` to keep the resource readable but skip tool-result link injection
 
+You can also associate a specific exposed MCP resource with an individual command result through `PowerShellConfiguration.CommandOverrides.<Command>.AssociatedResourceUri` (or legacy `FunctionOverrides`). This association can point at either:
+
+- a static/custom resource from `McpResources.Resources`
+- a noun-derived resource exposed through `EnableNounResources`
+
 ### Resource Link Blocks
 
 When noun-derived resources are enabled, successful tool results for the same noun get an extra content block appended at the end of the MCP result. The block points the client at the readable MCP resource for that noun.
@@ -138,6 +143,36 @@ This block is not appended when:
 - the noun override sets `Disabled: true`
 - the noun override sets `DisableResourceLinkBlock: true`
 - the tool result is returned with `isError: true`
+
+When `AssociatedResourceUri` is set on a command override, PoshMcp first tries to resolve that URI against the exposed resource surface. If it resolves, PoshMcp appends exactly one `application/json+mcp-resource-link` block for that target with `relationship: "context"`, even when the noun override has `DisableResourceLinkBlock: true`.
+
+If `AssociatedResourceUri` is missing or does not resolve to an exposed resource, PoshMcp falls back to the implicit noun-derived behavior above. Invalid or unresolvable URIs produce a startup warning and are otherwise ignored.
+
+Example:
+
+```json
+{
+  "PowerShellConfiguration": {
+    "CommandOverrides": {
+      "Invoke-Deployment": {
+        "AssociatedResourceUri": "poshmcp://resources/deployment-guide"
+      }
+    }
+  },
+  "McpResources": {
+    "Resources": [
+      {
+        "Uri": "poshmcp://resources/deployment-guide",
+        "Name": "Deployment Guide",
+        "Description": "Operator runbook for deployment workflows",
+        "MimeType": "text/markdown",
+        "Source": "file",
+        "Path": "docs/DEPLOYMENT.md"
+      }
+    ]
+  }
+}
+```
 
 ### Example: File-Based Resources
 


### PR DESCRIPTION
## Summary
- exclude noun-derived resources when the backing Get-* requires user-supplied parameters
- add `AssociatedResourceUri` on command overrides so a command result can link to an explicit MCP resource
- document the new noun-resource eligibility rules and explicit resource-link override behavior

## Validation
- dotnet test PoshMcp.Tests --filter "FullyQualifiedName~PowerShellConfiguration_Bind_LegacyFunctionOverrides_StillAppliesToEffectiveCommandOverrides|FullyQualifiedName~PowerShellConfiguration_Bind_CommandOverrides_TakesPrecedenceOverLegacyFunctionOverrides|FullyQualifiedName~NounRegistryTests|FullyQualifiedName~ResourceLinkInjectorTests|FullyQualifiedName~NounResourceHandlerAndLinkIntegrationTests" --logger "console;verbosity=minimal"