### PR TITLE
test: add OperationContext unit tests

### DIFF
--- a/.squad/agents/farnsworth/history.md
+++ b/.squad/agents/farnsworth/history.md
@@ -96,6 +96,22 @@ Detailed entries archived to history-archive.md: Spec 009 review wave (6 PRs, cl
 
 **Review comment posted:** REJECT on PR #278 with the specific missed sinks called out for follow-up.
 
+### 2026-05-17T08:20:00-05:00 — PR #278 re-review after Hermes revision
+
+**Verdict:** REJECT.
+
+**What changed since prior review:** Hermes fixed the five originally-called-out sinks in `PowerShellAssemblyGenerator.cs`: generation-time command/error logging, `_MaxResults` validation, sort helper property logging, filter helper filter-script/exception logging, and group helper property logging. The broader pass also introduced a sustainable pattern for hot paths by scrubbing once into `safeCommandName` and `safeInvocationId` and reusing those values across the invocation lifecycle logs.
+
+**Remaining issue:** the claimed comprehensive scan is not yet complete. `PowerShellAssemblyGenerator.cs` still logs a dynamic string type name raw in the bound-parameter debug sink (`ValueType={ValueType}` uses `convertedValue?.GetType().Name` unsanitized while adjacent `ParameterName` and `Value` are scrubbed). I kept the verdict at REJECT because the architectural rule for this hardening pass should remain: every untrusted or runtime-derived string reaches the log sink only through `LogSanitizer.Scrub()` or a pre-scrubbed local.
+
+### 2026-05-17T08:30:00-05:00 — PR #278 final re-review (third revision)
+
+**Verdict:** APPROVE.
+
+**What I reviewed:** the full `main...squad/277-log-forging-fixes` diff, with focused verification of the `PowerShellAssemblyGenerator.cs` bound-parameter sink and a quick scan of remaining logger calls in the touched server files.
+
+**Key observations:** The prior blocker is resolved: `ValueType` now flows through `LogSanitizer.Scrub(convertedValue?.GetType().Name)` before reaching the bound-parameter debug log. The touched files now consistently scrub attacker-controlled or runtime-derived string fields at the sink (or via pre-scrubbed locals), including correlation scope values, JWT diagnostic payloads, command names, invocation IDs, `_MaxResults` warnings, and cached-output helper inputs (`property`, `filterScript`). I did not find any remaining unsanitized dynamic string values in logger calls during this re-review.
+
 ## 2026-05-17T13:12:00Z: Cross-team update — Log-forging fix #277
 
 Bender completed remediation of 24 CodeQL cs/log-forging alerts across PowerShellAssemblyGenerator.cs, AuthenticationServiceExtensions.cs, and LoggerExtensions.cs. Pattern: LogSanitizer.Scrub() applied to all untrusted sources (correlation IDs, JWT claims, config values) at structured log call sites. Build + tests pass. PR #278 open.
@@ -160,3 +176,20 @@ PRs #269 (Phase 1 ModuleDiscovery), #270 (Phase 2a DoctorService wiring), #271 (
 Code-grounded review passed: ApiKey dictionary-key-is-secret (`ApiKeyAuthenticationHandler.cs:32`), role-claim minting chain through `AuthorizationHelpers.HasRequiredRoles` any-match (L23), `ToolListAuthorizationFilter.CanAccessTool` ordering (L55-78), Docker base image contract (paths + `appuser` UID 1001), `DefaultScheme="Bearer"` default ([AuthenticationConfiguration.cs:8](PoshMcp.Server/Authentication/AuthenticationConfiguration.cs#L8)). All 5 non-blocking polish asks (doctor demo + DefaultScheme callout + Modules-vs-CommandNames callout + no-key boundary beat + Dockerfile.user drift note) landed by Leela in polish pass; Cubert re-verified clean. Squash-merged to ``main``.
 
 Patterns codified: (1) tutorials touching `Modules`/`IncludePatterns` should always demonstrate `poshmcp doctor` + v0.14.0 `moduleImports` section; (2) for code-grounded doc PRs, map each named config property to its handler/options class and verify spelling + semantics; (3) check `gh pr view N --json reviews,comments` first to avoid double-verdict races.
+
+## 2026-05-22T05:40:02 — Unit Test Gap-Fill Plan Development
+
+**Session:** Unit test review and remediation roadmap (background mode, coordinated with Fry)
+
+**Task:** Develop prioritized remediation plan based on Fry's confidence review and gap analysis.
+
+**Approach:** Phased roadmap prioritized for risk/effort trade-off:
+- **Phase 1 (8 quick wins):** No refactoring required — immediate coverage wins on straightforward code paths
+- **Phase 2 (6 items):** Minor mock/seam additions — leverage existing test patterns with minimal setup
+- **Phase 3 (2 items):** Interface extraction investments — well-scoped subsystems worthy of seam patterns
+
+**Input from Fry:** 412 tests across 51 files, Medium confidence, 6 critical gaps (ConvertParameterValue, HealthCheck, Auth filters, ObjectSerializer, SchemaGenerator, ToolFactory).
+
+**Outcome:** Roadmap ready for execution. Phase 1 establishes solid foundation with no architectural risk.
+
+**Note:** Decisions.md updated with Hermes log-forging revision (2026-05-17T08:15:00).

--- a/.squad/agents/fry/history.md
+++ b/.squad/agents/fry/history.md
@@ -117,3 +117,20 @@ Release v0.14.1 shipped successfully. Version bump, release notes, and GitHub re
 
 - Independently validated the combined noun-resource tightening and `AssociatedResourceUri` slice with 65 focused tests passing.
 - Validation covered the tightened noun-resource eligibility path together with the focused binding and link-injection behaviors exercised in the implementation worktree.
+## 2026-05-22T05:40:02 — Unit Test Confidence Review
+
+**Session:** Unit test review and gap identification (background mode, coordinated with Farnsworth)
+
+**Task:** Comprehensive assessment of current unit test coverage across all test tiers.
+
+**Outcome:** 412 tests found across 51 files. Medium confidence overall. 6 critical gaps identified:
+- ConvertParameterValue: Core type-mapping logic untested
+- HealthCheck stubs: Placeholder functions need implementation tests
+- Auth filters: JWT/API-key filter chains not comprehensively covered
+- ObjectSerializer: JSON object/array/primitive mapping not validated
+- SchemaGenerator: Type-to-JSON-schema translation gaps
+- ToolFactory core: McpToolFactoryV2 factory patterns need test density
+
+**Handoff to Farnsworth:** Gap analysis forwarded for prioritized roadmap development.
+
+**Note:** Decisions.md updated with Hermes log-forging revision (2026-05-17T08:15:00).

--- a/.squad/decisions/decisions.md
+++ b/.squad/decisions/decisions.md
@@ -108,3 +108,14 @@ Use the **existing user-assigned managed identity** (`poshmcp-identity`) on the 
 **By:** Steven Murawski (via Copilot)
 **What:** When you need to shell out to run a command, prefer `pwsh` to `powershell` unless you need a PowerShell command or module that is not supported under pwsh (PowerShell 7).
 **Why:** User request — captured for team memory
+
+### 2026-05-17T08:15:00-05:00: Hermes — log-forging revision
+**By:** Hermes
+**Status:** Proposed
+**Related:** #277, PR #278
+**Decision:** In `PoshMcp.Server\PowerShell\PowerShellAssemblyGenerator.cs`, every log sink that can receive user-controlled or environment-controlled string data must sanitize that value with `LogSanitizer.Scrub()` at the `ILogger` call site, and prefer structured logging over interpolated log strings.
+**Applied in this revision:**
+- generation-time command failure/skip logs
+- `_MaxResults` validation warning
+- cached output sort/filter/group helper diagnostics
+- invalid filter-script warning with scrubbed script and scrubbed exception message

--- a/PoshMcp.Tests/Unit/OperationContextTests.cs
+++ b/PoshMcp.Tests/Unit/OperationContextTests.cs
@@ -1,0 +1,114 @@
+using PoshMcp.Server.Observability;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PoshMcp.Tests.Unit;
+
+[Trait("Category", "Unit")]
+public class OperationContextTests : System.IDisposable
+{
+    public OperationContextTests()
+    {
+        ResetContext();
+    }
+
+    [Fact]
+    public void SetAndGetCycle_RoundTripsCorrelationIdAndOperationName()
+    {
+        // Arrange
+        const string correlationId = "corr-12345678";
+        const string operationName = "tool-discovery";
+
+        // Act
+        OperationContext.CorrelationId = correlationId;
+        OperationContext.OperationName = operationName;
+
+        // Assert
+        Assert.Equal(correlationId, OperationContext.CorrelationId);
+        Assert.Equal(operationName, OperationContext.OperationName);
+    }
+
+    [Fact]
+    public void BeginOperation_NestedScopes_RestoreOuterAndPreviousValuesOnDispose()
+    {
+        // Arrange
+        OperationContext.CorrelationId = "root-correlation";
+        OperationContext.OperationName = "root-operation";
+
+        // Act / Assert
+        using (OperationContext.BeginOperation("outer-operation"))
+        {
+            var outerCorrelationId = OperationContext.CorrelationId;
+
+            Assert.NotEqual("root-correlation", outerCorrelationId);
+            Assert.Equal("outer-operation", OperationContext.OperationName);
+
+            using (OperationContext.BeginOperation("inner-correlation", "inner-operation"))
+            {
+                Assert.Equal("inner-correlation", OperationContext.CorrelationId);
+                Assert.Equal("inner-operation", OperationContext.OperationName);
+            }
+
+            Assert.Equal(outerCorrelationId, OperationContext.CorrelationId);
+            Assert.Equal("outer-operation", OperationContext.OperationName);
+        }
+
+        Assert.Equal("root-correlation", OperationContext.CorrelationId);
+        Assert.Equal("root-operation", OperationContext.OperationName);
+    }
+
+    [Fact]
+    public void GenerateCorrelationId_ReturnsExpectedTimestampAndSuffixFormat()
+    {
+        var correlationId = OperationContext.GenerateCorrelationId();
+
+        Assert.Matches("^[0-9]{8}-[0-9]{6}-[0-9a-f]{8}$", correlationId);
+    }
+
+    [Fact]
+    public async Task CorrelationId_DoesNotLeakAcrossParallelAsyncContexts()
+    {
+        var firstContextReady = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowFirstContextToFinish = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var firstContext = Task.Run(async () =>
+        {
+            OperationContext.CorrelationId = "context-one";
+            OperationContext.OperationName = "operation-one";
+            firstContextReady.SetResult(true);
+
+            await allowFirstContextToFinish.Task;
+
+            Assert.Equal("context-one", OperationContext.CorrelationId);
+            Assert.Equal("operation-one", OperationContext.OperationName);
+        });
+
+        var secondContext = Task.Run(async () =>
+        {
+            await firstContextReady.Task;
+
+            Assert.Null(OperationContext.OperationName);
+
+            var generatedCorrelationId = OperationContext.CorrelationId;
+            Assert.Matches("^[0-9]{8}-[0-9]{6}-[0-9a-f]{8}$", generatedCorrelationId);
+            Assert.NotEqual("context-one", generatedCorrelationId);
+
+            allowFirstContextToFinish.SetResult(true);
+        });
+
+        await Task.WhenAll(firstContext, secondContext);
+
+        Assert.Null(OperationContext.OperationName);
+    }
+
+    public void Dispose()
+    {
+        ResetContext();
+    }
+
+    private static void ResetContext()
+    {
+        OperationContext.CorrelationId = null!;
+        OperationContext.OperationName = null;
+    }
+}


### PR DESCRIPTION
Closes #300

Adds unit tests for correlation ID set/get, BeginOperation scope nesting, GenerateCorrelationId format, and async flow isolation.