### PR TITLE
test: add PropertySetDiscovery unit tests

### DIFF
--- a/PoshMcp.Server/PowerShell/PropertySetDiscovery.cs
+++ b/PoshMcp.Server/PowerShell/PropertySetDiscovery.cs
@@ -104,6 +104,11 @@ public static class PropertySetDiscovery
         _cache.Clear();
     }
 
+    internal static bool CacheContainsKey(string commandName)
+    {
+        return _cache.ContainsKey(commandName);
+    }
+
     private static IReadOnlyList<string>? DiscoverDefaultDisplayPropertiesCore(string commandName)
     {
         try

--- a/PoshMcp.Tests/Shared/PropertySetDiscoveryTestCollection.cs
+++ b/PoshMcp.Tests/Shared/PropertySetDiscoveryTestCollection.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+namespace PoshMcp.Tests;
+
+[CollectionDefinition("PropertySetDiscoveryTests", DisableParallelization = true)]
+public sealed class PropertySetDiscoveryTestCollection
+{
+}

--- a/PoshMcp.Tests/Unit/PropertySetDiscoveryTests.cs
+++ b/PoshMcp.Tests/Unit/PropertySetDiscoveryTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using PoshMcp.Server.PowerShell;
+using Xunit;
+
+namespace PoshMcp.Tests.Unit;
+
+[Collection("PropertySetDiscoveryTests")]
+[Trait("Category", "Unit")]
+public sealed class PropertySetDiscoveryTests
+{
+    private const string KnownCommand = "Get-Process";
+
+    public PropertySetDiscoveryTests()
+    {
+        PropertySetDiscovery.ClearCache();
+    }
+
+    [Fact]
+    public void DiscoverDefaultDisplayProperties_NullCommandName_ReturnsNull()
+    {
+        var result = PropertySetDiscovery.DiscoverDefaultDisplayProperties(commandName: null!);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void DiscoverDefaultDisplayProperties_EmptyCommandName_ReturnsNull()
+    {
+        var result = PropertySetDiscovery.DiscoverDefaultDisplayProperties(string.Empty);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void DiscoverDefaultDisplayProperties_WhitespaceCommandName_ReturnsNull()
+    {
+        var result = PropertySetDiscovery.DiscoverDefaultDisplayProperties("  ");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void DiscoverDefaultDisplayProperties_KnownCommand_ReturnsCachedOnSecondCall()
+    {
+        var first = PropertySetDiscovery.DiscoverDefaultDisplayProperties(KnownCommand);
+        var second = PropertySetDiscovery.DiscoverDefaultDisplayProperties(KnownCommand);
+
+        Assert.NotNull(first);
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void DiscoverDefaultDisplayProperties_NonexistentCommand_ReturnsNull()
+    {
+        var result = PropertySetDiscovery.DiscoverDefaultDisplayProperties("Not-A-Real-Command-XYZ");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ClearCache_ThenReDiscover_ReturnsResult()
+    {
+        var first = PropertySetDiscovery.DiscoverDefaultDisplayProperties(KnownCommand);
+
+        PropertySetDiscovery.ClearCache();
+
+        var second = PropertySetDiscovery.DiscoverDefaultDisplayProperties(KnownCommand);
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.Contains("Id", second, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("Name", second, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DiscoverAll_NullInput_ReturnsEmptyDictionary()
+    {
+        var result = PropertySetDiscovery.DiscoverAll(commandNames: null!);
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void DiscoverAll_EmptyList_ReturnsEmptyDictionary()
+    {
+        var result = PropertySetDiscovery.DiscoverAll(Array.Empty<string>());
+
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void DiscoverAll_WithCommands_ReturnsDictionaryWithEntries()
+    {
+        var result = PropertySetDiscovery.DiscoverAll(new[] { KnownCommand });
+
+        Assert.True(result.TryGetValue(KnownCommand, out var properties));
+        Assert.NotNull(properties);
+        Assert.Contains("Id", properties, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("Name", properties, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DiscoverAll_CachesResults()
+    {
+        var batch = PropertySetDiscovery.DiscoverAll(new[] { KnownCommand });
+        var cached = PropertySetDiscovery.DiscoverDefaultDisplayProperties(KnownCommand);
+
+        var properties = Assert.IsAssignableFrom<IReadOnlyList<string>>(batch[KnownCommand]);
+        Assert.Same(properties, cached);
+    }
+
+    [Fact]
+    public void DiscoverDefaultDisplayProperties_GetProcess_ReturnsProperties()
+    {
+        var result = PropertySetDiscovery.DiscoverDefaultDisplayProperties(KnownCommand);
+
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+        Assert.Contains("Id", result, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("Name", result, StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/PoshMcp.Tests/Unit/PropertySetDiscoveryTests.cs
+++ b/PoshMcp.Tests/Unit/PropertySetDiscoveryTests.cs
@@ -118,9 +118,11 @@ public sealed class PropertySetDiscoveryTests
     public void DiscoverAll_NonexistentCommand_CachesNullEntry()
     {
         var result = PropertySetDiscovery.DiscoverAll(new[] { KnownCommand, MissingCommand });
+        var cached = PropertySetDiscovery.DiscoverDefaultDisplayProperties(MissingCommand);
 
         Assert.True(result.ContainsKey(MissingCommand));
         Assert.Null(result[MissingCommand]);
+        Assert.Null(cached);
     }
 
     [Fact]

--- a/PoshMcp.Tests/Unit/PropertySetDiscoveryTests.cs
+++ b/PoshMcp.Tests/Unit/PropertySetDiscoveryTests.cs
@@ -10,6 +10,7 @@ namespace PoshMcp.Tests.Unit;
 public sealed class PropertySetDiscoveryTests
 {
     private const string KnownCommand = "Get-Process";
+    private const string MissingCommand = "Not-A-Real-Command-XYZ";
 
     public PropertySetDiscoveryTests()
     {
@@ -53,13 +54,13 @@ public sealed class PropertySetDiscoveryTests
     [Fact]
     public void DiscoverDefaultDisplayProperties_NonexistentCommand_ReturnsNull()
     {
-        var result = PropertySetDiscovery.DiscoverDefaultDisplayProperties("Not-A-Real-Command-XYZ");
+        var result = PropertySetDiscovery.DiscoverDefaultDisplayProperties(MissingCommand);
 
         Assert.Null(result);
     }
 
     [Fact]
-    public void ClearCache_ThenReDiscover_ReturnsResult()
+    public void ClearCache_ThenReDiscover_ReturnsNewResult()
     {
         var first = PropertySetDiscovery.DiscoverDefaultDisplayProperties(KnownCommand);
 
@@ -69,6 +70,7 @@ public sealed class PropertySetDiscoveryTests
 
         Assert.NotNull(first);
         Assert.NotNull(second);
+        Assert.NotSame(first, second);
         Assert.Contains("Id", second, StringComparer.OrdinalIgnoreCase);
         Assert.Contains("Name", second, StringComparer.OrdinalIgnoreCase);
     }
@@ -110,6 +112,15 @@ public sealed class PropertySetDiscoveryTests
 
         var properties = Assert.IsAssignableFrom<IReadOnlyList<string>>(batch[KnownCommand]);
         Assert.Same(properties, cached);
+    }
+
+    [Fact]
+    public void DiscoverAll_NonexistentCommand_CachesNullEntry()
+    {
+        var result = PropertySetDiscovery.DiscoverAll(new[] { KnownCommand, MissingCommand });
+
+        Assert.True(result.ContainsKey(MissingCommand));
+        Assert.Null(result[MissingCommand]);
     }
 
     [Fact]

--- a/PoshMcp.Tests/Unit/PropertySetDiscoveryTests.cs
+++ b/PoshMcp.Tests/Unit/PropertySetDiscoveryTests.cs
@@ -117,12 +117,13 @@ public sealed class PropertySetDiscoveryTests
     [Fact]
     public void DiscoverAll_NonexistentCommand_CachesNullEntry()
     {
-        var result = PropertySetDiscovery.DiscoverAll(new[] { KnownCommand, MissingCommand });
-        var cached = PropertySetDiscovery.DiscoverDefaultDisplayProperties(MissingCommand);
+        Assert.False(PropertySetDiscovery.CacheContainsKey(MissingCommand));
 
+        var result = PropertySetDiscovery.DiscoverAll(new[] { KnownCommand, MissingCommand });
+
+        Assert.True(PropertySetDiscovery.CacheContainsKey(MissingCommand));
         Assert.True(result.ContainsKey(MissingCommand));
         Assert.Null(result[MissingCommand]);
-        Assert.Null(cached);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #308

Adds unit tests for PropertySetDiscovery covering:
- Null/empty/whitespace input guards
- Caching contract (GetOrAdd semantics)
- ClearCache behavior
- DiscoverAll with null/empty/valid inputs
- Real command discovery (Get-Process properties)

Note: Defers the IRunspaceFactory extraction to a future refactoring PR.

Parent: #293