### PR TITLE
Prepare PoshMcp for MCP 2025-11-25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,17 +50,20 @@ jobs:
     # are buildable and discoverable without making machine-dependent claims.
     - name: Benchmark contract
       run: |
+        dotnet run --no-build --project PoshMcp.Benchmarks --configuration Release -- --verify-http-session-contract | tee benchmark-contract.txt
         dotnet run --no-build --project PoshMcp.Benchmarks --configuration Release -- --list flat | tee benchmark-cases.txt
-        grep -q "HttpSessionBenchmark" benchmark-cases.txt
-        grep -q "FirstHttpSessionLatency" benchmark-cases.txt
-        grep -q "BoundedCapacityRejection" benchmark-cases.txt
+        for benchmark in FirstHttpSessionLatency WarmSessionToolLatency ConcurrentWarmSessionThroughput BoundedCapacityRejection; do
+          grep -Fxq "PoshMcp.Benchmarks.Scenarios.HttpSessionBenchmark.${benchmark}" benchmark-cases.txt
+        done
 
     - name: Upload Benchmark Contract
       if: always()
       uses: actions/upload-artifact@v4
       with:
         name: benchmark-contract
-        path: benchmark-cases.txt
+        path: |
+          benchmark-contract.txt
+          benchmark-cases.txt
 
     # ---------------------------------------------------------------------------
     # Phased test execution per spec 009 (issue #215).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,23 @@ jobs:
     - name: Build
       run: dotnet build --configuration Release --no-restore
 
+    # Timing assertions are intentionally excluded from shared CI runners.
+    # This verifies that the benchmark suite and its session-affinity coverage
+    # are buildable and discoverable without making machine-dependent claims.
+    - name: Benchmark contract
+      run: |
+        dotnet run --no-build --project PoshMcp.Benchmarks --configuration Release -- --list flat | tee benchmark-cases.txt
+        grep -q "HttpSessionBenchmark" benchmark-cases.txt
+        grep -q "FirstHttpSessionLatency" benchmark-cases.txt
+        grep -q "BoundedCapacityRejection" benchmark-cases.txt
+
+    - name: Upload Benchmark Contract
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: benchmark-contract
+        path: benchmark-cases.txt
+
     # ---------------------------------------------------------------------------
     # Phased test execution per spec 009 (issue #215).
     #
@@ -236,4 +253,3 @@ jobs:
       with:
         name: test-results-azure
         path: ./TestResults/*.trx
-

--- a/.squad/decisions/inbox/fry-performance-gates.md
+++ b/.squad/decisions/inbox/fry-performance-gates.md
@@ -1,0 +1,14 @@
+# 2026-07-16: Benchmark quality gates use a discoverability contract
+
+**By:** Fry (issue #336)
+
+**What:** Shared CI verifies that the HTTP session benchmark scenarios build and
+are discoverable, then uploads that case list as an artifact. It does not make
+timing assertions. The benchmark suite measures first-session startup,
+warm-session calls, concurrent warm sessions, and bounded-capacity behavior
+using a deterministic benchmark configuration.
+
+**Why:** Benchmark timings are machine-dependent and therefore unsuitable as
+required checks on shared CI runners. The contract gate prevents accidental
+scenario removal while controlled-machine BenchmarkDotNet reports provide
+reproducible comparison evidence.

--- a/.squad/decisions/inbox/hermes-oop-resilience.md
+++ b/.squad/decisions/inbox/hermes-oop-resilience.md
@@ -1,0 +1,3 @@
+# OOP cancellation and reload isolation
+
+Interrupted subprocess-pool workers are quarantined and replaced rather than reused. Configuration reload advances a pool generation: idle workers are configured immediately, active workers complete their existing request and retire on return, and replacements inherit the latest cached configuration. This prevents setup frames from being sent into a worker with an active command.

--- a/.squad/decisions/inbox/leela-oop-task-retention.md
+++ b/.squad/decisions/inbox/leela-oop-task-retention.md
@@ -1,0 +1,5 @@
+# Bounded OOP cleanup tracking
+
+## 2026-07-16
+
+Out-of-process cleanup retains at most `MaxTrackedCleanupOperations` incomplete tasks (default 16) for shutdown waiting. Every cleanup task gets a completion observer, including untracked overflow tasks: completed entries are removed, faults are observed and logged, and overflow is logged explicitly. This prevents repeated stuck-worker replacement from retaining an unbounded task or exception collection while preserving bounded disposal waits and failure visibility.

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -31,6 +31,23 @@ docker build -t myorg/poshmcp:latest .
 docker run -d -p 8080:8080 -e POSHMCP_TRANSPORT=http myorg/poshmcp:latest
 ```
 
+### HTTP MCP operator notes
+
+The container's HTTP transport is MCP Streamable HTTP targeting
+2025-11-25. Publish the configured MCP endpoint (default `/`, with `/mcp` as
+a compatibility alias) and keep `/health` and `/health/ready` available for
+probes. Behind a reverse proxy, preserve `Mcp-Session-Id` and
+`MCP-Protocol-Version` headers. Browser-origin requests must be same-origin or
+match `Authentication:Cors:AllowedOrigins`; non-browser MCP clients generally
+omit `Origin`.
+
+HTTP session runspaces are bounded and session-affine. Set the `McpServer`
+settings in the mounted or baked `appsettings.json` according to concurrent
+stateful sessions and memory available for initialized PowerShell runspaces.
+See [Transport Modes](docs/articles/transport-modes.md#http-mode) and
+[Configuration](docs/articles/configuration.md#mcp-server-http-sessions) for
+protocol negotiation, legacy compatibility, lifecycle, and exact settings.
+
 ### Build mode semantics
 - `poshmcp build` defaults to `--type custom`, using `examples/Dockerfile.user` and a source image reference.
 - Default source image reference is `ghcr.io/usepowershell/poshmcp/poshmcp:latest`.
@@ -226,3 +243,5 @@ curl http://localhost:8080/health/ready
 - [infrastructure/azure/](infrastructure/azure/) --- Azure deployment guide
 - [examples/](examples/) --- Sample Dockerfiles and configurations
 - [docs/articles/environment.md](docs/articles/environment.md) --- PowerShell environment setup
+- [docs/articles/transport-modes.md](docs/articles/transport-modes.md) --- Streamable HTTP and transport compatibility
+- [docs/articles/configuration.md](docs/articles/configuration.md#mcp-server-http-sessions) --- HTTP session capacity and lifecycle

--- a/PoshMcp.Benchmarks/BenchmarkAssets/http-session-benchmark.appsettings.json
+++ b/PoshMcp.Benchmarks/BenchmarkAssets/http-session-benchmark.appsettings.json
@@ -1,0 +1,35 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "ApplicationInsights": {
+    "Enabled": false,
+    "ConnectionString": ""
+  },
+  "PowerShellConfiguration": {
+    "RuntimeMode": "InProcess",
+    "CommandNames": [ "Get-Date" ],
+    "Modules": [ "Microsoft.PowerShell.Utility" ],
+    "Environment": {
+      "StartupScript": "$script:PoshMcpBenchmarkSetup = 'ready'"
+    },
+    "EnableDynamicReloadTools": false,
+    "EnableConfigurationTroubleshootingTool": false
+  },
+  "McpServer": {
+    "IdleSessionTimeoutSeconds": 60,
+    "SessionRunspaceCapacity": 4,
+    "SessionRunspaceIdleTtlSeconds": 300,
+    "SessionRunspaceSweepIntervalSeconds": 30,
+    "SessionRunspaceWarmStandbyCount": 0,
+    "SessionRunspaceAcquisitionTimeoutSeconds": 1,
+    "EnableLegacySse": false
+  },
+  "Authentication": {
+    "Enabled": false,
+    "Schemes": {}
+  }
+}

--- a/PoshMcp.Benchmarks/BenchmarkConfig.cs
+++ b/PoshMcp.Benchmarks/BenchmarkConfig.cs
@@ -39,6 +39,7 @@ public sealed class BenchmarkConfig : ManualConfig
         // PoshMcp.Benchmarks/README.md.
         AddColumn(StatisticColumn.P95);
         AddColumn(new P99StatisticColumn());
+        AddColumn(new CapacityOutcomeColumn());
 
         SummaryStyle = SummaryStyle.Default.WithRatioStyle(RatioStyle.Trend);
     }

--- a/PoshMcp.Benchmarks/BenchmarkContract.cs
+++ b/PoshMcp.Benchmarks/BenchmarkContract.cs
@@ -1,0 +1,60 @@
+using System.Reflection;
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+using PoshMcp.Benchmarks.Scenarios;
+
+namespace PoshMcp.Benchmarks;
+
+internal static class BenchmarkContract
+{
+    private static readonly string[] RequiredHttpSessionMethods =
+    [
+        nameof(HttpSessionBenchmark.FirstHttpSessionLatency),
+        nameof(HttpSessionBenchmark.WarmSessionToolLatency),
+        nameof(HttpSessionBenchmark.ConcurrentWarmSessionThroughput),
+        nameof(HttpSessionBenchmark.BoundedCapacityRejection)
+    ];
+
+    public static void VerifyHttpSessionContract()
+    {
+        var discoveredMethods = typeof(HttpSessionBenchmark)
+            .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)
+            .Where(method => method.GetCustomAttribute<BenchmarkAttribute>() is not null)
+            .Select(method => method.Name)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+        var expectedMethods = RequiredHttpSessionMethods.OrderBy(name => name, StringComparer.Ordinal).ToArray();
+
+        if (!discoveredMethods.SequenceEqual(expectedMethods, StringComparer.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"HTTP session benchmark contract mismatch. Expected: {string.Join(", ", expectedMethods)}. "
+                + $"Discovered: {string.Join(", ", discoveredMethods)}.");
+        }
+
+        var capacityProperty = typeof(HttpSessionBenchmark).GetProperty(nameof(HttpSessionBenchmark.SessionRunspaceCapacity));
+        if (capacityProperty?.GetCustomAttribute<ParamsAttribute>() is null)
+        {
+            throw new InvalidOperationException("HTTP session benchmark must expose SessionRunspaceCapacity as a BenchmarkDotNet parameter.");
+        }
+
+        using var rejectedResponse = JsonDocument.Parse("""{"result":{"isError":true}}""");
+        using var topLevelErrorResponse = JsonDocument.Parse("""{"error":{"code":-32603}}""");
+        using var successfulResponse = JsonDocument.Parse("""{"result":{"isError":false}}""");
+        if (!BenchmarkMcpClient.IsMcpError(rejectedResponse.RootElement)
+            || !BenchmarkMcpClient.IsMcpError(topLevelErrorResponse.RootElement)
+            || BenchmarkMcpClient.IsMcpError(successfulResponse.RootElement))
+        {
+            throw new InvalidOperationException("Bounded-capacity MCP error validation is not configured correctly.");
+        }
+
+        foreach (var method in RequiredHttpSessionMethods)
+        {
+            Console.WriteLine($"HTTP session benchmark contract: {method}");
+        }
+
+        Console.WriteLine(
+            $"Bounded capacity metadata: SessionRunspaceCapacity={HttpSessionBenchmark.DefaultSessionRunspaceCapacity}; "
+            + "overflow MCP error (validated).");
+    }
+}

--- a/PoshMcp.Benchmarks/BenchmarkHttpServer.cs
+++ b/PoshMcp.Benchmarks/BenchmarkHttpServer.cs
@@ -22,7 +22,7 @@ internal sealed class BenchmarkHttpServer : IAsyncDisposable
 
     public Uri BaseUri { get; }
 
-    public static async Task<BenchmarkHttpServer> StartAsync()
+    public static async Task<BenchmarkHttpServer> StartAsync(int sessionRunspaceCapacity = 4)
     {
         var serverAssembly = typeof(PowerShellConfiguration).Assembly.Location;
         var configPath = Path.Combine(
@@ -48,6 +48,7 @@ internal sealed class BenchmarkHttpServer : IAsyncDisposable
         startInfo.ArgumentList.Add(configPath);
         startInfo.Environment["ApplicationInsights__Enabled"] = "false";
         startInfo.Environment["APPLICATIONINSIGHTS_CONNECTION_STRING"] = string.Empty;
+        startInfo.Environment["McpServer__SessionRunspaceCapacity"] = sessionRunspaceCapacity.ToString();
 
         var process = Process.Start(startInfo)
             ?? throw new InvalidOperationException("Unable to start the benchmark HTTP server.");
@@ -162,6 +163,28 @@ internal sealed class BenchmarkMcpClient : IAsyncDisposable
         method = "tools/call",
         @params = new { name = "get_date", arguments = new { } }
     });
+
+    public static async Task<bool> IsMcpErrorAsync(HttpResponseMessage response)
+    {
+        var payload = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        if (payload.StartsWith("event:", StringComparison.Ordinal))
+        {
+            payload = payload.Split('\n')
+                .FirstOrDefault(line => line.StartsWith("data:", StringComparison.Ordinal))?[5..].TrimStart()
+                ?? throw new InvalidOperationException("The benchmark MCP server returned an SSE response without JSON data.");
+        }
+
+        using var document = JsonDocument.Parse(payload);
+        return IsMcpError(document.RootElement);
+    }
+
+    internal static bool IsMcpError(JsonElement response)
+    {
+        return response.TryGetProperty("error", out _)
+            || (response.TryGetProperty("result", out var result)
+                && result.TryGetProperty("isError", out var isError)
+                && isError.ValueKind is JsonValueKind.True);
+    }
 
     private Task<HttpResponseMessage> SendAsync(object payload)
     {

--- a/PoshMcp.Benchmarks/BenchmarkHttpServer.cs
+++ b/PoshMcp.Benchmarks/BenchmarkHttpServer.cs
@@ -1,0 +1,186 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using PoshMcp.Server.PowerShell;
+
+namespace PoshMcp.Benchmarks;
+
+internal sealed class BenchmarkHttpServer : IAsyncDisposable
+{
+    private const string ProtocolVersion = "2025-11-25";
+    private readonly Process _process;
+    private readonly HttpClient _healthClient = new() { Timeout = TimeSpan.FromSeconds(2) };
+
+    private BenchmarkHttpServer(Process process, Uri baseUri)
+    {
+        _process = process;
+        BaseUri = baseUri;
+    }
+
+    public Uri BaseUri { get; }
+
+    public static async Task<BenchmarkHttpServer> StartAsync()
+    {
+        var serverAssembly = typeof(PowerShellConfiguration).Assembly.Location;
+        var configPath = Path.Combine(
+            AppContext.BaseDirectory,
+            "BenchmarkAssets",
+            "http-session-benchmark.appsettings.json");
+        var port = AllocatePort();
+        var baseUri = new Uri($"http://127.0.0.1:{port}");
+
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = AppContext.BaseDirectory,
+        };
+        startInfo.ArgumentList.Add(serverAssembly);
+        startInfo.ArgumentList.Add("serve");
+        startInfo.ArgumentList.Add("--transport");
+        startInfo.ArgumentList.Add("http");
+        startInfo.ArgumentList.Add("--url");
+        startInfo.ArgumentList.Add(baseUri.ToString().TrimEnd('/'));
+        startInfo.ArgumentList.Add("--config");
+        startInfo.ArgumentList.Add(configPath);
+        startInfo.Environment["ApplicationInsights__Enabled"] = "false";
+        startInfo.Environment["APPLICATIONINSIGHTS_CONNECTION_STRING"] = string.Empty;
+
+        var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Unable to start the benchmark HTTP server.");
+        var server = new BenchmarkHttpServer(process, baseUri);
+
+        try
+        {
+            await server.WaitForReadyAsync().ConfigureAwait(false);
+            return server;
+        }
+        catch
+        {
+            await server.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    public BenchmarkMcpClient CreateClient() => new(BaseUri);
+
+    private async Task WaitForReadyAsync()
+    {
+        var deadline = Stopwatch.GetTimestamp() + (long)(Stopwatch.Frequency * 60);
+        while (Stopwatch.GetTimestamp() < deadline)
+        {
+            if (_process.HasExited)
+            {
+                throw new InvalidOperationException(
+                    $"Benchmark HTTP server exited with code {_process.ExitCode} before becoming ready.");
+            }
+
+            try
+            {
+                using var response = await _healthClient.GetAsync(new Uri(BaseUri, "health")).ConfigureAwait(false);
+                if (response.IsSuccessStatusCode)
+                {
+                    return;
+                }
+            }
+            catch (HttpRequestException)
+            {
+            }
+            catch (TaskCanceledException)
+            {
+            }
+
+            await Task.Delay(100).ConfigureAwait(false);
+        }
+
+        throw new TimeoutException($"Benchmark HTTP server did not become ready at {BaseUri}.");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _healthClient.Dispose();
+        if (!_process.HasExited)
+        {
+            _process.Kill(entireProcessTree: true);
+            await _process.WaitForExitAsync().ConfigureAwait(false);
+        }
+
+        _process.Dispose();
+    }
+
+    private static int AllocatePort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        return ((IPEndPoint)listener.LocalEndpoint).Port;
+    }
+}
+
+internal sealed class BenchmarkMcpClient : IAsyncDisposable
+{
+    private const string ProtocolVersion = "2025-11-25";
+    private static long _nextRequestId;
+    private readonly HttpClient _client;
+
+    public BenchmarkMcpClient(Uri baseUri)
+    {
+        _client = new HttpClient { BaseAddress = baseUri, Timeout = TimeSpan.FromSeconds(30) };
+        _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+    }
+
+    public string? SessionId { get; private set; }
+
+    public async Task InitializeAsync()
+    {
+        using var response = await SendAsync(new
+        {
+            jsonrpc = "2.0",
+            id = Interlocked.Increment(ref _nextRequestId),
+            method = "initialize",
+            @params = new
+            {
+                protocolVersion = ProtocolVersion,
+                capabilities = new { tools = new { } },
+                clientInfo = new { name = "poshmcp-benchmark", version = "1.0" }
+            }
+        }).ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
+        SessionId = response.Headers.TryGetValues("Mcp-Session-Id", out var values)
+            ? values.FirstOrDefault()
+            : throw new InvalidOperationException("The benchmark MCP server did not return a session ID.");
+    }
+
+    public Task<HttpResponseMessage> CallGetDateAsync() => SendAsync(new
+    {
+        jsonrpc = "2.0",
+        id = Interlocked.Increment(ref _nextRequestId),
+        method = "tools/call",
+        @params = new { name = "get_date", arguments = new { } }
+    });
+
+    private Task<HttpResponseMessage> SendAsync(object payload)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "/")
+        {
+            Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json")
+        };
+        if (!string.IsNullOrWhiteSpace(SessionId))
+        {
+            request.Headers.Add("Mcp-Session-Id", SessionId);
+            request.Headers.Add("MCP-Protocol-Version", ProtocolVersion);
+        }
+
+        return _client.SendAsync(request);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _client.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/PoshMcp.Benchmarks/CapacityOutcomeColumn.cs
+++ b/PoshMcp.Benchmarks/CapacityOutcomeColumn.cs
@@ -1,0 +1,35 @@
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+
+namespace PoshMcp.Benchmarks;
+
+/// <summary>
+/// Identifies the validated result condition for the bounded HTTP-session case.
+/// BenchmarkDotNet records timing rather than benchmark return values, so the
+/// benchmark throws when the required MCP error is not observed.
+/// </summary>
+internal sealed class CapacityOutcomeColumn : IColumn
+{
+    public string Id => nameof(CapacityOutcomeColumn);
+    public string ColumnName => "Capacity outcome";
+    public string Legend => "Validated bounded-capacity result; a displayed benchmark row means this condition passed.";
+    public bool AlwaysShow => true;
+    public ColumnCategory Category => ColumnCategory.Custom;
+    public int PriorityInCategory => 0;
+    public bool IsNumeric => false;
+    public UnitType UnitType => UnitType.Dimensionless;
+
+    public bool IsAvailable(Summary summary) => true;
+    public bool IsDefault(Summary summary, BenchmarkCase benchmarkCase) => false;
+
+    public string GetValue(Summary summary, BenchmarkCase benchmarkCase)
+        => GetValue(summary, benchmarkCase, SummaryStyle.Default);
+
+    public string GetValue(Summary summary, BenchmarkCase benchmarkCase, SummaryStyle style)
+    {
+        return benchmarkCase.Descriptor.WorkloadMethod.Name == nameof(Scenarios.HttpSessionBenchmark.BoundedCapacityRejection)
+            ? "overflow MCP error (validated)"
+            : "N/A";
+    }
+}

--- a/PoshMcp.Benchmarks/PoshMcp.Benchmarks.csproj
+++ b/PoshMcp.Benchmarks/PoshMcp.Benchmarks.csproj
@@ -21,4 +21,10 @@
     <ProjectReference Include="..\PoshMcp.Server\PoshMcp.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="BenchmarkAssets\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/PoshMcp.Benchmarks/Program.cs
+++ b/PoshMcp.Benchmarks/Program.cs
@@ -15,6 +15,14 @@ using PoshMcp.Benchmarks;
 Environment.SetEnvironmentVariable("ApplicationInsights__Enabled", "false");
 Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING", string.Empty);
 
+if (args.SequenceEqual(["--verify-http-session-contract"], StringComparer.Ordinal))
+{
+    BenchmarkContract.VerifyHttpSessionContract();
+    return 0;
+}
+
 BenchmarkSwitcher
     .FromAssembly(typeof(BenchmarkConfig).Assembly)
     .Run(args, new BenchmarkConfig());
+
+return 0;

--- a/PoshMcp.Benchmarks/README.md
+++ b/PoshMcp.Benchmarks/README.md
@@ -21,6 +21,7 @@ one row per (mode × scenario × payload-size) combination in one results table.
 | `PayloadSizeSerializationBenchmark`          | Round-trip a string of size `PayloadBytes` (1 KB / 16 KB / 256 KB / 1 MB). |
 | `ProcessCrashRecoveryBenchmark`              | Kill one underlying `pwsh` host, then time the next successful invoke. |
 | `RunspaceCorruptionRecoveryBenchmark`        | Slow invoke in flight → time a fast probe (head-of-line-blocking gate). |
+| `HttpSessionBenchmark`                       | HTTP startup + first session call, warm-session latency, concurrent session throughput, and capacity rejection. |
 
 ## Running
 
@@ -40,6 +41,7 @@ dotnet run --project PoshMcp.Benchmarks --configuration Release -- --filter '*Co
 dotnet run --project PoshMcp.Benchmarks --configuration Release -- --filter '*PayloadSize*'
 dotnet run --project PoshMcp.Benchmarks --configuration Release -- --filter '*ProcessCrash*'
 dotnet run --project PoshMcp.Benchmarks --configuration Release -- --filter '*RunspaceCorruption*'
+dotnet run --project PoshMcp.Benchmarks --configuration Release -- --filter '*HttpSession*'
 ```
 
 ### Filter by mode (BDN matches `[Params]` values in the case ID)
@@ -103,3 +105,23 @@ against an inherited connection string in the host shell.
   `Get-Date`, `Get-Random`, `Write-Output`, `Invoke-WebRequest`, and
   `Start-Sleep` are callable directly. The harness measures executor cost,
   not module install / import.
+- `HttpSessionBenchmark` is intentionally different: it launches the actual
+  HTTP server with `BenchmarkAssets/http-session-benchmark.appsettings.json`.
+  Its first-session row includes server tool discovery, the configured
+  `Microsoft.PowerShell.Utility` import, inline startup-script setup, and the
+  first `initialize` + `tools/call` exchange. Its warm row excludes that
+  startup work. The bounded-capacity row fills the configured four session
+  runspaces, then reports the response status for one more session's tool call;
+  it demonstrates bounded rejection rather than asserting a machine-specific
+  duration.
+
+## Quality gates
+
+CI does not run timing benchmarks: shared runners are not stable enough for
+time-based pass/fail thresholds. Instead, the `Benchmark contract` CI step
+builds the benchmark executable and verifies that the reproducible HTTP/session
+scenarios are discoverable. Capture timing reports on a controlled machine with
+the same command and compare like-for-like runs (same hardware, SDK, config,
+and benchmark filter). Commit or attach the resulting
+`*-report-github.md`/CSV when a performance decision needs review; treat large
+same-machine regressions as investigation signals, not normal test assertions.

--- a/PoshMcp.Benchmarks/README.md
+++ b/PoshMcp.Benchmarks/README.md
@@ -110,17 +110,21 @@ against an inherited connection string in the host shell.
   Its first-session row includes server tool discovery, the configured
   `Microsoft.PowerShell.Utility` import, inline startup-script setup, and the
   first `initialize` + `tools/call` exchange. Its warm row excludes that
-  startup work. The bounded-capacity row fills the configured four session
-  runspaces, then reports the response status for one more session's tool call;
-  it demonstrates bounded rejection rather than asserting a machine-specific
-  duration.
+  startup work. The bounded-capacity row fills the configured
+  `SessionRunspaceCapacity` (currently 4) session runspaces, then makes one
+  overflow call. It validates an MCP error response (`result.isError=true` or a
+  JSON-RPC `error`) and throws if that condition is absent. The BDN report
+  exposes both the capacity parameter and a `Capacity outcome` column stating
+  `overflow MCP error (validated)`; the row is emitted only after that
+  validation passes.
 
 ## Quality gates
 
 CI does not run timing benchmarks: shared runners are not stable enough for
 time-based pass/fail thresholds. Instead, the `Benchmark contract` CI step
-builds the benchmark executable and verifies that the reproducible HTTP/session
-scenarios are discoverable. Capture timing reports on a controlled machine with
+builds the benchmark executable, verifies the four-method HTTP/session contract,
+and checks exact BDN discovery names for all four scenarios. It does not run
+performance measurements or enforce timing thresholds. Capture timing reports on a controlled machine with
 the same command and compare like-for-like runs (same hardware, SDK, config,
 and benchmark filter). Commit or attach the resulting
 `*-report-github.md`/CSV when a performance decision needs review; treat large

--- a/PoshMcp.Benchmarks/README.md
+++ b/PoshMcp.Benchmarks/README.md
@@ -129,3 +129,13 @@ the same command and compare like-for-like runs (same hardware, SDK, config,
 and benchmark filter). Commit or attach the resulting
 `*-report-github.md`/CSV when a performance decision needs review; treat large
 same-machine regressions as investigation signals, not normal test assertions.
+
+## Interpreting historical OOP results
+
+The controlled-machine OOP comparison and the rationale for the `Pool` default
+are recorded in
+[`specs/004-out-of-process-execution/benchmark-findings.md`](../specs/004-out-of-process-execution/benchmark-findings.md).
+Those measurements are historical single-machine findings, not production
+capacity or SLO guarantees. Use the commands above and compare identical
+hardware, SDK, configuration, and benchmark filters before making an
+operational decision.

--- a/PoshMcp.Benchmarks/Scenarios/HttpSessionBenchmark.cs
+++ b/PoshMcp.Benchmarks/Scenarios/HttpSessionBenchmark.cs
@@ -10,16 +10,21 @@ namespace PoshMcp.Benchmarks.Scenarios;
 [MaxIterationCount(10)]
 public class HttpSessionBenchmark
 {
+    public const int DefaultSessionRunspaceCapacity = 4;
+
     private BenchmarkHttpServer? _server;
     private BenchmarkMcpClient? _warmClient;
     private List<BenchmarkMcpClient>? _throughputClients;
     private List<BenchmarkMcpClient>? _capacityClients;
     private BenchmarkMcpClient? _overflowClient;
 
+    [Params(DefaultSessionRunspaceCapacity)]
+    public int SessionRunspaceCapacity { get; set; }
+
     [GlobalSetup(Target = nameof(WarmSessionToolLatency))]
     public async Task StartWarmSessionAsync()
     {
-        _server = await BenchmarkHttpServer.StartAsync().ConfigureAwait(false);
+        _server = await BenchmarkHttpServer.StartAsync(SessionRunspaceCapacity).ConfigureAwait(false);
         _warmClient = _server!.CreateClient();
         await _warmClient.InitializeAsync().ConfigureAwait(false);
         using var response = await _warmClient.CallGetDateAsync().ConfigureAwait(false);
@@ -29,9 +34,9 @@ public class HttpSessionBenchmark
     [GlobalSetup(Target = nameof(ConcurrentWarmSessionThroughput))]
     public async Task StartConcurrentWarmSessionsAsync()
     {
-        _server = await BenchmarkHttpServer.StartAsync().ConfigureAwait(false);
+        _server = await BenchmarkHttpServer.StartAsync(SessionRunspaceCapacity).ConfigureAwait(false);
         _throughputClients = new List<BenchmarkMcpClient>();
-        for (var index = 0; index < 4; index++)
+        for (var index = 0; index < SessionRunspaceCapacity; index++)
         {
             var client = _server.CreateClient();
             await client.InitializeAsync().ConfigureAwait(false);
@@ -44,9 +49,9 @@ public class HttpSessionBenchmark
     [GlobalSetup(Target = nameof(BoundedCapacityRejection))]
     public async Task FillCapacityAsync()
     {
-        _server = await BenchmarkHttpServer.StartAsync().ConfigureAwait(false);
+        _server = await BenchmarkHttpServer.StartAsync(SessionRunspaceCapacity).ConfigureAwait(false);
         _capacityClients = new List<BenchmarkMcpClient>();
-        for (var index = 0; index < 4; index++)
+        for (var index = 0; index < SessionRunspaceCapacity; index++)
         {
             var client = _server!.CreateClient();
             await client.InitializeAsync().ConfigureAwait(false);
@@ -107,7 +112,7 @@ public class HttpSessionBenchmark
     [InvocationCount(1)]
     public async Task FirstHttpSessionLatency()
     {
-        await using var server = await BenchmarkHttpServer.StartAsync().ConfigureAwait(false);
+        await using var server = await BenchmarkHttpServer.StartAsync(SessionRunspaceCapacity).ConfigureAwait(false);
         await using var client = server.CreateClient();
         await client.InitializeAsync().ConfigureAwait(false);
         using var response = await client.CallGetDateAsync().ConfigureAwait(false);
@@ -144,11 +149,16 @@ public class HttpSessionBenchmark
         }
     }
 
-    [Benchmark(Description = "Over-capacity session tool call returns without unbounded allocation")]
+    [Benchmark(Description = "Over-capacity session call validates an MCP error response")]
     [InvocationCount(1)]
-    public async Task<int> BoundedCapacityRejection()
+    public async Task BoundedCapacityRejection()
     {
         using var response = await _overflowClient!.CallGetDateAsync().ConfigureAwait(false);
-        return (int)response.StatusCode;
+        response.EnsureSuccessStatusCode();
+        if (!await BenchmarkMcpClient.IsMcpErrorAsync(response).ConfigureAwait(false))
+        {
+            throw new InvalidOperationException(
+                $"Expected an MCP tool error after exhausting {SessionRunspaceCapacity} session runspaces.");
+        }
     }
 }

--- a/PoshMcp.Benchmarks/Scenarios/HttpSessionBenchmark.cs
+++ b/PoshMcp.Benchmarks/Scenarios/HttpSessionBenchmark.cs
@@ -1,0 +1,154 @@
+using BenchmarkDotNet.Attributes;
+
+namespace PoshMcp.Benchmarks.Scenarios;
+
+/// <summary>
+/// Measures the HTTP MCP session path with the same configured module import and
+/// startup script used for every benchmark server process.
+/// </summary>
+[MinIterationCount(3)]
+[MaxIterationCount(10)]
+public class HttpSessionBenchmark
+{
+    private BenchmarkHttpServer? _server;
+    private BenchmarkMcpClient? _warmClient;
+    private List<BenchmarkMcpClient>? _throughputClients;
+    private List<BenchmarkMcpClient>? _capacityClients;
+    private BenchmarkMcpClient? _overflowClient;
+
+    [GlobalSetup(Target = nameof(WarmSessionToolLatency))]
+    public async Task StartWarmSessionAsync()
+    {
+        _server = await BenchmarkHttpServer.StartAsync().ConfigureAwait(false);
+        _warmClient = _server!.CreateClient();
+        await _warmClient.InitializeAsync().ConfigureAwait(false);
+        using var response = await _warmClient.CallGetDateAsync().ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+    }
+
+    [GlobalSetup(Target = nameof(ConcurrentWarmSessionThroughput))]
+    public async Task StartConcurrentWarmSessionsAsync()
+    {
+        _server = await BenchmarkHttpServer.StartAsync().ConfigureAwait(false);
+        _throughputClients = new List<BenchmarkMcpClient>();
+        for (var index = 0; index < 4; index++)
+        {
+            var client = _server.CreateClient();
+            await client.InitializeAsync().ConfigureAwait(false);
+            using var response = await client.CallGetDateAsync().ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            _throughputClients.Add(client);
+        }
+    }
+
+    [GlobalSetup(Target = nameof(BoundedCapacityRejection))]
+    public async Task FillCapacityAsync()
+    {
+        _server = await BenchmarkHttpServer.StartAsync().ConfigureAwait(false);
+        _capacityClients = new List<BenchmarkMcpClient>();
+        for (var index = 0; index < 4; index++)
+        {
+            var client = _server!.CreateClient();
+            await client.InitializeAsync().ConfigureAwait(false);
+            using var response = await client.CallGetDateAsync().ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            _capacityClients.Add(client);
+        }
+    }
+
+    [IterationSetup(Target = nameof(BoundedCapacityRejection))]
+    public void StartOverflowSession()
+    {
+        _overflowClient = _server!.CreateClient();
+        _overflowClient.InitializeAsync().GetAwaiter().GetResult();
+    }
+
+    [IterationCleanup(Target = nameof(BoundedCapacityRejection))]
+    public void DisposeOverflowSession()
+    {
+        if (_overflowClient is not null)
+        {
+            _overflowClient.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            _overflowClient = null;
+        }
+    }
+
+    [GlobalCleanup]
+    public async Task CleanupAsync()
+    {
+        if (_warmClient is not null)
+        {
+            await _warmClient.DisposeAsync().ConfigureAwait(false);
+        }
+
+        if (_capacityClients is not null)
+        {
+            foreach (var client in _capacityClients)
+            {
+                await client.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        if (_throughputClients is not null)
+        {
+            foreach (var client in _throughputClients)
+            {
+                await client.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        if (_server is not null)
+        {
+            await _server.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    [Benchmark(Description = "HTTP server startup + first session tool call (module/setup included)")]
+    [InvocationCount(1)]
+    public async Task FirstHttpSessionLatency()
+    {
+        await using var server = await BenchmarkHttpServer.StartAsync().ConfigureAwait(false);
+        await using var client = server.CreateClient();
+        await client.InitializeAsync().ConfigureAwait(false);
+        using var response = await client.CallGetDateAsync().ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+    }
+
+    [Benchmark(Description = "Warm HTTP session tool-call latency")]
+    public async Task WarmSessionToolLatency()
+    {
+        using var response = await _warmClient!.CallGetDateAsync().ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+    }
+
+    [Benchmark(Description = "Concurrent warm-session throughput")]
+    [Arguments(4)]
+    public async Task ConcurrentWarmSessionThroughput(int concurrency)
+    {
+        var responses = await Task.WhenAll(_throughputClients!
+            .Take(concurrency)
+            .Select(client => client.CallGetDateAsync())).ConfigureAwait(false);
+        try
+        {
+            foreach (var response in responses)
+            {
+                response.EnsureSuccessStatusCode();
+            }
+        }
+        finally
+        {
+            foreach (var response in responses)
+            {
+                response.Dispose();
+            }
+        }
+    }
+
+    [Benchmark(Description = "Over-capacity session tool call returns without unbounded allocation")]
+    [InvocationCount(1)]
+    public async Task<int> BoundedCapacityRejection()
+    {
+        using var response = await _overflowClient!.CallGetDateAsync().ConfigureAwait(false);
+        return (int)response.StatusCode;
+    }
+}

--- a/PoshMcp.Server/McpServerConfiguration.cs
+++ b/PoshMcp.Server/McpServerConfiguration.cs
@@ -12,6 +12,21 @@ public class McpServerConfiguration
     /// </summary>
     public int IdleSessionTimeoutSeconds { get; set; } = 60;
 
+    /// <summary>Maximum number of stateful PowerShell runspaces assigned to HTTP MCP sessions.</summary>
+    public int SessionRunspaceCapacity { get; set; } = 16;
+
+    /// <summary>Seconds an inactive session runspace is retained before it is released.</summary>
+    public int SessionRunspaceIdleTtlSeconds { get; set; } = 300;
+
+    /// <summary>Seconds between idle runspace sweeps.</summary>
+    public int SessionRunspaceSweepIntervalSeconds { get; set; } = 30;
+
+    /// <summary>Number of clean initialized runspaces kept ready for newly created sessions.</summary>
+    public int SessionRunspaceWarmStandbyCount { get; set; } = 2;
+
+    /// <summary>Seconds to wait for session runspace capacity before failing acquisition.</summary>
+    public int SessionRunspaceAcquisitionTimeoutSeconds { get; set; } = 15;
+
     /// <summary>
     /// Enables the deprecated HTTP-with-SSE endpoints for clients that cannot use
     /// the Streamable HTTP transport. Disabled by default.

--- a/PoshMcp.Server/McpServerConfiguration.cs
+++ b/PoshMcp.Server/McpServerConfiguration.cs
@@ -11,4 +11,10 @@ public class McpServerConfiguration
     /// Default: 60 seconds.
     /// </summary>
     public int IdleSessionTimeoutSeconds { get; set; } = 60;
+
+    /// <summary>
+    /// Enables the deprecated HTTP-with-SSE endpoints for clients that cannot use
+    /// the Streamable HTTP transport. Disabled by default.
+    /// </summary>
+    public bool EnableLegacySse { get; set; }
 }

--- a/PoshMcp.Server/McpToolFactoryV2.cs
+++ b/PoshMcp.Server/McpToolFactoryV2.cs
@@ -996,7 +996,10 @@ public class McpToolFactoryV2
 
         try
         {
-            return McpServerTool.Create(methodDelegate, options);
+            var tool = McpServerTool.Create(methodDelegate, options);
+            return McpToolSchema.HasOnlyInfrastructureParameters(method)
+                ? McpToolSchema.ApplyStrictEmptyObjectSchema(tool)
+                : tool;
         }
         catch (InvalidOperationException ex) when (ex.Message.Contains("pointer type") || ex.Message.Contains("ref struct"))
         {

--- a/PoshMcp.Server/McpToolSchema.cs
+++ b/PoshMcp.Server/McpToolSchema.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading;
+using ModelContextProtocol.Server;
+
+namespace PoshMcp;
+
+internal static class McpToolSchema
+{
+    private const string StrictEmptyObjectSchema = """
+        {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": false
+        }
+        """;
+
+    public static bool HasOnlyInfrastructureParameters(MethodInfo method)
+    {
+        ArgumentNullException.ThrowIfNull(method);
+
+        foreach (var parameter in method.GetParameters())
+        {
+            if (parameter.ParameterType != typeof(CancellationToken))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static McpServerTool ApplyStrictEmptyObjectSchema(McpServerTool tool)
+    {
+        ArgumentNullException.ThrowIfNull(tool);
+
+        tool.ProtocolTool.InputSchema = JsonDocument.Parse(StrictEmptyObjectSchema).RootElement.Clone();
+        return tool;
+    }
+}

--- a/PoshMcp.Server/PoshMcp.csproj
+++ b/PoshMcp.Server/PoshMcp.csproj
@@ -38,10 +38,10 @@
   <ItemGroup>
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.1" />
 
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.6.0" />
-    <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.1" />
   <PackageReference Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessCommandExecutor.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessCommandExecutor.cs
@@ -319,12 +319,16 @@ public class OutOfProcessCommandExecutor : ICommandExecutor
             result = await host.SendRequestAsync<JsonElement>("invoke", invokeParams, cancellationToken)
                 .ConfigureAwait(false);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Cancellation is delivered to pwsh as a best-effort control frame.
+            // Never reuse that process: a host may acknowledge cancellation before
+            // an interrupted pipeline has completely unwound.
+            await QuarantineAndReplaceHostAsync(host).ConfigureAwait(false);
+            throw;
+        }
         catch (InvalidOperationException ex) when (!_disposed && IsSubprocessDead(host, ex))
         {
-            // The pwsh subprocess died (e.g. a user command terminated the host).
-            // Restart it, replay the cached environment setup, and retry the
-            // invoke exactly once so the caller sees a normal failure path
-            // rather than a permanent "OOP subprocess is not running" error.
             _logger.LogWarning(ex,
                 "OOP subprocess died while invoking '{CommandName}'. Restarting and retrying once.",
                 commandName);
@@ -394,50 +398,27 @@ public class OutOfProcessCommandExecutor : ICommandExecutor
     }
 
     /// <summary>
-    /// Returns true when <paramref name="ex"/> indicates that the supplied
-    /// <paramref name="host"/>'s subprocess has died (either before the send
-    /// or while the request was in flight). Used to gate the
-    /// restart-and-retry path in <see cref="InvokeAsync"/>.
+    /// Quarantines an interrupted host, starts a clean replacement, and replays
+    /// the latest setup. The cancelled command is intentionally never retried.
     /// </summary>
-    private static bool IsSubprocessDead(OutOfProcessHost host, InvalidOperationException ex)
+    private async Task QuarantineAndReplaceHostAsync(OutOfProcessHost interruptedHost)
     {
-        if (!host.IsRunning) return true;
-
-        // SendRequestAsync throws this exact message when the process has
-        // exited before the call; match defensively so we still recover even
-        // if IsRunning briefly disagrees with HasExited.
-        return ex.Message.Contains("OOP subprocess is not running", StringComparison.Ordinal);
-    }
-
-    /// <summary>
-    /// Disposes the current <see cref="OutOfProcessHost"/>, starts a new one,
-    /// and replays the cached environment setup (if any). Serialized so
-    /// concurrent failed invokes only trigger a single restart.
-    /// </summary>
-    private async Task<OutOfProcessHost> RestartHostAsync(CancellationToken cancellationToken)
-    {
-        ObjectDisposedException.ThrowIf(_disposed, this);
-
-        await _restartLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await _restartLock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
         try
         {
-            // Another waiter may have already restarted while we were queued.
-            if (_host is { IsRunning: true })
+            if (_disposed || !ReferenceEquals(_host, interruptedHost))
             {
-                return _host;
+                return;
             }
 
-            if (_host is not null)
+            _host = null;
+            try
             {
-                try
-                {
-                    await _host.DisposeAsync().ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogDebug(ex, "Disposing dead OOP host before restart raised an exception.");
-                }
-                _host = null;
+                await interruptedHost.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Quarantined OOP host cleanup failed.");
             }
 
             var scriptPath = await ResolveHostScriptPathAsync().ConfigureAwait(false);
@@ -447,7 +428,7 @@ public class OutOfProcessCommandExecutor : ICommandExecutor
             var newHost = new OutOfProcessHost(pwshPath, scriptPath, hostLogger, _requestTimeout);
             try
             {
-                await newHost.StartAsync(cancellationToken).ConfigureAwait(false);
+                await newHost.StartAsync(CancellationToken.None).ConfigureAwait(false);
             }
             catch
             {
@@ -467,7 +448,7 @@ public class OutOfProcessCommandExecutor : ICommandExecutor
                         _lastSetupConfigFilePath,
                         _lastSetupTimeout,
                         _lastDiscoveryModules,
-                        cancellationToken).ConfigureAwait(false);
+                        CancellationToken.None).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -476,11 +457,61 @@ public class OutOfProcessCommandExecutor : ICommandExecutor
                 }
             }
 
-            return newHost;
         }
         finally
         {
             try { _restartLock.Release(); } catch (ObjectDisposedException) { /* shutting down */ }
+        }
+    }
+
+    private static bool IsSubprocessDead(OutOfProcessHost host, InvalidOperationException ex) =>
+        !host.IsRunning
+        || ex.Message.Contains("OOP subprocess is not running", StringComparison.Ordinal);
+
+    private async Task<OutOfProcessHost> RestartHostAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        await _restartLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_host is { IsRunning: true })
+                return _host;
+
+            if (_host is not null)
+            {
+                try { await _host.DisposeAsync().ConfigureAwait(false); }
+                catch (Exception ex) { _logger.LogDebug(ex, "Disposing dead OOP host before restart failed."); }
+                _host = null;
+            }
+
+            var scriptPath = await ResolveHostScriptPathAsync().ConfigureAwait(false);
+            var newHost = new OutOfProcessHost(
+                ResolvePwshPath(), scriptPath,
+                _loggerFactory.CreateLogger<OutOfProcessHost>(), _requestTimeout);
+            try
+            {
+                await newHost.StartAsync(cancellationToken).ConfigureAwait(false);
+                _host = newHost;
+
+                if (_lastSetupConfig is not null)
+                {
+                    await SendSetupAsync(newHost, _lastSetupConfig, _lastSetupConfigFilePath,
+                        _lastSetupTimeout, _lastDiscoveryModules, cancellationToken).ConfigureAwait(false);
+                }
+
+                return newHost;
+            }
+            catch
+            {
+                await newHost.DisposeAsync().ConfigureAwait(false);
+                _host = null;
+                throw;
+            }
+        }
+        finally
+        {
+            try { _restartLock.Release(); } catch (ObjectDisposedException) { }
         }
     }
 

--- a/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessSubprocessPool.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessSubprocessPool.cs
@@ -98,6 +98,9 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
             });
 
     private readonly object _envLock = new();
+    private readonly object _cleanupLock = new();
+    private readonly HashSet<Task> _pendingCleanupTasks = new();
+    private readonly List<Exception> _asynchronousCleanupFailures = new();
     // Serializes the point at which a caller obtains a host with the currently
     // configured environment. It is deliberately not held for command execution:
     // reloads let existing work finish, but prevent new work from leasing stale hosts.
@@ -144,6 +147,12 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
         if (options.MinHealthyForStartup > options.PoolSize)
             throw new ArgumentOutOfRangeException(nameof(options),
                 "MinHealthyForStartup must be <= PoolSize.");
+        if (options.CleanupTimeout <= TimeSpan.Zero
+            || options.CleanupTimeout == Timeout.InfiniteTimeSpan)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options),
+                "CleanupTimeout must be a positive, finite duration.");
+        }
 
         _pwshPath = pwshPath;
         _hostScriptPath = hostScriptPath;
@@ -539,7 +548,14 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
     }
 
     /// <inheritdoc />
-    public async ValueTask DisposeAsync()
+    public ValueTask DisposeAsync() => DisposeAsync(CancellationToken.None);
+
+    /// <summary>
+    /// Stops the pool without allowing a stuck worker teardown to block shutdown
+    /// indefinitely. Cleanup failures are logged and returned to the caller as an
+    /// aggregate after all cleanup attempts have been given the configured bound.
+    /// </summary>
+    public async ValueTask DisposeAsync(CancellationToken cancellationToken)
     {
         if (_disposed) return;
         _disposed = true;
@@ -548,35 +564,100 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
 
         _available.Writer.TryComplete();
 
+        var cleanupFailures = new List<Exception>();
+
         if (_reconcilerCts is not null)
         {
-            try { _reconcilerCts.Cancel(); } catch { /* ignore */ }
+            try
+            {
+                _reconcilerCts.Cancel();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to cancel OOP subprocess pool reconciler.");
+                cleanupFailures.Add(ex);
+            }
         }
 
         if (_reconcilerTask is not null)
         {
-            try { await _reconcilerTask.ConfigureAwait(false); }
-            catch { /* reconciler exits on cancel */ }
+            var failure = await AwaitCleanupAsync(
+                _reconcilerTask, "OOP subprocess pool reconciler", cancellationToken)
+                .ConfigureAwait(false);
+            if (failure is not null)
+                cleanupFailures.Add(failure);
         }
 
-        var disposeTasks = _slots
+        foreach (var host in _slots
             .Select(kvp => kvp.Value)
             .Where(s => s.Host is not null)
-            .Select(s => s.Host!.DisposeAsync().AsTask())
-            .ToArray();
+            .Select(s => (Host: s.Host!, SlotIndex: s.Index)))
+        {
+            _ = TrackHostCleanup(host.Host, host.SlotIndex);
+        }
 
-        try
+        Task[] cleanupTasks;
+        lock (_cleanupLock)
         {
-            await Task.WhenAll(disposeTasks).ConfigureAwait(false);
+            cleanupTasks = _pendingCleanupTasks.ToArray();
+            cleanupFailures.AddRange(_asynchronousCleanupFailures);
+            _asynchronousCleanupFailures.Clear();
         }
-        catch
-        {
-            // Best-effort.
-        }
+
+        var cleanupResults = await Task.WhenAll(cleanupTasks.Select(task =>
+            AwaitCleanupAsync(task, "OOP subprocess host", cancellationToken))).ConfigureAwait(false);
+        cleanupFailures.AddRange(cleanupResults.OfType<Exception>());
 
         _slots.Clear();
         _reconcilerCts?.Dispose();
         _reloadGate.Dispose();
+
+        if (cleanupFailures.Count > 0)
+        {
+            throw new AggregateException(
+                "One or more OOP subprocess pool cleanup operations failed.",
+                cleanupFailures);
+        }
+    }
+
+    /// <summary>
+    /// Waits for cleanup with a deterministic timeout source and returns failures
+    /// instead of allowing cleanup to hide the operation that triggered it.
+    /// </summary>
+    internal async Task<Exception?> AwaitCleanupAsync(
+        Task cleanupTask,
+        string operation,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(cleanupTask);
+
+        var timeoutTask = Task.Delay(
+            _options.CleanupTimeout,
+            _options.TimeProvider,
+            cancellationToken);
+        var completed = await Task.WhenAny(cleanupTask, timeoutTask).ConfigureAwait(false);
+
+        if (completed != cleanupTask)
+        {
+            Exception failure = cancellationToken.IsCancellationRequested
+                ? new OperationCanceledException(
+                    $"Cleanup of {operation} was cancelled.", cancellationToken)
+                : new TimeoutException(
+                    $"Cleanup of {operation} exceeded {_options.CleanupTimeout}.");
+            _logger.LogError(failure, "OOP cleanup did not complete: {Operation}.", operation);
+            return failure;
+        }
+
+        try
+        {
+            await cleanupTask.ConfigureAwait(false);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "OOP cleanup failed: {Operation}.", operation);
+            return ex;
+        }
     }
 
     // ---- Internal helpers (visible to tests) ----
@@ -653,7 +734,10 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
         }
         catch
         {
-            try { await host.DisposeAsync().ConfigureAwait(false); } catch { /* ignore */ }
+            await AwaitCleanupAsync(
+                TrackHostCleanup(host, index),
+                $"failed startup host for slot {index}",
+                cancellationToken).ConfigureAwait(false);
             slot.Status = HostStatus.Dead;
 
             if (failFast)
@@ -894,13 +978,7 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
         var host = slot.Host;
         if (host is not null)
         {
-            // Fire-and-forget kill — synchronous Kill on Process is fine here since
-            // OutOfProcessHost.DisposeAsync is the proper teardown path.
-            _ = Task.Run(async () =>
-            {
-                try { await host.DisposeAsync().ConfigureAwait(false); }
-                catch { /* best-effort */ }
-            });
+            TrackHostCleanup(host, slot.Index);
             slot.Host = null;
         }
 
@@ -931,8 +1009,9 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
                     .Where(s => s.Status == HostStatus.Dead)
                     .ToArray();
             }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogWarning(ex, "Failed to enumerate OOP subprocess pool slots for reconciliation.");
                 continue;
             }
 
@@ -991,8 +1070,10 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
 
                     if (slot.Host is not null)
                     {
-                        try { await slot.Host.DisposeAsync().ConfigureAwait(false); }
-                        catch { /* ignore */ }
+                        await AwaitCleanupAsync(
+                            TrackHostCleanup(slot.Host, slot.Index),
+                            $"failed replacement host for slot {slot.Index}",
+                            cancellationToken).ConfigureAwait(false);
                         slot.Host = null;
                     }
 
@@ -1006,6 +1087,51 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
     {
         if (!_started)
             throw new InvalidOperationException("Pool has not been started. Call StartAsync first.");
+    }
+
+    private Task TrackHostCleanup(OutOfProcessHost host, int slotIndex)
+    {
+        Task cleanupTask;
+        try
+        {
+            cleanupTask = host.DisposeAsync().AsTask();
+        }
+        catch (Exception ex)
+        {
+            cleanupTask = Task.FromException(ex);
+        }
+
+        lock (_cleanupLock)
+        {
+            _pendingCleanupTasks.Add(cleanupTask);
+        }
+
+        _ = cleanupTask.ContinueWith(
+            task =>
+            {
+                lock (_cleanupLock)
+                {
+                    _pendingCleanupTasks.Remove(task);
+                }
+
+                if (task.IsFaulted)
+                {
+                    var exception = task.Exception!;
+                    lock (_cleanupLock)
+                    {
+                        _asynchronousCleanupFailures.Add(exception);
+                    }
+                    _logger.LogError(
+                        exception,
+                        "OOP subprocess cleanup faulted asynchronously for slot {Index}.",
+                        slotIndex);
+                }
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        return cleanupTask;
     }
 
     /// <summary>
@@ -1108,4 +1234,16 @@ public sealed class OutOfProcessSubprocessPoolOptions
     /// replacements. Default: 1 second.
     /// </summary>
     public TimeSpan ReconcilerInterval { get; init; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Maximum time shutdown waits for each worker or reconciler cleanup task.
+    /// Worker teardown continues to be observed and logged after this bound expires.
+    /// </summary>
+    public TimeSpan CleanupTimeout { get; init; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Time source used for cleanup bounds. Internal to keep production configuration
+    /// stable while enabling deterministic lifecycle tests.
+    /// </summary>
+    internal TimeProvider TimeProvider { get; init; } = TimeProvider.System;
 }

--- a/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessSubprocessPool.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessSubprocessPool.cs
@@ -100,7 +100,6 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
     private readonly object _envLock = new();
     private readonly object _cleanupLock = new();
     private readonly HashSet<Task> _pendingCleanupTasks = new();
-    private readonly List<Exception> _asynchronousCleanupFailures = new();
     // Serializes the point at which a caller obtains a host with the currently
     // configured environment. It is deliberately not held for command execution:
     // reloads let existing work finish, but prevent new work from leasing stale hosts.
@@ -153,6 +152,11 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
             throw new ArgumentOutOfRangeException(nameof(options),
                 "CleanupTimeout must be a positive, finite duration.");
         }
+        if (options.MaxTrackedCleanupOperations < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options),
+                "MaxTrackedCleanupOperations must be >= 1.");
+        }
 
         _pwshPath = pwshPath;
         _hostScriptPath = hostScriptPath;
@@ -186,6 +190,14 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
     /// Configured pool size (constant).
     /// </summary>
     public int PoolSize => _options.PoolSize;
+
+    /// <summary>
+    /// Number of cleanup operations currently retained for bounded shutdown waiting.
+    /// </summary>
+    internal int PendingCleanupTaskCount
+    {
+        get { lock (_cleanupLock) { return _pendingCleanupTasks.Count; } }
+    }
 
     /// <inheritdoc />
     public async Task StartAsync(CancellationToken cancellationToken = default)
@@ -588,20 +600,18 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
                 cleanupFailures.Add(failure);
         }
 
+        var cleanupTasks = new HashSet<Task>();
         foreach (var host in _slots
             .Select(kvp => kvp.Value)
             .Where(s => s.Host is not null)
             .Select(s => (Host: s.Host!, SlotIndex: s.Index)))
         {
-            _ = TrackHostCleanup(host.Host, host.SlotIndex);
+            cleanupTasks.Add(TrackHostCleanup(host.Host, host.SlotIndex));
         }
 
-        Task[] cleanupTasks;
         lock (_cleanupLock)
         {
-            cleanupTasks = _pendingCleanupTasks.ToArray();
-            cleanupFailures.AddRange(_asynchronousCleanupFailures);
-            _asynchronousCleanupFailures.Clear();
+            cleanupTasks.UnionWith(_pendingCleanupTasks);
         }
 
         var cleanupResults = await Task.WhenAll(cleanupTasks.Select(task =>
@@ -1101,26 +1111,45 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
             cleanupTask = Task.FromException(ex);
         }
 
+        return TrackCleanupTask(cleanupTask, slotIndex);
+    }
+
+    internal Task TrackCleanupTask(Task cleanupTask, int slotIndex)
+    {
+        ArgumentNullException.ThrowIfNull(cleanupTask);
+
+        var tracked = false;
         lock (_cleanupLock)
         {
-            _pendingCleanupTasks.Add(cleanupTask);
+            if (_pendingCleanupTasks.Count < _options.MaxTrackedCleanupOperations)
+            {
+                tracked = _pendingCleanupTasks.Add(cleanupTask);
+            }
+        }
+
+        if (!tracked)
+        {
+            _logger.LogWarning(
+                "OOP cleanup tracking capacity ({Capacity}) reached; cleanup for slot {Index} " +
+                "will continue without retained shutdown tracking.",
+                _options.MaxTrackedCleanupOperations,
+                slotIndex);
         }
 
         _ = cleanupTask.ContinueWith(
             task =>
             {
-                lock (_cleanupLock)
+                if (tracked)
                 {
-                    _pendingCleanupTasks.Remove(task);
+                    lock (_cleanupLock)
+                    {
+                        _pendingCleanupTasks.Remove(task);
+                    }
                 }
 
                 if (task.IsFaulted)
                 {
                     var exception = task.Exception!;
-                    lock (_cleanupLock)
-                    {
-                        _asynchronousCleanupFailures.Add(exception);
-                    }
                     _logger.LogError(
                         exception,
                         "OOP subprocess cleanup faulted asynchronously for slot {Index}.",
@@ -1240,6 +1269,12 @@ public sealed class OutOfProcessSubprocessPoolOptions
     /// Worker teardown continues to be observed and logged after this bound expires.
     /// </summary>
     public TimeSpan CleanupTimeout { get; init; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Maximum number of incomplete cleanup operations retained for shutdown waiting.
+    /// Additional operations are still observed and logged, but are not retained.
+    /// </summary>
+    public int MaxTrackedCleanupOperations { get; init; } = 16;
 
     /// <summary>
     /// Time source used for cleanup bounds. Internal to keep production configuration

--- a/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessSubprocessPool.cs
+++ b/PoshMcp.Server/PowerShell/OutOfProcess/OutOfProcessSubprocessPool.cs
@@ -98,6 +98,10 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
             });
 
     private readonly object _envLock = new();
+    // Serializes the point at which a caller obtains a host with the currently
+    // configured environment. It is deliberately not held for command execution:
+    // reloads let existing work finish, but prevent new work from leasing stale hosts.
+    private readonly SemaphoreSlim _reloadGate = new(1, 1);
     private EnvironmentConfiguration? _cachedEnv;
     private string? _cachedEnvFingerprint;
     private string? _cachedConfigFilePath;
@@ -106,6 +110,7 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
     private IReadOnlyList<RemoteToolSchema>? _cachedSchemas;
     private string? _cachedSchemasFingerprint;
     private RemoteModuleImportsPayload? _cachedModuleImports;
+    private long _generation;
 
     /// <inheritdoc />
     public RemoteModuleImportsPayload? LastModuleImports
@@ -269,55 +274,69 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
         var discoveryModulesArr = discoveryModules?.ToArray();
         var fingerprint = ComputeEnvironmentFingerprint(config, discoveryModulesArr);
 
-        lock (_envLock)
+        await _reloadGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
-            _cachedEnv = config;
-            _cachedEnvFingerprint = fingerprint;
-            _cachedConfigFilePath = configFilePath;
-            _cachedSetupTimeout = setupRequestTimeout;
-            _cachedDiscoveryModules = discoveryModulesArr;
-
-            // Invalidate schema cache if the fingerprint changed.
-            if (_cachedSchemasFingerprint is not null
-                && !string.Equals(_cachedSchemasFingerprint, fingerprint, StringComparison.Ordinal))
+            var generation = Interlocked.Increment(ref _generation);
+            lock (_envLock)
             {
-                _logger.LogDebug(
-                    "Environment fingerprint changed ({Old} -> {New}); invalidating discovery cache.",
-                    _cachedSchemasFingerprint, fingerprint);
-                _cachedSchemas = null;
-                _cachedSchemasFingerprint = null;
-                _cachedModuleImports = null;
+                _cachedEnv = config;
+                _cachedEnvFingerprint = fingerprint;
+                _cachedConfigFilePath = configFilePath;
+                _cachedSetupTimeout = setupRequestTimeout;
+                _cachedDiscoveryModules = discoveryModulesArr;
+
+                if (_cachedSchemasFingerprint is not null
+                    && !string.Equals(_cachedSchemasFingerprint, fingerprint, StringComparison.Ordinal))
+                {
+                    _logger.LogDebug(
+                        "Environment fingerprint changed ({Old} -> {New}); invalidating discovery cache.",
+                        _cachedSchemasFingerprint, fingerprint);
+                    _cachedSchemas = null;
+                    _cachedSchemasFingerprint = null;
+                    _cachedModuleImports = null;
+                }
             }
+
+            // The gate prevents a Healthy slot becoming leased while setup is sent.
+            // Existing leases are never reconfigured in-flight: they finish against
+            // their original environment and are retired when returned.
+            var snapshot = _slots.Values.ToArray();
+            var idleSlots = snapshot.Where(slot => slot.Status == HostStatus.Healthy).ToArray();
+            foreach (var leasedSlot in snapshot.Where(slot => slot.Status == HostStatus.Leased))
+            {
+                leasedSlot.RetireOnReturn = true;
+            }
+
+            _logger.LogInformation(
+                "Applying environment generation {Generation} to {Count} idle hosts; {Retiring} active hosts will drain.",
+                generation, idleSlots.Length, snapshot.Count(slot => slot.Status == HostStatus.Leased));
+
+            var setupTasks = idleSlots.Select(async slot =>
+            {
+                try
+                {
+                    await ApplySetupToHostAsync(slot, config, configFilePath,
+                        setupRequestTimeout, discoveryModulesArr, cancellationToken)
+                        .ConfigureAwait(false);
+                    slot.Generation = generation;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex,
+                        "Setup failed on slot {Index}; marking dead for reconciliation.",
+                        slot.Index);
+                    MarkSlotDead(slot);
+                    throw;
+                }
+            }).ToArray();
+
+            await Task.WhenAll(setupTasks).ConfigureAwait(false);
         }
-
-        // Apply setup to every currently-healthy host in parallel.
-        var snapshot = _slots
-            .Where(kvp => kvp.Value.Status is HostStatus.Healthy or HostStatus.Leased)
-            .Select(kvp => kvp.Value)
-            .ToArray();
-
-        _logger.LogInformation(
-            "Applying environment setup to {Count} hosts (fingerprint: {Fingerprint}).",
-            snapshot.Length, fingerprint);
-
-        var setupTasks = snapshot.Select(slot => Task.Run(async () =>
+        finally
         {
-            try
-            {
-                await ApplySetupToHostAsync(slot, config, configFilePath,
-                    setupRequestTimeout, discoveryModulesArr, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex,
-                    "Setup failed on slot {Index}; marking dead for reconciliation.",
-                    slot.Index);
-                MarkSlotDead(slot);
-            }
-        }, cancellationToken)).ToArray();
-
-        await Task.WhenAll(setupTasks).ConfigureAwait(false);
+            _reloadGate.Release();
+        }
     }
 
     /// <inheritdoc />
@@ -351,7 +370,7 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
             excludePatterns = config.ExcludePatterns
         };
 
-        await using var lease = await LeaseAsync(cancellationToken).ConfigureAwait(false);
+        await using var lease = await LeaseCurrentGenerationAsync(cancellationToken).ConfigureAwait(false);
         var host = lease.Host;
 
         _logger.LogInformation(
@@ -418,7 +437,7 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
         ObjectDisposedException.ThrowIf(_disposed, this);
         EnsureStarted();
 
-        await using var lease = await LeaseAsync(cancellationToken).ConfigureAwait(false);
+        await using var lease = await LeaseCurrentGenerationAsync(cancellationToken).ConfigureAwait(false);
         var host = lease.Host;
         var slotIndex = lease.SlotIndex;
 
@@ -463,6 +482,17 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
             // mode: only this slot dies; the rest of the pool keeps serving.
             _logger.LogWarning(tex,
                 "Invoke '{CommandName}' timed out on slot {Index}; killing host.",
+                commandName, slotIndex);
+            lease.MarkBroken();
+            throw;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // A cancel frame is best-effort. Do not put a host whose pipeline was
+            // interrupted back into rotation; replacement is safer than reusing
+            // potentially contaminated runspace/process state.
+            _logger.LogInformation(
+                "Invoke '{CommandName}' was cancelled on slot {Index}; quarantining host.",
                 commandName, slotIndex);
             lease.MarkBroken();
             throw;
@@ -546,6 +576,7 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
 
         _slots.Clear();
         _reconcilerCts?.Dispose();
+        _reloadGate.Dispose();
     }
 
     // ---- Internal helpers (visible to tests) ----
@@ -674,6 +705,8 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
                 }
             }
         }
+
+        slot.Generation = Volatile.Read(ref _generation);
 
         return slot;
     }
@@ -809,11 +842,13 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
                 throw new InvalidOperationException("Pool is shut down.", ex);
             }
 
-            if (slot.Status != HostStatus.Healthy || slot.Host is null || !slot.Host.IsRunning)
+            if (slot.Status != HostStatus.Healthy || slot.Host is null || !slot.Host.IsRunning
+                || slot.RetireOnReturn || slot.Generation != Volatile.Read(ref _generation))
             {
                 _logger.LogDebug(
-                    "Skipping stale lease for slot {Index} (status={Status}).",
-                    slot.Index, slot.Status);
+                    "Skipping stale lease for slot {Index} (status={Status}, generation={Generation}).",
+                    slot.Index, slot.Status, slot.Generation);
+                MarkSlotDead(slot);
                 continue;
             }
 
@@ -822,11 +857,24 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
         }
     }
 
+    private async Task<PoolLease> LeaseCurrentGenerationAsync(CancellationToken cancellationToken)
+    {
+        await _reloadGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return await LeaseAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _reloadGate.Release();
+        }
+    }
+
     private void ReturnLease(HostSlot slot, bool broken)
     {
         if (_disposed) return;
 
-        if (broken || slot.Host is null || !slot.Host.IsRunning)
+        if (broken || slot.RetireOnReturn || slot.Host is null || !slot.Host.IsRunning)
         {
             MarkSlotDead(slot);
             return;
@@ -926,6 +974,8 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
                             .ConfigureAwait(false);
                     }
 
+                    slot.Generation = Volatile.Read(ref _generation);
+                    slot.RetireOnReturn = false;
                     slot.FailedReplacements = 0;
                     _available.Writer.TryWrite(slot);
 
@@ -970,6 +1020,8 @@ public sealed class OutOfProcessSubprocessPool : ICommandExecutor
         public volatile HostStatus Status;
         public OutOfProcessHost? Host;
         public int FailedReplacements;
+        public long Generation;
+        public volatile bool RetireOnReturn;
     }
 
     /// <summary>

--- a/PoshMcp.Server/PowerShell/PowerShellAssemblyGenerator.cs
+++ b/PoshMcp.Server/PowerShell/PowerShellAssemblyGenerator.cs
@@ -1015,7 +1015,9 @@ public class PowerShellAssemblyGenerator
                                 safeInvocationId,
                                 stopwatch.ElapsedMilliseconds);
                             ps.Commands.Clear();
-                            return Task.FromResult($"{{\"error\": \"The term '{commandName}' is not recognized as a name of a cmdlet, function, script file, or executable program.\"}}");
+                            return Task.FromException<string>(new InvalidOperationException(
+                                $"The term '{commandName}' is not recognized as a name of a cmdlet, function, script file, or executable program.",
+                                cmdEx));
                         }
                         catch (Exception ex)
                         {
@@ -1028,7 +1030,9 @@ public class PowerShellAssemblyGenerator
                                 safeInvocationId,
                                 stopwatch.ElapsedMilliseconds);
                             ps.Commands.Clear();
-                            return Task.FromResult($"{{\"error\": \"Command execution failed: {ex.Message}\"}}");
+                            return Task.FromException<string>(new InvalidOperationException(
+                                $"Command execution failed: {ex.Message}",
+                                ex));
                         }
 
                         // Handle errors
@@ -1046,7 +1050,8 @@ public class PowerShellAssemblyGenerator
                                 LogSanitizer.Scrub(errorMessage),
                                 stopwatch.ElapsedMilliseconds);
                             ps.Commands.Clear();
-                            return Task.FromResult($"{{\"error\": \"Command completed with errors: {errorMessage}\"}}");
+                            return Task.FromException<string>(new InvalidOperationException(
+                                $"Command completed with errors: {errorMessage}"));
                         }
 
                         // Convert results to JSON using System.Text.Json (much faster than PowerShell's ConvertTo-Json)
@@ -1098,7 +1103,9 @@ public class PowerShellAssemblyGenerator
                                 safeInvocationId,
                                 stopwatch.ElapsedMilliseconds);
                             ps.Commands.Clear();
-                            return Task.FromResult($"{{\"error\": \"Failed to serialize results to JSON: {ex.Message}\"}}");
+                            return Task.FromException<string>(new InvalidOperationException(
+                                $"Failed to serialize results to JSON: {ex.Message}",
+                                ex));
                         }
                     }
                     catch (OperationCanceledException ex)
@@ -1140,7 +1147,9 @@ public class PowerShellAssemblyGenerator
                             safeInvocationId,
                             stopwatch.ElapsedMilliseconds);
                         ps.Commands.Clear();
-                        return Task.FromResult($"{{\"error\": \"Unexpected error: {ex.Message}\"}}");
+                        return Task.FromException<string>(new InvalidOperationException(
+                            $"Unexpected error: {ex.Message}",
+                            ex));
                     }
                 });
             }

--- a/PoshMcp.Server/PowerShell/PowerShellConfigurationReloadService.cs
+++ b/PoshMcp.Server/PowerShell/PowerShellConfigurationReloadService.cs
@@ -20,17 +20,20 @@ public class PowerShellConfigurationReloadService
     private PowerShellConfiguration _currentConfiguration;
     private List<McpServerTool> _currentTools;
     private readonly string _configurationFilePath;
+    private readonly Action? _onConfigurationReloaded;
 
     public PowerShellConfigurationReloadService(
         ILogger<PowerShellConfigurationReloadService> logger,
         McpToolFactoryV2 toolFactory,
         PowerShellConfiguration initialConfiguration,
-        string configurationFilePath)
+        string configurationFilePath,
+        Action? onConfigurationReloaded = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _toolFactory = toolFactory ?? throw new ArgumentNullException(nameof(toolFactory));
         _currentConfiguration = initialConfiguration ?? throw new ArgumentNullException(nameof(initialConfiguration));
         _configurationFilePath = configurationFilePath ?? throw new ArgumentNullException(nameof(configurationFilePath));
+        _onConfigurationReloaded = onConfigurationReloaded;
         _currentTools = new List<McpServerTool>();
     }
 
@@ -159,6 +162,7 @@ public class PowerShellConfigurationReloadService
 
                 // Update current tools list
                 _currentTools = newTools;
+                _onConfigurationReloaded?.Invoke();
 
                 return Task.FromResult(new ConfigurationReloadResult
                 {

--- a/PoshMcp.Server/PowerShell/SessionAwarePowerShellRunspace.cs
+++ b/PoshMcp.Server/PowerShell/SessionAwarePowerShellRunspace.cs
@@ -29,11 +29,11 @@ public sealed class SessionRunspaceOptions
 /// </summary>
 public class SessionAwarePowerShellRunspace : IPowerShellRunspace, IDisposable
 {
-    private const string DefaultSessionId = "default";
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly ILogger<SessionAwarePowerShellRunspace> _logger;
     private readonly ConcurrentDictionary<string, SessionRunspaceEntry> _sessionRunspaces = new(StringComparer.Ordinal);
     private readonly Queue<IsolatedPowerShellRunspace> _warmStandbys = new();
+    private readonly IsolatedPowerShellRunspace _discoveryRunspace;
     private readonly object _gate = new();
     private readonly SessionRunspaceOptions _options;
     private readonly TimeProvider _timeProvider;
@@ -59,6 +59,7 @@ public class SessionAwarePowerShellRunspace : IPowerShellRunspace, IDisposable
         _options = Normalize(options ?? throw new ArgumentNullException(nameof(options)));
         _timeProvider = timeProvider ?? TimeProvider.System;
         _sweepTimer = new Timer(_ => SweepIdleRunspaces(), null, _options.SweepInterval, _options.SweepInterval);
+        _discoveryRunspace = CreateInitializedRunspace();
 
         lock (_gate)
         {
@@ -81,7 +82,7 @@ public class SessionAwarePowerShellRunspace : IPowerShellRunspace, IDisposable
         AcquisitionTimeout = options.AcquisitionTimeout < TimeSpan.Zero ? TimeSpan.Zero : options.AcquisitionTimeout
     };
 
-    private string GetSessionId()
+    private string? GetSessionId()
     {
         var httpContext = _httpContextAccessor.HttpContext;
         if (httpContext?.Request.Headers.TryGetValue("Mcp-Session-Id", out var sessionHeader) == true)
@@ -93,12 +94,17 @@ public class SessionAwarePowerShellRunspace : IPowerShellRunspace, IDisposable
             }
         }
 
-        return DefaultSessionId;
+        return null;
     }
 
     private SessionRunspaceEntry GetSessionRunspace()
     {
         var sessionId = GetSessionId();
+        if (sessionId is null)
+        {
+            throw new InvalidOperationException("A persistent PowerShell runspace requires a non-empty Mcp-Session-Id request header.");
+        }
+
         lock (_gate)
         {
             ThrowIfDisposed_NoLock();
@@ -142,21 +148,51 @@ public class SessionAwarePowerShellRunspace : IPowerShellRunspace, IDisposable
         }
     }
 
-    public PSPowerShell Instance => GetSessionRunspace().Instance;
+    public PSPowerShell Instance
+    {
+        get
+        {
+            if (_httpContextAccessor.HttpContext is null)
+            {
+                return _discoveryRunspace.Instance;
+            }
 
-    public T ExecuteThreadSafe<T>(Func<PSPowerShell, T> operation) =>
+            return GetSessionRunspace().Instance;
+        }
+    }
+
+    public T ExecuteThreadSafe<T>(Func<PSPowerShell, T> operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        return GetSessionId() is null
+            ? ExecuteEphemeral(operation)
+            : GetSessionRunspace().Execute(operation, CompleteReleasedEntry);
+    }
+
+    public void ExecuteThreadSafe(Action<PSPowerShell> operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        if (GetSessionId() is null)
+        {
+            ExecuteEphemeral(operation);
+            return;
+        }
+
         GetSessionRunspace().Execute(operation, CompleteReleasedEntry);
+    }
 
-    public void ExecuteThreadSafe(Action<PSPowerShell> operation) =>
-        GetSessionRunspace().Execute(operation, CompleteReleasedEntry);
-
-    public Task<T> ExecuteThreadSafeAsync<T>(Func<PSPowerShell, Task<T>> operation) =>
-        GetSessionRunspace().ExecuteAsync(operation, CompleteReleasedEntry);
+    public Task<T> ExecuteThreadSafeAsync<T>(Func<PSPowerShell, Task<T>> operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        return GetSessionId() is null
+            ? ExecuteEphemeralAsync(operation)
+            : GetSessionRunspace().ExecuteAsync(operation, CompleteReleasedEntry);
+    }
 
     /// <summary>Releases state for a terminated MCP session without interrupting its active invocation.</summary>
     public void CleanupSession(string sessionId)
     {
-        if (string.IsNullOrWhiteSpace(sessionId) || sessionId == DefaultSessionId)
+        if (string.IsNullOrWhiteSpace(sessionId))
         {
             return;
         }
@@ -209,6 +245,64 @@ public class SessionAwarePowerShellRunspace : IPowerShellRunspace, IDisposable
         lock (_gate)
         {
             entry.Dispose();
+            _ownedSessionRunspaces--;
+            Monitor.PulseAll(_gate);
+            if (!_disposed)
+            {
+                RefillWarmStandbys_NoLock();
+            }
+        }
+    }
+
+    private T ExecuteEphemeral<T>(Func<PSPowerShell, T> operation)
+    {
+        using var runspace = AcquireEphemeralRunspace();
+        return runspace.ExecuteThreadSafe(operation);
+    }
+
+    private void ExecuteEphemeral(Action<PSPowerShell> operation)
+    {
+        using var runspace = AcquireEphemeralRunspace();
+        runspace.ExecuteThreadSafe(operation);
+    }
+
+    private async Task<T> ExecuteEphemeralAsync<T>(Func<PSPowerShell, Task<T>> operation)
+    {
+        using var runspace = AcquireEphemeralRunspace();
+        return await runspace.ExecuteThreadSafeAsync(operation);
+    }
+
+    private EphemeralRunspaceLease AcquireEphemeralRunspace()
+    {
+        lock (_gate)
+        {
+            ThrowIfDisposed_NoLock();
+            var timeout = _options.AcquisitionTimeout;
+            var stopwatch = Stopwatch.StartNew();
+            while (_ownedSessionRunspaces >= _options.Capacity)
+            {
+                var remaining = timeout - stopwatch.Elapsed;
+                if (timeout == TimeSpan.Zero || remaining <= TimeSpan.Zero || !Monitor.Wait(_gate, remaining))
+                {
+                    throw new TimeoutException("Timed out acquiring a one-shot PowerShell runspace for a request without an MCP session.");
+                }
+
+                ThrowIfDisposed_NoLock();
+            }
+
+            var runspace = _warmStandbys.Count > 0
+                ? _warmStandbys.Dequeue()
+                : CreateInitializedRunspace();
+            _ownedSessionRunspaces++;
+            return new EphemeralRunspaceLease(this, runspace);
+        }
+    }
+
+    private void ReleaseEphemeralRunspace(IsolatedPowerShellRunspace runspace)
+    {
+        lock (_gate)
+        {
+            runspace.Dispose();
             _ownedSessionRunspaces--;
             Monitor.PulseAll(_gate);
             if (!_disposed)
@@ -275,11 +369,43 @@ public class SessionAwarePowerShellRunspace : IPowerShellRunspace, IDisposable
             standby.Dispose();
         }
 
+        _discoveryRunspace.Dispose();
+
         foreach (var entry in entries)
         {
             if (entry.RequestRelease())
             {
                 CompleteReleasedEntry(entry);
+            }
+        }
+    }
+
+    private sealed class EphemeralRunspaceLease : IDisposable
+    {
+        private readonly SessionAwarePowerShellRunspace _owner;
+        private IsolatedPowerShellRunspace? _runspace;
+
+        public EphemeralRunspaceLease(SessionAwarePowerShellRunspace owner, IsolatedPowerShellRunspace runspace)
+        {
+            _owner = owner;
+            _runspace = runspace;
+        }
+
+        public T ExecuteThreadSafe<T>(Func<PSPowerShell, T> operation) =>
+            (_runspace ?? throw new ObjectDisposedException(nameof(EphemeralRunspaceLease))).ExecuteThreadSafe(operation);
+
+        public void ExecuteThreadSafe(Action<PSPowerShell> operation) =>
+            (_runspace ?? throw new ObjectDisposedException(nameof(EphemeralRunspaceLease))).ExecuteThreadSafe(operation);
+
+        public Task<T> ExecuteThreadSafeAsync<T>(Func<PSPowerShell, Task<T>> operation) =>
+            (_runspace ?? throw new ObjectDisposedException(nameof(EphemeralRunspaceLease))).ExecuteThreadSafeAsync(operation);
+
+        public void Dispose()
+        {
+            var runspace = Interlocked.Exchange(ref _runspace, null);
+            if (runspace is not null)
+            {
+                _owner.ReleaseEphemeralRunspace(runspace);
             }
         }
     }

--- a/PoshMcp.Server/PowerShell/SessionAwarePowerShellRunspace.cs
+++ b/PoshMcp.Server/PowerShell/SessionAwarePowerShellRunspace.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -10,39 +12,79 @@ using PSPowerShell = System.Management.Automation.PowerShell;
 namespace PoshMcp.Server.PowerShell;
 
 /// <summary>
-/// Proxy PowerShell runspace that delegates to session-specific isolated runspaces.
-/// Registered as a singleton, but creates separate runspace instances per MCP session
-/// identified by the Mcp-Session-Id request header.
+/// Limits and maintains the isolated PowerShell runspaces used by HTTP MCP sessions.
+/// </summary>
+public sealed class SessionRunspaceOptions
+{
+    public int Capacity { get; set; } = 16;
+    public TimeSpan IdleTtl { get; set; } = TimeSpan.FromMinutes(5);
+    public TimeSpan SweepInterval { get; set; } = TimeSpan.FromSeconds(30);
+    public int WarmStandbyCount { get; set; } = 2;
+    public TimeSpan AcquisitionTimeout { get; set; } = TimeSpan.FromSeconds(15);
+}
+
+/// <summary>
+/// Proxy PowerShell runspace that delegates to a bounded, session-specific isolated runspace.
+/// A runspace is never reassigned after it has served a session.
 /// </summary>
 public class SessionAwarePowerShellRunspace : IPowerShellRunspace, IDisposable
 {
+    private const string DefaultSessionId = "default";
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly ILogger<SessionAwarePowerShellRunspace> _logger;
-    private readonly ConcurrentDictionary<string, IsolatedPowerShellRunspace> _sessionRunspaces;
-    private readonly object _lock = new object();
+    private readonly ConcurrentDictionary<string, SessionRunspaceEntry> _sessionRunspaces = new(StringComparer.Ordinal);
+    private readonly Queue<IsolatedPowerShellRunspace> _warmStandbys = new();
+    private readonly object _gate = new();
+    private readonly SessionRunspaceOptions _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly Timer _sweepTimer;
+    private int _ownedSessionRunspaces;
     private bool _disposed;
 
     public SessionAwarePowerShellRunspace(
         IHttpContextAccessor httpContextAccessor,
         ILogger<SessionAwarePowerShellRunspace> logger)
+        : this(httpContextAccessor, logger, new SessionRunspaceOptions())
+    {
+    }
+
+    public SessionAwarePowerShellRunspace(
+        IHttpContextAccessor httpContextAccessor,
+        ILogger<SessionAwarePowerShellRunspace> logger,
+        SessionRunspaceOptions options,
+        TimeProvider? timeProvider = null)
     {
         _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _sessionRunspaces = new ConcurrentDictionary<string, IsolatedPowerShellRunspace>(StringComparer.Ordinal);
+        _options = Normalize(options ?? throw new ArgumentNullException(nameof(options)));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _sweepTimer = new Timer(_ => SweepIdleRunspaces(), null, _options.SweepInterval, _options.SweepInterval);
 
-        _logger.LogInformation("SessionAwarePowerShellRunspace created - runspaces are keyed by Mcp-Session-Id");
+        lock (_gate)
+        {
+            RefillWarmStandbys_NoLock();
+        }
+
+        _logger.LogInformation(
+            "Session runspace manager started with capacity {Capacity}, idle TTL {IdleTtl}, and {WarmStandbyCount} warm standbys",
+            _options.Capacity,
+            _options.IdleTtl,
+            _options.WarmStandbyCount);
     }
+
+    private static SessionRunspaceOptions Normalize(SessionRunspaceOptions options) => new()
+    {
+        Capacity = Math.Max(1, options.Capacity),
+        IdleTtl = options.IdleTtl <= TimeSpan.Zero ? TimeSpan.FromMinutes(5) : options.IdleTtl,
+        SweepInterval = options.SweepInterval <= TimeSpan.Zero ? TimeSpan.FromSeconds(30) : options.SweepInterval,
+        WarmStandbyCount = Math.Max(0, options.WarmStandbyCount),
+        AcquisitionTimeout = options.AcquisitionTimeout < TimeSpan.Zero ? TimeSpan.Zero : options.AcquisitionTimeout
+    };
 
     private string GetSessionId()
     {
         var httpContext = _httpContextAccessor.HttpContext;
-        if (httpContext == null)
-        {
-            _logger.LogDebug("No HTTP context available, using default session");
-            return "default";
-        }
-
-        if (httpContext.Request.Headers.TryGetValue("Mcp-Session-Id", out var sessionHeader))
+        if (httpContext?.Request.Headers.TryGetValue("Mcp-Session-Id", out var sessionHeader) == true)
         {
             var sessionId = sessionHeader.ToString().Trim();
             if (!string.IsNullOrEmpty(sessionId))
@@ -51,106 +93,317 @@ public class SessionAwarePowerShellRunspace : IPowerShellRunspace, IDisposable
             }
         }
 
-        return "default";
+        return DefaultSessionId;
     }
 
-    private IsolatedPowerShellRunspace GetSessionRunspace()
+    private SessionRunspaceEntry GetSessionRunspace()
+    {
+        var sessionId = GetSessionId();
+        lock (_gate)
+        {
+            ThrowIfDisposed_NoLock();
+            if (_sessionRunspaces.TryGetValue(sessionId, out var existing))
+            {
+                existing.Touch(_timeProvider.GetUtcNow());
+                return existing;
+            }
+
+            var timeout = _options.AcquisitionTimeout;
+            var stopwatch = Stopwatch.StartNew();
+            while (_ownedSessionRunspaces >= _options.Capacity)
+            {
+                var remaining = timeout - stopwatch.Elapsed;
+                if (timeout == TimeSpan.Zero || remaining <= TimeSpan.Zero || !Monitor.Wait(_gate, remaining))
+                {
+                    throw new TimeoutException($"Timed out acquiring a PowerShell runspace for MCP session '{sessionId}'.");
+                }
+
+                ThrowIfDisposed_NoLock();
+                if (_sessionRunspaces.TryGetValue(sessionId, out existing))
+                {
+                    existing.Touch(_timeProvider.GetUtcNow());
+                    return existing;
+                }
+            }
+
+            var runspace = _warmStandbys.Count > 0
+                ? _warmStandbys.Dequeue()
+                : CreateInitializedRunspace();
+            var entry = new SessionRunspaceEntry(runspace, _timeProvider.GetUtcNow, _timeProvider.GetUtcNow());
+            if (!_sessionRunspaces.TryAdd(sessionId, entry))
+            {
+                runspace.Dispose();
+                return _sessionRunspaces[sessionId];
+            }
+
+            _ownedSessionRunspaces++;
+            _logger.LogInformation("Assigned clean PowerShell runspace to session {SessionId}", sessionId);
+            return entry;
+        }
+    }
+
+    public PSPowerShell Instance => GetSessionRunspace().Instance;
+
+    public T ExecuteThreadSafe<T>(Func<PSPowerShell, T> operation) =>
+        GetSessionRunspace().Execute(operation, CompleteReleasedEntry);
+
+    public void ExecuteThreadSafe(Action<PSPowerShell> operation) =>
+        GetSessionRunspace().Execute(operation, CompleteReleasedEntry);
+
+    public Task<T> ExecuteThreadSafeAsync<T>(Func<PSPowerShell, Task<T>> operation) =>
+        GetSessionRunspace().ExecuteAsync(operation, CompleteReleasedEntry);
+
+    /// <summary>Releases state for a terminated MCP session without interrupting its active invocation.</summary>
+    public void CleanupSession(string sessionId)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId) || sessionId == DefaultSessionId)
+        {
+            return;
+        }
+
+        ReleaseSession(sessionId, "session completed");
+    }
+
+    public void SweepIdleRunspaces()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        var cutoff = _timeProvider.GetUtcNow() - _options.IdleTtl;
+        foreach (var pair in _sessionRunspaces)
+        {
+            if (pair.Value.LastTouched <= cutoff)
+            {
+                ReleaseSession(pair.Key, "idle TTL expired");
+            }
+        }
+    }
+
+    /// <summary>Releases every session-owned runspace so subsequent requests get clean state.</summary>
+    public void ReleaseAllSessions()
+    {
+        foreach (var sessionId in _sessionRunspaces.Keys)
+        {
+            ReleaseSession(sessionId, "configuration reloaded");
+        }
+    }
+
+    private void ReleaseSession(string sessionId, string reason)
+    {
+        if (!_sessionRunspaces.TryRemove(sessionId, out var entry))
+        {
+            return;
+        }
+
+        _logger.LogInformation("Releasing PowerShell runspace for session {SessionId}: {Reason}", sessionId, reason);
+        if (entry.RequestRelease())
+        {
+            CompleteReleasedEntry(entry);
+        }
+    }
+
+    private void CompleteReleasedEntry(SessionRunspaceEntry entry)
+    {
+        lock (_gate)
+        {
+            entry.Dispose();
+            _ownedSessionRunspaces--;
+            Monitor.PulseAll(_gate);
+            if (!_disposed)
+            {
+                RefillWarmStandbys_NoLock();
+            }
+        }
+    }
+
+    private void RefillWarmStandbys_NoLock()
+    {
+        while (!_disposed && _warmStandbys.Count < _options.WarmStandbyCount)
+        {
+            _warmStandbys.Enqueue(CreateInitializedRunspace());
+        }
+    }
+
+    private static IsolatedPowerShellRunspace CreateInitializedRunspace() =>
+        new(PowerShellRunspaceHolder.GetProductionInitializationScript());
+
+    private void ThrowIfDisposed_NoLock()
     {
         if (_disposed)
         {
             throw new ObjectDisposedException(nameof(SessionAwarePowerShellRunspace));
         }
-
-        var sessionId = GetSessionId();
-
-        return _sessionRunspaces.GetOrAdd(sessionId, id =>
-        {
-            _logger.LogInformation("Creating PowerShell runspace for session: {SessionId}", id);
-            var initScript = PowerShellRunspaceHolder.GetProductionInitializationScript();
-            return new IsolatedPowerShellRunspace(initScript);
-        });
-    }
-
-    public PSPowerShell Instance => GetSessionRunspace().Instance;
-
-    public T ExecuteThreadSafe<T>(Func<PSPowerShell, T> operation)
-    {
-        var sessionRunspace = GetSessionRunspace();
-        return sessionRunspace.ExecuteThreadSafe(operation);
-    }
-
-    public void ExecuteThreadSafe(Action<PSPowerShell> operation)
-    {
-        var sessionRunspace = GetSessionRunspace();
-        sessionRunspace.ExecuteThreadSafe(operation);
-    }
-
-    public Task<T> ExecuteThreadSafeAsync<T>(Func<PSPowerShell, Task<T>> operation)
-    {
-        var sessionRunspace = GetSessionRunspace();
-        return sessionRunspace.ExecuteThreadSafeAsync(operation);
-    }
-
-    public void CleanupSession(string sessionId)
-    {
-        if (string.IsNullOrWhiteSpace(sessionId))
-        {
-            return;
-        }
-
-        if (_sessionRunspaces.TryRemove(sessionId, out var runspace))
-        {
-            _logger.LogInformation("Cleaning up PowerShell runspace for session: {SessionId}", sessionId);
-            try
-            {
-                runspace.Dispose();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Error disposing runspace for session {SessionId}", sessionId);
-            }
-        }
     }
 
     public SessionRunspaceStats GetStats()
     {
-        return new SessionRunspaceStats
+        lock (_gate)
         {
-            ActiveSessions = _sessionRunspaces.Count,
-            SessionIds = _sessionRunspaces.Keys.OrderBy(id => id, StringComparer.Ordinal).ToList()
-        };
+            return new SessionRunspaceStats
+            {
+                ActiveSessions = _sessionRunspaces.Count,
+                SessionIds = _sessionRunspaces.Keys.OrderBy(id => id, StringComparer.Ordinal).ToList(),
+                WarmStandbyCount = _warmStandbys.Count,
+                OwnedSessionRunspaces = _ownedSessionRunspaces
+            };
+        }
     }
 
     public void Dispose()
     {
-        if (_disposed)
-        {
-            return;
-        }
-
-        lock (_lock)
+        List<SessionRunspaceEntry> entries;
+        List<IsolatedPowerShellRunspace> standbys;
+        lock (_gate)
         {
             if (_disposed)
             {
                 return;
             }
 
-            _logger.LogInformation("Disposing SessionAwarePowerShellRunspace with {Count} active sessions", _sessionRunspaces.Count);
+            _disposed = true;
+            _sweepTimer.Dispose();
+            entries = _sessionRunspaces.Values.ToList();
+            _sessionRunspaces.Clear();
+            standbys = _warmStandbys.ToList();
+            _warmStandbys.Clear();
+        }
 
-            foreach (var kvp in _sessionRunspaces)
+        foreach (var standby in standbys)
+        {
+            standby.Dispose();
+        }
+
+        foreach (var entry in entries)
+        {
+            if (entry.RequestRelease())
             {
-                try
+                CompleteReleasedEntry(entry);
+            }
+        }
+    }
+
+    private sealed class SessionRunspaceEntry
+    {
+        private readonly IsolatedPowerShellRunspace _runspace;
+        private readonly object _gate = new();
+        private readonly Func<DateTimeOffset> _utcNow;
+        private int _activeInvocations;
+        private bool _releaseRequested;
+        private bool _disposed;
+
+        public SessionRunspaceEntry(
+            IsolatedPowerShellRunspace runspace,
+            Func<DateTimeOffset> utcNow,
+            DateTimeOffset createdAt)
+        {
+            _runspace = runspace;
+            _utcNow = utcNow;
+            LastTouched = createdAt;
+        }
+
+        public DateTimeOffset LastTouched { get; private set; }
+        public PSPowerShell Instance => _runspace.Instance;
+
+        public void Touch(DateTimeOffset now)
+        {
+            lock (_gate)
+            {
+                LastTouched = now;
+            }
+        }
+
+        public T Execute<T>(Func<PSPowerShell, T> operation, Action<SessionRunspaceEntry> release)
+        {
+            BeginInvocation();
+            try
+            {
+                return _runspace.ExecuteThreadSafe(operation);
+            }
+            finally
+            {
+                EndInvocation(release);
+            }
+        }
+
+        public void Execute(Action<PSPowerShell> operation, Action<SessionRunspaceEntry> release)
+        {
+            BeginInvocation();
+            try
+            {
+                _runspace.ExecuteThreadSafe(operation);
+            }
+            finally
+            {
+                EndInvocation(release);
+            }
+        }
+
+        public async Task<T> ExecuteAsync<T>(Func<PSPowerShell, Task<T>> operation, Action<SessionRunspaceEntry> release)
+        {
+            BeginInvocation();
+            try
+            {
+                return await _runspace.ExecuteThreadSafeAsync(operation);
+            }
+            finally
+            {
+                EndInvocation(release);
+            }
+        }
+
+        public bool RequestRelease()
+        {
+            lock (_gate)
+            {
+                _releaseRequested = true;
+                return _activeInvocations == 0;
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_gate)
+            {
+                if (_disposed)
                 {
-                    kvp.Value.Dispose();
+                    return;
                 }
-                catch (Exception ex)
+
+                _disposed = true;
+                _runspace.Dispose();
+            }
+        }
+
+        private void BeginInvocation()
+        {
+            lock (_gate)
+            {
+                if (_releaseRequested || _disposed)
                 {
-                    _logger.LogWarning(ex, "Error disposing runspace for session {SessionId}", kvp.Key);
+                    throw new ObjectDisposedException(nameof(SessionAwarePowerShellRunspace));
                 }
+
+                _activeInvocations++;
+                LastTouched = _utcNow();
+            }
+        }
+
+        private void EndInvocation(Action<SessionRunspaceEntry> release)
+        {
+            var dispose = false;
+            lock (_gate)
+            {
+                _activeInvocations--;
+                LastTouched = _utcNow();
+                dispose = _releaseRequested && _activeInvocations == 0;
             }
 
-            _sessionRunspaces.Clear();
-            _disposed = true;
+            if (dispose)
+            {
+                release(this);
+            }
         }
     }
 }
@@ -158,5 +411,7 @@ public class SessionAwarePowerShellRunspace : IPowerShellRunspace, IDisposable
 public sealed class SessionRunspaceStats
 {
     public int ActiveSessions { get; set; }
-    public List<string> SessionIds { get; set; } = new List<string>();
+    public List<string> SessionIds { get; set; } = new();
+    public int WarmStandbyCount { get; set; }
+    public int OwnedSessionRunspaces { get; set; }
 }

--- a/PoshMcp.Server/Server/HttpServerHost.cs
+++ b/PoshMcp.Server/Server/HttpServerHost.cs
@@ -141,6 +141,9 @@ internal static class HttpServerHost
             .WithHttpTransport(opts =>
             {
                 opts.IdleTimeout = TimeSpan.FromSeconds(mcpServerConfig.IdleSessionTimeoutSeconds);
+#pragma warning disable MCP9004 // Legacy SSE is opt-in, disabled by default, and documented for isolated trusted clients only.
+                opts.EnableLegacySse = mcpServerConfig.EnableLegacySse;
+#pragma warning restore MCP9004
             })
             .WithTools(tools)
             .WithListPromptsHandler(httpPromptHandler.HandleListPromptsAsync)
@@ -267,6 +270,7 @@ internal static class HttpServerHost
         app.UseMiddleware<McpOriginValidationMiddleware>(
             mcpEndpointPaths,
             authConfigValue.Cors?.AllowedOrigins ?? []);
+        app.UseMiddleware<McpProtocolVersionMiddleware>((object)mcpEndpointPaths);
 
         IEndpointConventionBuilder mcpEndpoint;
         if (string.IsNullOrWhiteSpace(normalizedMcpPath))
@@ -329,7 +333,8 @@ internal static class HttpServerHost
                     // Auth disabled — keep wide-open for dev/stdio use
                     policy.AllowAnyOrigin();
                 }
-                policy.AllowAnyMethod().AllowAnyHeader().WithExposedHeaders("Mcp-Session-Id");
+                policy.AllowAnyMethod().AllowAnyHeader()
+                    .WithExposedHeaders("Mcp-Session-Id", "MCP-Protocol-Version");
             });
         });
     }

--- a/PoshMcp.Server/Server/HttpServerHost.cs
+++ b/PoshMcp.Server/Server/HttpServerHost.cs
@@ -100,8 +100,10 @@ internal static class HttpServerHost
         var sharedHttpContextAccessor = new HttpContextAccessor();
         var sharedRunspaceLogger = bootstrapLoggerFactory.CreateLogger<SessionAwarePowerShellRunspace>();
         var sharedSessionRunspace = new SessionAwarePowerShellRunspace(sharedHttpContextAccessor, sharedRunspaceLogger);
+        var sessionLifecycle = new McpSessionLifecycle(sharedSessionRunspace.CleanupSession);
 
         builder.Services.AddSingleton<IHttpContextAccessor>(sharedHttpContextAccessor);
+        builder.Services.AddSingleton(sessionLifecycle);
         builder.Services.AddSingleton<IPowerShellRunspace>(sharedSessionRunspace);
 
         logger.LogInformation("Using configuration source: {ConfigurationPath}", ConfigurationHelpers.DescribeConfigurationPath(finalConfigPath));
@@ -144,6 +146,9 @@ internal static class HttpServerHost
 #pragma warning disable MCP9004 // Legacy SSE is opt-in, disabled by default, and documented for isolated trusted clients only.
                 opts.EnableLegacySse = mcpServerConfig.EnableLegacySse;
 #pragma warning restore MCP9004
+#pragma warning disable MCPEXP002 // Required to release session-scoped resources when the SDK ends a session.
+                opts.RunSessionHandler = sessionLifecycle.RunSessionAsync;
+#pragma warning restore MCPEXP002
             })
             .WithTools(tools)
             .WithListPromptsHandler(httpPromptHandler.HandleListPromptsAsync)
@@ -298,7 +303,14 @@ internal static class HttpServerHost
         // OAuth proxy: /.well-known/oauth-authorization-server + /register (DCR)
         app.MapOAuthProxyEndpoints(authConfigForEndpoints.Value);
 
-        await app.RunAsync();
+        try
+        {
+            await app.RunAsync();
+        }
+        finally
+        {
+            await app.DisposeAsync();
+        }
     }
 
     /// <summary>

--- a/PoshMcp.Server/Server/HttpServerHost.cs
+++ b/PoshMcp.Server/Server/HttpServerHost.cs
@@ -97,9 +97,21 @@ internal static class HttpServerHost
         var config = ConfigurationLoader.LoadPowerShellConfiguration(finalConfigPath, logger, runtimeModeOverride);
         await using var executorLease = await McpToolSetupService.StartOutOfProcessExecutorIfNeededAsync(config, bootstrapLoggerFactory, logger, finalConfigPath);
 
+        var mcpServerConfig = authRootConfig.GetSection("McpServer").Get<McpServerConfiguration>()
+            ?? new McpServerConfiguration();
         var sharedHttpContextAccessor = new HttpContextAccessor();
         var sharedRunspaceLogger = bootstrapLoggerFactory.CreateLogger<SessionAwarePowerShellRunspace>();
-        var sharedSessionRunspace = new SessionAwarePowerShellRunspace(sharedHttpContextAccessor, sharedRunspaceLogger);
+        var sharedSessionRunspace = new SessionAwarePowerShellRunspace(
+            sharedHttpContextAccessor,
+            sharedRunspaceLogger,
+            new SessionRunspaceOptions
+            {
+                Capacity = mcpServerConfig.SessionRunspaceCapacity,
+                IdleTtl = TimeSpan.FromSeconds(mcpServerConfig.SessionRunspaceIdleTtlSeconds),
+                SweepInterval = TimeSpan.FromSeconds(mcpServerConfig.SessionRunspaceSweepIntervalSeconds),
+                WarmStandbyCount = mcpServerConfig.SessionRunspaceWarmStandbyCount,
+                AcquisitionTimeout = TimeSpan.FromSeconds(mcpServerConfig.SessionRunspaceAcquisitionTimeoutSeconds)
+            });
         var sessionLifecycle = new McpSessionLifecycle(sharedSessionRunspace.CleanupSession);
 
         builder.Services.AddSingleton<IHttpContextAccessor>(sharedHttpContextAccessor);
@@ -135,9 +147,6 @@ internal static class HttpServerHost
         var promptsConfig = ConfigurationLoader.LoadPromptsConfiguration(finalConfigPath);
         var httpConfigDirectory = Path.GetDirectoryName(finalConfigPath) ?? Directory.GetCurrentDirectory();
         var httpPromptHandler = new McpPromptHandler(promptsConfig, httpConfigDirectory, bootstrapLoggerFactory.CreateLogger<McpPromptHandler>());
-        var mcpServerConfig = authRootConfig.GetSection("McpServer").Get<McpServerConfiguration>()
-            ?? new McpServerConfiguration();
-
         var mcpBuilder = builder.Services
             .AddMcpServer()
             .WithHttpTransport(opts =>

--- a/PoshMcp.Server/Server/HttpServerHost.cs
+++ b/PoshMcp.Server/Server/HttpServerHost.cs
@@ -261,6 +261,13 @@ internal static class HttpServerHost
         }).AllowAnonymous();
 
         var normalizedMcpPath = SettingsResolver.NormalizeMcpPath(mcpPath);
+        var mcpEndpointPaths = string.IsNullOrWhiteSpace(normalizedMcpPath)
+            ? new[] { "/", "/mcp" }
+            : new[] { normalizedMcpPath };
+        app.UseMiddleware<McpOriginValidationMiddleware>(
+            mcpEndpointPaths,
+            authConfigValue.Cors?.AllowedOrigins ?? []);
+
         IEndpointConventionBuilder mcpEndpoint;
         if (string.IsNullOrWhiteSpace(normalizedMcpPath))
         {

--- a/PoshMcp.Server/Server/HttpServerHost.cs
+++ b/PoshMcp.Server/Server/HttpServerHost.cs
@@ -101,7 +101,7 @@ internal static class HttpServerHost
             ?? new McpServerConfiguration();
         var sharedHttpContextAccessor = new HttpContextAccessor();
         var sharedRunspaceLogger = bootstrapLoggerFactory.CreateLogger<SessionAwarePowerShellRunspace>();
-        var sharedSessionRunspace = new SessionAwarePowerShellRunspace(
+        using var sharedSessionRunspace = new SessionAwarePowerShellRunspace(
             sharedHttpContextAccessor,
             sharedRunspaceLogger,
             new SessionRunspaceOptions
@@ -239,6 +239,7 @@ internal static class HttpServerHost
         builder.Services.AddPoshMcpAuthentication(authRootConfig);
 
         var app = builder.Build();
+        app.Lifetime.ApplicationStopped.Register(sharedSessionRunspace.Dispose);
 
         app.Use(async (context, next) =>
         {

--- a/PoshMcp.Server/Server/McpOriginValidationMiddleware.cs
+++ b/PoshMcp.Server/Server/McpOriginValidationMiddleware.cs
@@ -1,0 +1,89 @@
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PoshMcp;
+
+/// <summary>
+/// Validates browser origins for Streamable HTTP MCP endpoints.
+/// </summary>
+internal sealed class McpOriginValidationMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly HashSet<string> _mcpPaths;
+    private readonly HashSet<string> _allowedOrigins;
+
+    public McpOriginValidationMiddleware(
+        RequestDelegate next,
+        IEnumerable<string> mcpPaths,
+        IEnumerable<string> allowedOrigins)
+    {
+        _next = next;
+        _mcpPaths = new HashSet<string>(mcpPaths, StringComparer.OrdinalIgnoreCase);
+        _allowedOrigins = new HashSet<string>(
+            allowedOrigins
+                .Select(NormalizeOrigin)
+                .Where(origin => origin is not null)
+                .Cast<string>(),
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!_mcpPaths.Contains(context.Request.Path.Value ?? string.Empty) ||
+            !context.Request.Headers.TryGetValue("Origin", out var origin))
+        {
+            await _next(context);
+            return;
+        }
+
+        if (!IsAllowedOrigin(context.Request, origin.ToString()))
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            return;
+        }
+
+        await _next(context);
+    }
+
+    internal bool IsAllowedOrigin(HttpRequest request, string origin)
+    {
+        var normalizedOrigin = NormalizeOrigin(origin);
+        if (normalizedOrigin is null)
+        {
+            return false;
+        }
+
+        return string.Equals(normalizedOrigin, GetRequestOrigin(request), StringComparison.OrdinalIgnoreCase)
+            || _allowedOrigins.Contains(normalizedOrigin);
+    }
+
+    private static string? GetRequestOrigin(HttpRequest request)
+    {
+        if (!Uri.TryCreate($"{request.Scheme}://{request.Host}", UriKind.Absolute, out var requestUri))
+        {
+            return null;
+        }
+
+        return NormalizeOrigin(requestUri.AbsoluteUri);
+    }
+
+    private static string? NormalizeOrigin(string? origin)
+    {
+        if (string.IsNullOrWhiteSpace(origin) ||
+            !Uri.TryCreate(origin, UriKind.Absolute, out var uri) ||
+            !string.IsNullOrEmpty(uri.UserInfo) ||
+            !string.Equals(uri.AbsolutePath, "/", StringComparison.Ordinal) ||
+            !string.IsNullOrEmpty(uri.Query) ||
+            !string.IsNullOrEmpty(uri.Fragment) ||
+            (!string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
+             !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)))
+        {
+            return null;
+        }
+
+        return uri.GetLeftPart(UriPartial.Authority);
+    }
+}

--- a/PoshMcp.Server/Server/McpOriginValidationMiddleware.cs
+++ b/PoshMcp.Server/Server/McpOriginValidationMiddleware.cs
@@ -21,7 +21,9 @@ internal sealed class McpOriginValidationMiddleware
         IEnumerable<string> allowedOrigins)
     {
         _next = next;
-        _mcpPaths = new HashSet<string>(mcpPaths, StringComparer.OrdinalIgnoreCase);
+        _mcpPaths = new HashSet<string>(
+            mcpPaths.Select(NormalizeMcpPath),
+            StringComparer.OrdinalIgnoreCase);
         _allowedOrigins = new HashSet<string>(
             allowedOrigins
                 .Select(NormalizeOrigin)
@@ -32,7 +34,7 @@ internal sealed class McpOriginValidationMiddleware
 
     public async Task InvokeAsync(HttpContext context)
     {
-        if (!_mcpPaths.Contains(context.Request.Path.Value ?? string.Empty) ||
+        if (!_mcpPaths.Contains(NormalizeMcpPath(context.Request.Path.Value)) ||
             !context.Request.Headers.TryGetValue("Origin", out var origin))
         {
             await _next(context);
@@ -85,5 +87,15 @@ internal sealed class McpOriginValidationMiddleware
         }
 
         return uri.GetLeftPart(UriPartial.Authority);
+    }
+
+    private static string NormalizeMcpPath(string? path)
+    {
+        if (string.IsNullOrEmpty(path) || path == "/")
+        {
+            return path ?? string.Empty;
+        }
+
+        return path.TrimEnd('/');
     }
 }

--- a/PoshMcp.Server/Server/McpProtocolVersionMiddleware.cs
+++ b/PoshMcp.Server/Server/McpProtocolVersionMiddleware.cs
@@ -1,0 +1,114 @@
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace PoshMcp;
+
+/// <summary>
+/// Enforces Streamable HTTP protocol-version headers after session negotiation.
+/// </summary>
+internal sealed class McpProtocolVersionMiddleware
+{
+    internal const string CurrentProtocolVersion = "2025-11-25";
+    internal const string CompatibilityProtocolVersion = "2024-11-05";
+
+    private readonly RequestDelegate _next;
+    private readonly HashSet<string> _mcpPaths;
+    private readonly ConcurrentDictionary<string, string> _sessionProtocolVersions = new(StringComparer.Ordinal);
+
+    public McpProtocolVersionMiddleware(RequestDelegate next, IEnumerable<string> mcpPaths)
+    {
+        _next = next;
+        _mcpPaths = new HashSet<string>(mcpPaths, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!_mcpPaths.Contains(context.Request.Path.Value ?? string.Empty))
+        {
+            await _next(context);
+            return;
+        }
+
+        var sessionId = context.Request.Headers["Mcp-Session-Id"].ToString();
+        if (!string.IsNullOrWhiteSpace(sessionId) &&
+            _sessionProtocolVersions.TryGetValue(sessionId, out var negotiatedVersion) &&
+            !IsValidProtocolHeader(context.Request, negotiatedVersion))
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return;
+        }
+
+        var initializeProtocolVersion = string.IsNullOrWhiteSpace(sessionId)
+            ? await GetInitializeProtocolVersionAsync(context.Request)
+            : null;
+
+        await _next(context);
+
+        if (!string.IsNullOrWhiteSpace(initializeProtocolVersion) &&
+            context.Response.StatusCode < StatusCodes.Status400BadRequest)
+        {
+            var createdSessionId = context.Response.Headers["Mcp-Session-Id"].ToString();
+            if (!string.IsNullOrWhiteSpace(createdSessionId))
+            {
+                _sessionProtocolVersions[createdSessionId] = initializeProtocolVersion;
+            }
+        }
+
+        if (HttpMethods.IsDelete(context.Request.Method) &&
+            !string.IsNullOrWhiteSpace(sessionId) &&
+            context.Response.StatusCode is StatusCodes.Status200OK or StatusCodes.Status404NotFound)
+        {
+            _sessionProtocolVersions.TryRemove(sessionId, out _);
+        }
+    }
+
+    private static bool IsValidProtocolHeader(HttpRequest request, string negotiatedVersion)
+    {
+        var protocolVersion = request.Headers["MCP-Protocol-Version"].ToString();
+
+        if (string.Equals(negotiatedVersion, CompatibilityProtocolVersion, StringComparison.Ordinal))
+        {
+            return string.IsNullOrWhiteSpace(protocolVersion) ||
+                string.Equals(protocolVersion, negotiatedVersion, StringComparison.Ordinal);
+        }
+
+        return string.Equals(protocolVersion, negotiatedVersion, StringComparison.Ordinal) &&
+            string.Equals(protocolVersion, CurrentProtocolVersion, StringComparison.Ordinal);
+    }
+
+    private static async Task<string?> GetInitializeProtocolVersionAsync(HttpRequest request)
+    {
+        if (!HttpMethods.IsPost(request.Method) || !request.HasJsonContentType())
+        {
+            return null;
+        }
+
+        request.EnableBuffering();
+        try
+        {
+            using var document = await JsonDocument.ParseAsync(request.Body);
+            var root = document.RootElement;
+            if (!root.TryGetProperty("method", out var method) ||
+                !string.Equals(method.GetString(), "initialize", StringComparison.Ordinal) ||
+                !root.TryGetProperty("params", out var parameters) ||
+                !parameters.TryGetProperty("protocolVersion", out var protocolVersion))
+            {
+                return null;
+            }
+
+            return protocolVersion.GetString();
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+        finally
+        {
+            request.Body.Position = 0;
+        }
+    }
+}

--- a/PoshMcp.Server/Server/McpProtocolVersionMiddleware.cs
+++ b/PoshMcp.Server/Server/McpProtocolVersionMiddleware.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Http;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -17,11 +16,15 @@ internal sealed class McpProtocolVersionMiddleware
 
     private readonly RequestDelegate _next;
     private readonly HashSet<string> _mcpPaths;
-    private readonly ConcurrentDictionary<string, string> _sessionProtocolVersions = new(StringComparer.Ordinal);
+    private readonly McpSessionLifecycle _sessionLifecycle;
 
-    public McpProtocolVersionMiddleware(RequestDelegate next, IEnumerable<string> mcpPaths)
+    public McpProtocolVersionMiddleware(
+        RequestDelegate next,
+        McpSessionLifecycle sessionLifecycle,
+        IEnumerable<string> mcpPaths)
     {
         _next = next;
+        _sessionLifecycle = sessionLifecycle;
         _mcpPaths = new HashSet<string>(mcpPaths, StringComparer.OrdinalIgnoreCase);
     }
 
@@ -35,7 +38,7 @@ internal sealed class McpProtocolVersionMiddleware
 
         var sessionId = context.Request.Headers["Mcp-Session-Id"].ToString();
         if (!string.IsNullOrWhiteSpace(sessionId) &&
-            _sessionProtocolVersions.TryGetValue(sessionId, out var negotiatedVersion) &&
+            _sessionLifecycle.TryGetProtocolVersion(sessionId, out var negotiatedVersion) &&
             !IsValidProtocolHeader(context.Request, negotiatedVersion))
         {
             context.Response.StatusCode = StatusCodes.Status400BadRequest;
@@ -54,7 +57,7 @@ internal sealed class McpProtocolVersionMiddleware
             var createdSessionId = context.Response.Headers["Mcp-Session-Id"].ToString();
             if (!string.IsNullOrWhiteSpace(createdSessionId))
             {
-                _sessionProtocolVersions[createdSessionId] = initializeProtocolVersion;
+                _sessionLifecycle.TrackProtocolVersion(createdSessionId, initializeProtocolVersion);
             }
         }
 
@@ -62,7 +65,7 @@ internal sealed class McpProtocolVersionMiddleware
             !string.IsNullOrWhiteSpace(sessionId) &&
             context.Response.StatusCode is StatusCodes.Status200OK or StatusCodes.Status404NotFound)
         {
-            _sessionProtocolVersions.TryRemove(sessionId, out _);
+            _sessionLifecycle.RemoveProtocolVersion(sessionId);
         }
     }
 

--- a/PoshMcp.Server/Server/McpSessionLifecycle.cs
+++ b/PoshMcp.Server/Server/McpSessionLifecycle.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using ModelContextProtocol.Server;
+
+namespace PoshMcp;
+
+/// <summary>
+/// Tracks state associated with stateful HTTP MCP sessions and releases it when the SDK closes a session.
+/// </summary>
+internal sealed class McpSessionLifecycle
+{
+    private readonly ConcurrentDictionary<string, string> _protocolVersions = new(StringComparer.Ordinal);
+    private readonly Action<string> _cleanupSession;
+
+    public McpSessionLifecycle(Action<string> cleanupSession)
+    {
+        _cleanupSession = cleanupSession ?? throw new ArgumentNullException(nameof(cleanupSession));
+    }
+
+    public bool TryGetProtocolVersion(string sessionId, [NotNullWhen(true)] out string? protocolVersion) =>
+        _protocolVersions.TryGetValue(sessionId, out protocolVersion);
+
+    public void TrackProtocolVersion(string sessionId, string protocolVersion)
+    {
+        _protocolVersions[sessionId] = protocolVersion;
+    }
+
+    public void RemoveProtocolVersion(string sessionId)
+    {
+        _protocolVersions.TryRemove(sessionId, out _);
+    }
+
+    public async Task RunSessionAsync(HttpContext _, McpServer session, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await session.RunAsync(cancellationToken);
+        }
+        finally
+        {
+            CompleteSession(session.SessionId);
+        }
+    }
+
+    internal void CompleteSession(string? sessionId)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId))
+        {
+            return;
+        }
+
+        RemoveProtocolVersion(sessionId);
+        _cleanupSession(sessionId);
+    }
+}

--- a/PoshMcp.Server/Server/McpToolSetupService.cs
+++ b/PoshMcp.Server/Server/McpToolSetupService.cs
@@ -385,7 +385,7 @@ internal static class McpToolSetupService
     private static McpServerTool CreateReloadFromFileToolInstance(ConfigurationReloadTools reloadTools)
     {
         var reloadConfigFromFileDelegate = new Func<CancellationToken, Task<string>>(reloadTools.ReloadConfigurationFromFile);
-        return McpServerTool.Create(reloadConfigFromFileDelegate, new McpServerToolCreateOptions
+        return McpToolSchema.ApplyStrictEmptyObjectSchema(McpServerTool.Create(reloadConfigFromFileDelegate, new McpServerToolCreateOptions
         {
             Name = "reload-configuration-from-file",
             Description = "Reloads PowerShell configuration from the configuration file and regenerates available tools",
@@ -395,7 +395,7 @@ internal static class McpToolSetupService
             Idempotent = true,
             OpenWorld = false,
             UseStructuredContent = true
-        });
+        }));
     }
 
     /// <summary>
@@ -423,7 +423,7 @@ internal static class McpToolSetupService
     private static McpServerTool CreateGetConfigurationStatusToolInstance(ConfigurationReloadTools reloadTools)
     {
         var getConfigStatusDelegate = new Func<CancellationToken, Task<string>>(reloadTools.GetConfigurationStatus);
-        return McpServerTool.Create(getConfigStatusDelegate, new McpServerToolCreateOptions
+        return McpToolSchema.ApplyStrictEmptyObjectSchema(McpServerTool.Create(getConfigStatusDelegate, new McpServerToolCreateOptions
         {
             Name = "get-configuration-status",
             Description = "Gets current PowerShell configuration status and tool information",
@@ -433,7 +433,7 @@ internal static class McpToolSetupService
             Idempotent = true,
             OpenWorld = false,
             UseStructuredContent = true
-        });
+        }));
     }
 
     /// <summary>
@@ -557,7 +557,7 @@ internal static class McpToolSetupService
                 importSourceTracker,
                 nounRegistryProvider));
 
-        return McpServerTool.Create(troubleshootingDelegate, new McpServerToolCreateOptions
+        return McpToolSchema.ApplyStrictEmptyObjectSchema(McpServerTool.Create(troubleshootingDelegate, new McpServerToolCreateOptions
         {
             Name = "get-configuration-troubleshooting",
             Description = "Returns doctor-style configuration diagnostics for the running server. Output includes runtime settings, environment variables, PowerShell info, configured functions, MCP definitions, authentication configuration, and caller identity (when available).",
@@ -567,7 +567,7 @@ internal static class McpToolSetupService
             Idempotent = true,
             OpenWorld = false,
             UseStructuredContent = true
-        });
+        }));
     }
 
     /// <summary>
@@ -627,7 +627,7 @@ internal static class McpToolSetupService
             effectiveMcpPath,
             guidanceLogger);
 
-        return McpServerTool.Create(guidanceTools.GetConfigurationGuidance, new McpServerToolCreateOptions
+        return McpToolSchema.ApplyStrictEmptyObjectSchema(McpServerTool.Create(guidanceTools.GetConfigurationGuidance, new McpServerToolCreateOptions
         {
             Name = "get-configuration-guidance",
             Description = "Returns configuration guidance for creating and updating appsettings.json, including environment customization and authentication recommendations based on the current runtime transport.",
@@ -637,7 +637,7 @@ internal static class McpToolSetupService
             Idempotent = true,
             OpenWorld = false,
             UseStructuredContent = true
-        });
+        }));
     }
 
     /// <summary>

--- a/PoshMcp.Server/Server/McpToolSetupService.cs
+++ b/PoshMcp.Server/Server/McpToolSetupService.cs
@@ -50,7 +50,7 @@ internal static class McpToolSetupService
 
         if (config.EnableDynamicReloadTools)
         {
-            var reloadTools = CreateConfigurationReloadTools(loggerFactory, toolFactory, config, finalConfigPath, configurationPathSource, "stdio", config.RuntimeMode.ToString(), null, () => tools, importSourceTracker);
+            var reloadTools = CreateConfigurationReloadTools(loggerFactory, toolFactory, config, finalConfigPath, configurationPathSource, "stdio", config.RuntimeMode.ToString(), null, () => tools, importSourceTracker, null);
             AddConfigurationReloadToolsToList(tools, reloadTools);
             logger.LogInformation($"Added {tools.Count} total tools (including 3 configuration reload tools)");
         }
@@ -109,7 +109,20 @@ internal static class McpToolSetupService
 
         if (config.EnableDynamicReloadTools)
         {
-            var reloadTools = CreateConfigurationReloadTools(loggerFactory, toolFactory, config, finalConfigPath, configurationPathSource, "http", config.RuntimeMode.ToString(), null, () => tools, importSourceTracker);
+            var reloadTools = CreateConfigurationReloadTools(
+                loggerFactory,
+                toolFactory,
+                config,
+                finalConfigPath,
+                configurationPathSource,
+                "http",
+                config.RuntimeMode.ToString(),
+                null,
+                () => tools,
+                importSourceTracker,
+                sessionAwareRunspace is SessionAwarePowerShellRunspace managedRunspace
+                    ? managedRunspace.ReleaseAllSessions
+                    : null);
             AddConfigurationReloadToolsToList(tools, reloadTools);
             logger.LogInformation($"Added {tools.Count} total tools (including 3 configuration reload tools)");
         }
@@ -341,10 +354,16 @@ internal static class McpToolSetupService
         string? effectiveRuntimeMode,
         string? effectiveMcpPath,
         Func<List<McpServerTool>> registeredToolsProvider,
-        IToolImportSourceTracker? importSourceTracker)
+        IToolImportSourceTracker? importSourceTracker,
+        Action? onConfigurationReloaded)
     {
         var reloadServiceLogger = loggerFactory.CreateLogger<PowerShellConfigurationReloadService>();
-        var reloadService = new PowerShellConfigurationReloadService(reloadServiceLogger, toolFactory, config, finalConfigPath);
+        var reloadService = new PowerShellConfigurationReloadService(
+            reloadServiceLogger,
+            toolFactory,
+            config,
+            finalConfigPath,
+            onConfigurationReloaded);
         var reloadToolsLogger = loggerFactory.CreateLogger<ConfigurationReloadTools>();
         return new ConfigurationReloadTools(
             reloadService,

--- a/PoshMcp.Server/appsettings.json
+++ b/PoshMcp.Server/appsettings.json
@@ -51,7 +51,8 @@
     ]
   },
   "McpServer": {
-    "IdleSessionTimeoutSeconds": 60
+    "IdleSessionTimeoutSeconds": 60,
+    "EnableLegacySse": false
   },
   "Authentication": {
     "Enabled": false,

--- a/PoshMcp.Server/appsettings.json
+++ b/PoshMcp.Server/appsettings.json
@@ -52,6 +52,11 @@
   },
   "McpServer": {
     "IdleSessionTimeoutSeconds": 60,
+    "SessionRunspaceCapacity": 16,
+    "SessionRunspaceIdleTtlSeconds": 300,
+    "SessionRunspaceSweepIntervalSeconds": 30,
+    "SessionRunspaceWarmStandbyCount": 2,
+    "SessionRunspaceAcquisitionTimeoutSeconds": 15,
     "EnableLegacySse": false
   },
   "Authentication": {

--- a/PoshMcp.Tests/Functional/PowerShellCommandExecution/ShouldHandleInvalidCommandTest.cs
+++ b/PoshMcp.Tests/Functional/PowerShellCommandExecution/ShouldHandleInvalidCommandTest.cs
@@ -9,8 +9,6 @@ using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
 using System.Linq;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace PoshMcp.Tests.Functional.PowerShellCommandExecution;
 
@@ -25,33 +23,24 @@ public class InvalidCommand : PowerShellTestBase
     }
 
     [Fact]
-    public async Task UnknownCommand_ReturnsStructuredErrorJson_NotEmptyArray()
+    public async Task UnknownCommand_ThrowsExecutionError()
     {
         // Arrange
         var commandName = "NonExistentCommand-UnknownCommand_ReturnsStructuredErrorJson_NotEmptyArray";
         var parameters = Array.Empty<PowerShellParameterInfo>();
 
         // Act
-        var result = await PowerShellAssemblyGenerator.ExecutePowerShellCommandTyped(
-            commandName,
-            parameters,
-            Array.Empty<object>(),
-            CancellationToken.None,
-            PowerShellRunspace,
-            Logger);
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            PowerShellAssemblyGenerator.ExecutePowerShellCommandTyped(
+                commandName,
+                parameters,
+                Array.Empty<object>(),
+                CancellationToken.None,
+                PowerShellRunspace,
+                Logger));
 
-        // Assert: response is not null/empty and not the historical empty-array regression payload
-        Assert.False(string.IsNullOrWhiteSpace(result));
-        Assert.NotEqual("[]", result.Trim());
-
-        // Assert: response is valid JSON object with a non-empty error property
-        var token = JToken.Parse(result);
-        var json = Assert.IsType<JObject>(token);
-        var error = json["error"]?.Value<string>();
-
-        Assert.False(string.IsNullOrWhiteSpace(error), $"Expected a non-empty error message JSON payload, but got: {result}");
-        Assert.Contains(commandName, error, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("not recognized", error, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(commandName, exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("not recognized", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -62,21 +51,16 @@ public class InvalidCommand : PowerShellTestBase
         var parameters = new PowerShellParameterInfo[0];
 
         // Act
-        var result = await PowerShellAssemblyGenerator.ExecutePowerShellCommandTyped(
-            commandName,
-            parameters,
-            new object[0],
-            CancellationToken.None,
-            PowerShellRunspace,
-            Logger);
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            PowerShellAssemblyGenerator.ExecutePowerShellCommandTyped(
+                commandName,
+                parameters,
+                Array.Empty<object>(),
+                CancellationToken.None,
+                PowerShellRunspace,
+                Logger));
 
-        // Assert
-        Assert.NotNull(result);
-        var json = JObject.Parse(result);
-        var error = json["error"]?.Value<string>();
-
-        Assert.False(string.IsNullOrWhiteSpace(error), $"Expected a non-empty error message JSON payload, but got: {result}");
-        Assert.Contains(commandName, error, StringComparison.Ordinal);
-        Assert.Contains("not recognized", error, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(commandName, exception.Message, StringComparison.Ordinal);
+        Assert.Contains("not recognized", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/PoshMcp.Tests/Integration/HelpParityFixtureSession.cs
+++ b/PoshMcp.Tests/Integration/HelpParityFixtureSession.cs
@@ -5,9 +5,10 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace PoshMcp.Tests.Integration;
 
@@ -37,18 +38,16 @@ internal sealed class HelpParityFixtureSession : IAsyncDisposable
     };
 
     private readonly ILogger _logger;
-    private readonly ITestOutputHelper _output;
     private readonly string _runtimeMode;
     private InProcessMcpServer? _server;
     private ExternalMcpClient? _client;
     private string? _configPath;
     private string? _previousPSModulePath;
 
-    public HelpParityFixtureSession(string runtimeMode, ILogger logger, ITestOutputHelper output)
+    public HelpParityFixtureSession(string runtimeMode, ILogger logger)
     {
         _runtimeMode = runtimeMode;
         _logger = logger;
-        _output = output;
     }
 
     /// <summary>
@@ -202,4 +201,59 @@ internal sealed class HelpParityFixtureSession : IAsyncDisposable
             ?? throw new InvalidOperationException(
                 $"Could not find workspace root from {Directory.GetCurrentDirectory()}");
     }
+}
+
+/// <summary>
+/// Shared lifecycle for the HelpParityFixture server snapshots. A collection
+/// fixture prevents each theory case from starting its own OOP subprocess pool.
+/// </summary>
+public sealed class ToolDescriptionFixture : IAsyncLifetime
+{
+    private static readonly ILogger Logger = NullLogger<ToolDescriptionFixture>.Instance;
+
+    internal HelpParityFixtureSession? InProcessSession { get; private set; }
+    internal HelpParityFixtureSession? OutOfProcessSession { get; private set; }
+    internal bool IsOutOfProcessAvailable { get; private set; }
+    internal string? OutOfProcessUnavailableReason { get; private set; }
+
+    public async Task InitializeAsync()
+    {
+        InProcessSession = new HelpParityFixtureSession(
+            HelpParityFixtureSession.RuntimeModeInProcess, Logger);
+        await InProcessSession.StartAsync();
+
+        try
+        {
+            var pwsh = PoshMcp.Server.PowerShell.OutOfProcess
+                .OutOfProcessCommandExecutor.ResolvePwshPath();
+            if (string.IsNullOrEmpty(pwsh))
+            {
+                OutOfProcessUnavailableReason = "pwsh not on PATH";
+                return;
+            }
+
+            OutOfProcessSession = new HelpParityFixtureSession(
+                HelpParityFixtureSession.RuntimeModeOutOfProcess, Logger);
+            await OutOfProcessSession.StartAsync();
+            IsOutOfProcessAvailable = true;
+        }
+        catch (Exception ex)
+        {
+            OutOfProcessUnavailableReason = ex.Message;
+            Logger.LogWarning(ex, "Failed to start OutOfProcess fixture session");
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (InProcessSession is not null)
+            await InProcessSession.DisposeAsync();
+        if (OutOfProcessSession is not null)
+            await OutOfProcessSession.DisposeAsync();
+    }
+}
+
+[CollectionDefinition("Tool Description Fixtures", DisableParallelization = true)]
+public sealed class ToolDescriptionFixtureCollection : ICollectionFixture<ToolDescriptionFixture>
+{
 }

--- a/PoshMcp.Tests/Integration/HttpMcpClient.cs
+++ b/PoshMcp.Tests/Integration/HttpMcpClient.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -22,9 +21,12 @@ public class HttpMcpClient : IDisposable
     private readonly string _baseUrl;
     private int _requestId = 1;
     private string? _sessionId;
+    private string? _protocolVersion;
     private static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(10);
+    public const string CurrentProtocolVersion = "2025-11-25";
 
     public string? SessionId => _sessionId;
+    public string? ProtocolVersion => _protocolVersion;
 
     public HttpMcpClient(ILogger logger, string baseUrl)
     {
@@ -80,7 +82,7 @@ public class HttpMcpClient : IDisposable
         _logger.LogInformation("HTTP MCP client connected to web server and server is ready");
     }
 
-    public async Task<JObject> SendInitializeAsync()
+    public async Task<JObject> SendInitializeAsync(string protocolVersion = CurrentProtocolVersion)
     {
         var request = new
         {
@@ -89,7 +91,7 @@ public class HttpMcpClient : IDisposable
             method = "initialize",
             @params = new
             {
-                protocolVersion = "2024-11-05",
+                protocolVersion,
                 capabilities = new
                 {
                     tools = new { }
@@ -102,7 +104,9 @@ public class HttpMcpClient : IDisposable
             }
         };
 
-        return await SendRequestAsync(request);
+        var response = await SendRequestAsync(request);
+        _protocolVersion = response["result"]?["protocolVersion"]?.ToString() ?? protocolVersion;
+        return response;
     }
 
     public async Task<JObject> SendListToolsAsync()
@@ -141,23 +145,22 @@ public class HttpMcpClient : IDisposable
 
         try
         {
-            var content = new StringContent(requestJson, Encoding.UTF8, "application/json");
+            using var requestMessage = new HttpRequestMessage(HttpMethod.Post, "/")
+            {
+                Content = new StringContent(requestJson, Encoding.UTF8, "application/json")
+            };
 
-            // Add session ID header for non-initialize requests
-            var headers = new Dictionary<string, string>();
             if (!string.IsNullOrEmpty(_sessionId))
             {
-                headers["Mcp-Session-Id"] = _sessionId;
+                requestMessage.Headers.Add("Mcp-Session-Id", _sessionId);
             }
 
-            foreach (var header in headers)
+            if (!string.IsNullOrEmpty(_protocolVersion))
             {
-                _httpClient.DefaultRequestHeaders.Remove(header.Key);
-                _httpClient.DefaultRequestHeaders.Add(header.Key, header.Value);
+                requestMessage.Headers.Add("MCP-Protocol-Version", _protocolVersion);
             }
 
-            // The MCP HTTP endpoint is at the root /
-            var response = await _httpClient.PostAsync("/", content);
+            using var response = await _httpClient.SendAsync(requestMessage);
 
             // Capture session ID from response headers if present
             if (response.Headers.TryGetValues("Mcp-Session-Id", out var sessionIdValues))
@@ -172,9 +175,7 @@ public class HttpMcpClient : IDisposable
                 throw new HttpRequestException($"HTTP {response.StatusCode}: {errorContent}");
             }
 
-            // Parse first Server-Sent Events payload line without waiting for stream end.
-            var responseJson = await ExtractJsonFromSSEAsync(response.Content);
-            var responseObject = JObject.Parse(responseJson);
+            var responseObject = await ReadJsonResponseAsync(response.Content);
             _logger.LogDebug($"[WEB SERVER RESPONSE] {responseObject.ToString(Formatting.Indented)}");
 
             return responseObject;
@@ -186,26 +187,25 @@ public class HttpMcpClient : IDisposable
         }
     }
 
-    private static async Task<string> ExtractJsonFromSSEAsync(HttpContent content)
+    private static async Task<JObject> ReadJsonResponseAsync(HttpContent content)
     {
-        await using var stream = await content.ReadAsStreamAsync();
-        using var reader = new StreamReader(stream);
-
-        while (true)
+        var responseText = await content.ReadAsStringAsync();
+        var mediaType = content.Headers.ContentType?.MediaType;
+        if (string.Equals(mediaType, "application/json", StringComparison.OrdinalIgnoreCase))
         {
-            var line = await reader.ReadLineAsync();
-            if (line == null)
-            {
-                break;
-            }
+            return JObject.Parse(responseText);
+        }
 
-            if (line.StartsWith("data: "))
+        using var reader = new StringReader(responseText);
+        while (await reader.ReadLineAsync() is { } line)
+        {
+            if (line.StartsWith("data: ", StringComparison.Ordinal))
             {
-                return line.Substring(6); // Remove "data: " prefix
+                return JObject.Parse(line.Substring(6));
             }
         }
 
-        throw new InvalidOperationException("No data line found in SSE response stream");
+        throw new InvalidOperationException($"No JSON response payload found for content type '{mediaType ?? "unknown"}'.");
     }
 
     public void Dispose()

--- a/PoshMcp.Tests/Integration/McpServerIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/McpServerIntegrationTests.cs
@@ -238,7 +238,7 @@ public class ServerWithExternalClient : PowerShellTestBase, IAsyncLifetime
 
         var response = await client.SendToolCallAsync("get_process_id", new JObject
         {
-            ["Id"] = new JArray(-1)
+            ["Id"] = new JArray(int.MaxValue)
         });
 
         Assert.Null(response["error"]);

--- a/PoshMcp.Tests/Integration/McpServerIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/McpServerIntegrationTests.cs
@@ -216,6 +216,36 @@ public class ServerWithExternalClient : PowerShellTestBase, IAsyncLifetime
         Logger.LogInformation($"Error handled correctly via external client: {errorMessage}");
     }
 
+    [Fact]
+    public async Task ToolCallsWithInvalidArguments_ReturnToolErrorResult()
+    {
+        var client = _sharedClient ?? throw new InvalidOperationException("Shared client not initialized");
+
+        var response = await client.SendToolCallAsync("get_process_id", new JObject
+        {
+            ["Id"] = new JArray("not-a-process-id")
+        });
+
+        Assert.Null(response["error"]);
+        Assert.True(response["result"]?["isError"]?.Value<bool>() == true,
+            $"Invalid tool arguments must be represented by result.isError=true. Response: {response}");
+    }
+
+    [Fact]
+    public async Task PowerShellExecutionFailures_ReturnToolErrorResult()
+    {
+        var client = _sharedClient ?? throw new InvalidOperationException("Shared client not initialized");
+
+        var response = await client.SendToolCallAsync("get_process_id", new JObject
+        {
+            ["Id"] = new JArray(-1)
+        });
+
+        Assert.Null(response["error"]);
+        Assert.True(response["result"]?["isError"]?.Value<bool>() == true,
+            $"PowerShell execution failures must be represented by result.isError=true. Response: {response}");
+    }
+
 
     #region Helper Methods (No longer needed - using shared instances)
 

--- a/PoshMcp.Tests/Integration/MultiUserIsolationTests.cs
+++ b/PoshMcp.Tests/Integration/MultiUserIsolationTests.cs
@@ -68,6 +68,8 @@ public class MultiUserIsolationTests : PowerShellTestBase, IAsyncLifetime
             Assert.NotNull(client1.SessionId);
             Assert.NotNull(client2.SessionId);
             Assert.NotEqual(client1.SessionId, client2.SessionId);
+            Assert.Equal(HttpMcpClient.CurrentProtocolVersion, client1.ProtocolVersion);
+            Assert.Equal(HttpMcpClient.CurrentProtocolVersion, client2.ProtocolVersion);
 
             Logger.LogInformation($"Client 1 session: {client1.SessionId}");
             Logger.LogInformation($"Client 2 session: {client2.SessionId}");

--- a/PoshMcp.Tests/Integration/OutOfProcessSubprocessPoolIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/OutOfProcessSubprocessPoolIntegrationTests.cs
@@ -109,6 +109,41 @@ public class OutOfProcessSubprocessPoolIntegrationTests : IAsyncLifetime
         _logger.LogInformation("Get-Date returned: {Output}", output);
     }
 
+    [PwshAvailableFact]
+    public async Task Pool_ReloadDuringInvoke_DrainsOldWorkerAndReplacesBeforeNextRequest()
+    {
+        if (_hostScriptPath is null) return;
+
+        await using var pool = CreatePool(1);
+        await pool.StartAsync();
+        await pool.SetupAsync(new EnvironmentConfiguration());
+
+        var oldPid = (await pool.InvokeAsync(
+            "Get-Variable",
+            new Dictionary<string, object?> { ["Name"] = "PID", ["ValueOnly"] = true },
+            CancellationToken.None)).Trim();
+
+        var inFlight = pool.InvokeAsync(
+            "Start-Sleep",
+            new Dictionary<string, object?> { ["Milliseconds"] = 800 },
+            CancellationToken.None);
+
+        await Task.Delay(150);
+        await pool.SetupAsync(new EnvironmentConfiguration());
+        await inFlight;
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        while (DateTime.UtcNow < deadline && pool.HealthyCount < 1)
+            await Task.Delay(100);
+        Assert.Equal(1, pool.HealthyCount);
+
+        var newPid = (await pool.InvokeAsync(
+            "Get-Variable",
+            new Dictionary<string, object?> { ["Name"] = "PID", ["ValueOnly"] = true },
+            CancellationToken.None)).Trim();
+        Assert.NotEqual(oldPid, newPid);
+    }
+
     [PwshAvailableTheory]
     [InlineData(1)]
     [InlineData(2)]

--- a/PoshMcp.Tests/Integration/ToolDescriptionParityTests.cs
+++ b/PoshMcp.Tests/Integration/ToolDescriptionParityTests.cs
@@ -6,7 +6,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
-using Xunit.Sdk;
 
 namespace PoshMcp.Tests.Integration;
 
@@ -23,57 +22,14 @@ namespace PoshMcp.Tests.Integration;
 /// </summary>
 [Trait("Category", "Integration")]
 [Trait("Spec", "010")]
-public sealed class ToolDescriptionParityTests : PowerShellTestBase, IAsyncLifetime
+[Collection("Tool Description Fixtures")]
+public sealed class ToolDescriptionParityTests : PowerShellTestBase
 {
-    private HelpParityFixtureSession? _inProcessSession;
-    private HelpParityFixtureSession? _outOfProcessSession;
-    private bool _bothModesAvailable;
-    private string? _oopUnavailableReason;
+    private readonly ToolDescriptionFixture _fixture;
 
-    public ToolDescriptionParityTests(ITestOutputHelper output) : base(output)
+    public ToolDescriptionParityTests(ToolDescriptionFixture fixture, ITestOutputHelper output) : base(output)
     {
-    }
-
-    public async Task InitializeAsync()
-    {
-        Logger.LogInformation("=== Initializing ToolDescriptionParityTests fixture sessions ===");
-
-        _inProcessSession = new HelpParityFixtureSession(
-            HelpParityFixtureSession.RuntimeModeInProcess, Logger, Output);
-        await _inProcessSession.StartAsync();
-
-        // OOP requires pwsh on PATH; if unavailable, leave the OOP session unset
-        // and rely on PwshAvailableFact/Theory attributes to skip cross-mode tests.
-        try
-        {
-            var pwsh = PoshMcp.Server.PowerShell.OutOfProcess
-                .OutOfProcessCommandExecutor.ResolvePwshPath();
-            if (!string.IsNullOrEmpty(pwsh))
-            {
-                _outOfProcessSession = new HelpParityFixtureSession(
-                    HelpParityFixtureSession.RuntimeModeOutOfProcess, Logger, Output);
-                await _outOfProcessSession.StartAsync();
-                _bothModesAvailable = true;
-            }
-            else
-            {
-                _oopUnavailableReason = "pwsh not on PATH";
-                Logger.LogWarning("pwsh not on PATH; OutOfProcess parity tests will be skipped");
-            }
-        }
-        catch (System.Exception ex)
-        {
-            _oopUnavailableReason = ex.Message;
-            Logger.LogWarning(ex, "Failed to start OutOfProcess fixture session; OOP tests will be skipped");
-        }
-    }
-
-    public async Task DisposeAsync()
-    {
-        if (_inProcessSession is not null)
-            await _inProcessSession.DisposeAsync();
-        if (_outOfProcessSession is not null)
-            await _outOfProcessSession.DisposeAsync();
+        _fixture = fixture;
     }
 
     /// <summary>
@@ -86,12 +42,12 @@ public sealed class ToolDescriptionParityTests : PowerShellTestBase, IAsyncLifet
     [PwshAvailableFact]
     public void FixtureCommands_AppearInBothModes_WithSameToolVariantCount()
     {
-        SkipIfNoOop();
+        if (!IsOopAvailable()) return;
 
         foreach (var commandName in HelpParityFixtureSession.FixtureCommands)
         {
-            var inProcessVariants = _inProcessSession!.GetToolsForCommand(commandName);
-            var outOfProcessVariants = _outOfProcessSession!.GetToolsForCommand(commandName);
+            var inProcessVariants = _fixture.InProcessSession!.GetToolsForCommand(commandName);
+            var outOfProcessVariants = _fixture.OutOfProcessSession!.GetToolsForCommand(commandName);
 
             Assert.True(
                 inProcessVariants.Count > 0,
@@ -119,10 +75,10 @@ public sealed class ToolDescriptionParityTests : PowerShellTestBase, IAsyncLifet
     [InlineData("Get-FixtureBare")]
     public void ToolDescription_IsByteIdentical_AcrossRuntimeModes(string commandName)
     {
-        SkipIfNoOop();
+        if (!IsOopAvailable()) return;
 
-        var inProcess = _inProcessSession!.GetToolsForCommand(commandName);
-        var outOfProcess = _outOfProcessSession!.GetToolsForCommand(commandName);
+        var inProcess = _fixture.InProcessSession!.GetToolsForCommand(commandName);
+        var outOfProcess = _fixture.OutOfProcessSession!.GetToolsForCommand(commandName);
 
         Assert.NotEmpty(inProcess);
         Assert.NotEmpty(outOfProcess);
@@ -159,10 +115,10 @@ public sealed class ToolDescriptionParityTests : PowerShellTestBase, IAsyncLifet
     [InlineData("Get-FixtureBare")]
     public void ParameterDescriptions_AreByteIdentical_AcrossRuntimeModes(string commandName)
     {
-        SkipIfNoOop();
+        if (!IsOopAvailable()) return;
 
-        var inProcessVariants = _inProcessSession!.GetToolsForCommand(commandName);
-        var outOfProcessVariants = _outOfProcessSession!.GetToolsForCommand(commandName);
+        var inProcessVariants = _fixture.InProcessSession!.GetToolsForCommand(commandName);
+        var outOfProcessVariants = _fixture.OutOfProcessSession!.GetToolsForCommand(commandName);
 
         // Match variants by tool name (e.g., "get_fixturefullhelp") which is
         // derived deterministically from the source command + parameter set.
@@ -223,9 +179,9 @@ public sealed class ToolDescriptionParityTests : PowerShellTestBase, IAsyncLifet
     public void ParameterDescription_IsNonEmpty_WhenHelpTextAvailable_InProcessMode(
         string commandName, string parameterName)
     {
-        Assert.NotNull(_inProcessSession);
+        Assert.NotNull(_fixture.InProcessSession);
 
-        var variants = _inProcessSession!.GetToolsForCommand(commandName);
+        var variants = _fixture.InProcessSession!.GetToolsForCommand(commandName);
         Assert.NotEmpty(variants);
 
         // The parameter must have a non-empty description in at least one variant
@@ -268,9 +224,9 @@ public sealed class ToolDescriptionParityTests : PowerShellTestBase, IAsyncLifet
     public void ParameterDescription_IsNonEmpty_WhenHelpTextAvailable_OutOfProcessMode(
         string commandName, string parameterName)
     {
-        SkipIfNoOop();
+        if (!IsOopAvailable()) return;
 
-        var variants = _outOfProcessSession!.GetToolsForCommand(commandName);
+        var variants = _fixture.OutOfProcessSession!.GetToolsForCommand(commandName);
         Assert.NotEmpty(variants);
 
         var variantsWithParam = variants
@@ -310,13 +266,16 @@ public sealed class ToolDescriptionParityTests : PowerShellTestBase, IAsyncLifet
         return result;
     }
 
-    private void SkipIfNoOop()
+    private bool IsOopAvailable()
     {
-        if (!_bothModesAvailable)
+        if (_fixture.IsOutOfProcessAvailable)
         {
-            throw SkipException.ForSkip(
-                "OutOfProcess fixture session was not initialized. " +
-                $"Reason: {_oopUnavailableReason ?? "unknown"}.");
+            return true;
         }
+
+        Logger.LogWarning(
+            "OutOfProcess parity assertions are not run because the fixture session was not initialized. Reason: {Reason}",
+            _fixture.OutOfProcessUnavailableReason ?? "unknown");
+        return false;
     }
 }

--- a/PoshMcp.Tests/Integration/ToolDescriptionRegressionTests.cs
+++ b/PoshMcp.Tests/Integration/ToolDescriptionRegressionTests.cs
@@ -26,13 +26,12 @@ namespace PoshMcp.Tests.Integration;
 /// </summary>
 [Trait("Category", "Integration")]
 [Trait("Spec", "010")]
-public sealed class ToolDescriptionRegressionTests : PowerShellTestBase, IAsyncLifetime
+[Collection("Tool Description Fixtures")]
+public sealed class ToolDescriptionRegressionTests : PowerShellTestBase
 {
     private const string ParagraphSeparator = "\n\n";
 
-    private HelpParityFixtureSession? _inProcessSession;
-    private HelpParityFixtureSession? _outOfProcessSession;
-    private bool _oopAvailable;
+    private readonly ToolDescriptionFixture _fixture;
 
     /// <summary>
     /// Cached map of fixture command name → its current <c>Get-Help .Synopsis</c>
@@ -42,53 +41,19 @@ public sealed class ToolDescriptionRegressionTests : PowerShellTestBase, IAsyncL
     private readonly Dictionary<string, string> _fixtureSynopses =
         new(StringComparer.Ordinal);
 
-    public ToolDescriptionRegressionTests(ITestOutputHelper output) : base(output)
+    public ToolDescriptionRegressionTests(ToolDescriptionFixture fixture, ITestOutputHelper output) : base(output)
     {
-    }
-
-    public async Task InitializeAsync()
-    {
-        _inProcessSession = new HelpParityFixtureSession(
-            HelpParityFixtureSession.RuntimeModeInProcess, Logger, Output);
-        await _inProcessSession.StartAsync();
-
-        try
-        {
-            var pwsh = PoshMcp.Server.PowerShell.OutOfProcess
-                .OutOfProcessCommandExecutor.ResolvePwshPath();
-            if (!string.IsNullOrEmpty(pwsh))
-            {
-                _outOfProcessSession = new HelpParityFixtureSession(
-                    HelpParityFixtureSession.RuntimeModeOutOfProcess, Logger, Output);
-                await _outOfProcessSession.StartAsync();
-                _oopAvailable = true;
-            }
-        }
-        catch (Exception ex)
-        {
-            Logger.LogWarning(ex, "OOP session unavailable; OOP regression assertions skipped");
-        }
-
-        // Pre-warm Get-Help against fixture commands and cache synopses for the
-        // FR-550 origin check.
-        ResolveFixtureSynopses();
-    }
-
-    public async Task DisposeAsync()
-    {
-        if (_inProcessSession is not null)
-            await _inProcessSession.DisposeAsync();
-        if (_outOfProcessSession is not null)
-            await _outOfProcessSession.DisposeAsync();
+        _fixture = fixture;
     }
 
     [Fact]
     public void Baseline_InProcess_PreservesSynopsisDescriptions()
     {
-        Assert.NotNull(_inProcessSession);
+        ResolveFixtureSynopses();
+        Assert.NotNull(_fixture.InProcessSession);
 
         var baseline = LoadBaseline("inprocess-tools-list.json");
-        var current = _inProcessSession!.Tools.OfType<JObject>().ToList();
+        var current = _fixture.InProcessSession!.Tools.OfType<JObject>().ToList();
 
         AssertEqualOrSuperset(baseline, current, mode: "InProcess");
     }
@@ -96,14 +61,16 @@ public sealed class ToolDescriptionRegressionTests : PowerShellTestBase, IAsyncL
     [PwshAvailableFact]
     public void Baseline_OutOfProcess_PreservesSynopsisDescriptions()
     {
-        if (!_oopAvailable)
+        if (!_fixture.IsOutOfProcessAvailable)
         {
-            throw new InvalidOperationException(
-                "OutOfProcess session not initialized; PwshAvailableFact gating should have skipped this.");
+            Logger.LogWarning(
+                "OutOfProcess regression assertion is not run because the fixture session was not initialized.");
+            return;
         }
 
+        ResolveFixtureSynopses();
         var baseline = LoadBaseline("oop-tools-list.json");
-        var current = _outOfProcessSession!.Tools.OfType<JObject>().ToList();
+        var current = _fixture.OutOfProcessSession!.Tools.OfType<JObject>().ToList();
 
         AssertEqualOrSuperset(baseline, current, mode: "OutOfProcess");
     }

--- a/PoshMcp.Tests/Integration/UnifiedHttpTransportIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/UnifiedHttpTransportIntegrationTests.cs
@@ -48,7 +48,7 @@ public class UnifiedHttpTransportIntegrationTests : PowerShellTestBase
     }
 
     [Fact]
-    public async Task ServeHttpTransport_ShouldInitializeAndListToolsOverMcp()
+    public async Task ServeHttpTransport_ShouldRetain2024_11_05Compatibility()
     {
         using var server = new InProcessUnifiedHttpServer();
 
@@ -110,6 +110,71 @@ public class UnifiedHttpTransportIntegrationTests : PowerShellTestBase
         {
             Output.WriteLine(server.GetCapturedOutput());
             throw new Xunit.Sdk.XunitException($"Unified HTTP MCP request flow failed: {ex.Message}");
+        }
+    }
+
+    [Fact]
+    public async Task ServeHttpTransport_ShouldEnforceNegotiatedProtocolAndDeleteSessions()
+    {
+        using var server = new InProcessUnifiedHttpServer();
+
+        try
+        {
+            await server.StartAsync();
+
+            using var httpClient = CreateMcpHttpClient(server.ServerUrl);
+            var (initializeResponse, sessionId) = await SendMcpRequestAsync(httpClient, CreateInitializeRequest("2025-11-25"));
+
+            Assert.Equal("2025-11-25", initializeResponse["result"]?["protocolVersion"]?.ToString());
+            Assert.False(string.IsNullOrWhiteSpace(sessionId));
+
+            using var missingVersionGetRequest = new HttpRequestMessage(HttpMethod.Get, "/");
+            missingVersionGetRequest.Headers.Add("Mcp-Session-Id", sessionId);
+            missingVersionGetRequest.Headers.Accept.ParseAdd("text/event-stream");
+            using var missingVersionGetResponse = await httpClient.SendAsync(missingVersionGetRequest);
+            Assert.Equal(System.Net.HttpStatusCode.BadRequest, missingVersionGetResponse.StatusCode);
+
+            using var missingVersionResponse = await SendRawMcpRequestAsync(
+                httpClient,
+                HttpMethod.Post,
+                new { jsonrpc = "2.0", id = 2, method = "tools/list" },
+                sessionId);
+            Assert.Equal(System.Net.HttpStatusCode.BadRequest, missingVersionResponse.StatusCode);
+
+            using var invalidVersionResponse = await SendRawMcpRequestAsync(
+                httpClient,
+                HttpMethod.Post,
+                new { jsonrpc = "2.0", id = 3, method = "tools/list" },
+                sessionId,
+                "unsupported-version");
+            Assert.Equal(System.Net.HttpStatusCode.BadRequest, invalidVersionResponse.StatusCode);
+
+            using var negotiatedVersionResponse = await SendRawMcpRequestAsync(
+                httpClient,
+                HttpMethod.Post,
+                new { jsonrpc = "2.0", id = 4, method = "tools/list" },
+                sessionId,
+                "2025-11-25");
+            Assert.True(negotiatedVersionResponse.IsSuccessStatusCode);
+
+            using var deleteRequest = new HttpRequestMessage(HttpMethod.Delete, "/");
+            deleteRequest.Headers.Add("Mcp-Session-Id", sessionId);
+            deleteRequest.Headers.Add("MCP-Protocol-Version", "2025-11-25");
+            using var deleteResponse = await httpClient.SendAsync(deleteRequest);
+            Assert.Equal(System.Net.HttpStatusCode.OK, deleteResponse.StatusCode);
+
+            using var expiredSessionResponse = await SendRawMcpRequestAsync(
+                httpClient,
+                HttpMethod.Post,
+                new { jsonrpc = "2.0", id = 5, method = "tools/list" },
+                sessionId,
+                "2025-11-25");
+            Assert.Equal(System.Net.HttpStatusCode.NotFound, expiredSessionResponse.StatusCode);
+        }
+        catch (Exception ex)
+        {
+            Output.WriteLine(server.GetCapturedOutput());
+            throw new Xunit.Sdk.XunitException($"Streamable HTTP protocol/session conformance failed: {ex.Message}");
         }
     }
 
@@ -257,6 +322,65 @@ public class UnifiedHttpTransportIntegrationTests : PowerShellTestBase
             Output.WriteLine(server.GetCapturedOutput());
             throw new Xunit.Sdk.XunitException($"Unified HTTP MCP error-path flow failed: {ex.Message}");
         }
+    }
+
+    private static HttpClient CreateMcpHttpClient(string serverUrl)
+    {
+        var httpClient = new HttpClient
+        {
+            BaseAddress = new Uri(serverUrl),
+            Timeout = TimeSpan.FromSeconds(10)
+        };
+        httpClient.DefaultRequestHeaders.Accept.ParseAdd("application/json");
+        httpClient.DefaultRequestHeaders.Accept.ParseAdd("text/event-stream");
+        return httpClient;
+    }
+
+    private static object CreateInitializeRequest(string protocolVersion)
+    {
+        return new
+        {
+            jsonrpc = "2.0",
+            id = 1,
+            method = "initialize",
+            @params = new
+            {
+                protocolVersion,
+                capabilities = new { tools = new { } },
+                clientInfo = new
+                {
+                    name = "unified-http-streamable-conformance-test",
+                    version = "1.0.0"
+                }
+            }
+        };
+    }
+
+    private static async Task<HttpResponseMessage> SendRawMcpRequestAsync(
+        HttpClient httpClient,
+        HttpMethod method,
+        object request,
+        string? sessionId,
+        string? protocolVersion = null)
+    {
+        var requestJson = JsonConvert.SerializeObject(request);
+        using var content = new StringContent(requestJson, Encoding.UTF8, "application/json");
+        using var requestMessage = new HttpRequestMessage(method, "/")
+        {
+            Content = content
+        };
+
+        if (!string.IsNullOrWhiteSpace(sessionId))
+        {
+            requestMessage.Headers.Add("Mcp-Session-Id", sessionId);
+        }
+
+        if (!string.IsNullOrWhiteSpace(protocolVersion))
+        {
+            requestMessage.Headers.Add("MCP-Protocol-Version", protocolVersion);
+        }
+
+        return await httpClient.SendAsync(requestMessage);
     }
 
     private static async Task<(JObject Response, string? SessionId)> SendMcpRequestAsync(HttpClient httpClient, object request, string? sessionId = null)

--- a/PoshMcp.Tests/Integration/UnifiedHttpTransportIntegrationTests.cs
+++ b/PoshMcp.Tests/Integration/UnifiedHttpTransportIntegrationTests.cs
@@ -20,6 +20,17 @@ public class UnifiedHttpTransportIntegrationTests : PowerShellTestBase
     {
     }
 
+    [Theory]
+    [InlineData("application/json", "{\"jsonrpc\":\"2.0\",\"result\":{\"tools\":[]}}")]
+    [InlineData("text/event-stream", "event: message\ndata: {\"jsonrpc\":\"2.0\",\"result\":{\"tools\":[]}}\n\n")]
+    public void StreamableHttpResponseParser_ShouldSupportJsonAndSse(string mediaType, string responseText)
+    {
+        var response = ParseJsonOrSsePayload(responseText, mediaType);
+
+        Assert.Equal("2.0", response["jsonrpc"]?.ToString());
+        Assert.NotNull(response["result"]);
+    }
+
     [Fact]
     public async Task ServeHttpTransport_ShouldStartAndExposeHealthEndpoint()
     {
@@ -156,6 +167,23 @@ public class UnifiedHttpTransportIntegrationTests : PowerShellTestBase
                 sessionId,
                 "2025-11-25");
             Assert.True(negotiatedVersionResponse.IsSuccessStatusCode);
+            AssertResponseIsJsonOrSse(negotiatedVersionResponse);
+
+            using var notificationResponse = await SendRawMcpRequestAsync(
+                httpClient,
+                HttpMethod.Post,
+                new { jsonrpc = "2.0", method = "notifications/initialized" },
+                sessionId,
+                "2025-11-25");
+            Assert.Equal(System.Net.HttpStatusCode.Accepted, notificationResponse.StatusCode);
+
+            using var getRequest = new HttpRequestMessage(HttpMethod.Get, "/");
+            getRequest.Headers.Add("Mcp-Session-Id", sessionId);
+            getRequest.Headers.Add("MCP-Protocol-Version", "2025-11-25");
+            getRequest.Headers.Accept.ParseAdd("text/event-stream");
+            using var getResponse = await httpClient.SendAsync(getRequest, HttpCompletionOption.ResponseHeadersRead);
+            Assert.True(getResponse.IsSuccessStatusCode);
+            Assert.Equal("text/event-stream", getResponse.Content.Headers.ContentType?.MediaType);
 
             using var deleteRequest = new HttpRequestMessage(HttpMethod.Delete, "/");
             deleteRequest.Headers.Add("Mcp-Session-Id", sessionId);
@@ -175,6 +203,36 @@ public class UnifiedHttpTransportIntegrationTests : PowerShellTestBase
         {
             Output.WriteLine(server.GetCapturedOutput());
             throw new Xunit.Sdk.XunitException($"Streamable HTTP protocol/session conformance failed: {ex.Message}");
+        }
+    }
+
+    [Fact]
+    public async Task ServeHttpTransport_ShouldRejectInvalidOrigins()
+    {
+        using var server = new InProcessUnifiedHttpServer();
+
+        try
+        {
+            await server.StartAsync();
+
+            using var httpClient = CreateMcpHttpClient(server.ServerUrl);
+            using var request = new HttpRequestMessage(HttpMethod.Post, "/")
+            {
+                Content = new StringContent(
+                    JsonConvert.SerializeObject(CreateInitializeRequest("2025-11-25")),
+                    Encoding.UTF8,
+                    "application/json")
+            };
+            request.Headers.Add("Origin", "https://attacker.example");
+
+            using var response = await httpClient.SendAsync(request);
+
+            Assert.Equal(System.Net.HttpStatusCode.Forbidden, response.StatusCode);
+        }
+        catch (Exception ex)
+        {
+            Output.WriteLine(server.GetCapturedOutput());
+            throw new Xunit.Sdk.XunitException($"Streamable HTTP origin conformance failed: {ex.Message}");
         }
     }
 
@@ -383,7 +441,11 @@ public class UnifiedHttpTransportIntegrationTests : PowerShellTestBase
         return await httpClient.SendAsync(requestMessage);
     }
 
-    private static async Task<(JObject Response, string? SessionId)> SendMcpRequestAsync(HttpClient httpClient, object request, string? sessionId = null)
+    private static async Task<(JObject Response, string? SessionId)> SendMcpRequestAsync(
+        HttpClient httpClient,
+        object request,
+        string? sessionId = null,
+        string? protocolVersion = null)
     {
         const int maxAttempts = 3;
         for (var attempt = 1; attempt <= maxAttempts; attempt++)
@@ -401,6 +463,11 @@ public class UnifiedHttpTransportIntegrationTests : PowerShellTestBase
                 requestMessage.Headers.Add("Mcp-Session-Id", sessionId);
             }
 
+            if (!string.IsNullOrWhiteSpace(protocolVersion))
+            {
+                requestMessage.Headers.Add("MCP-Protocol-Version", protocolVersion);
+            }
+
             try
             {
                 using var response = await httpClient.SendAsync(requestMessage);
@@ -411,7 +478,7 @@ public class UnifiedHttpTransportIntegrationTests : PowerShellTestBase
                     throw new HttpRequestException($"HTTP {(int)response.StatusCode}: {responseText}");
                 }
 
-                var responseObject = ParseSsePayload(responseText);
+                var responseObject = ParseJsonOrSsePayload(responseText, response.Content.Headers.ContentType?.MediaType);
                 var responseSessionId = response.Headers.TryGetValues("Mcp-Session-Id", out var sessionIdValues)
                     ? sessionIdValues.FirstOrDefault()
                     : null;
@@ -451,15 +518,27 @@ public class UnifiedHttpTransportIntegrationTests : PowerShellTestBase
             || message.Contains("address already in use", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static JObject ParseSsePayload(string sseResponse)
+    private static void AssertResponseIsJsonOrSse(HttpResponseMessage response)
     {
-        var dataLine = sseResponse
+        Assert.Contains(
+            response.Content.Headers.ContentType?.MediaType,
+            new[] { "application/json", "text/event-stream" });
+    }
+
+    private static JObject ParseJsonOrSsePayload(string responseText, string? mediaType)
+    {
+        if (string.Equals(mediaType, "application/json", StringComparison.OrdinalIgnoreCase))
+        {
+            return JObject.Parse(responseText);
+        }
+
+        var dataLine = responseText
             .Split('\n')
             .FirstOrDefault(line => line.StartsWith("data: ", StringComparison.Ordinal));
 
         if (string.IsNullOrWhiteSpace(dataLine))
         {
-            throw new InvalidOperationException($"No MCP data payload found in SSE response: {sseResponse}");
+            throw new InvalidOperationException($"No MCP data payload found in response: {responseText}");
         }
 
         return JObject.Parse(dataLine.Substring(6));

--- a/PoshMcp.Tests/OutOfProcess/OutOfProcessCancellationTests.cs
+++ b/PoshMcp.Tests/OutOfProcess/OutOfProcessCancellationTests.cs
@@ -159,7 +159,7 @@ public class OutOfProcessCancellationTests
     }
 
     [Fact]
-    public async Task ProcessPool_TokenCancel_StopsPipelineAndKeepsSlotsHealthy()
+    public async Task ProcessPool_TokenCancel_QuarantinesWorkerAndReplacesIt()
     {
         if (!TryResolvePwsh(out var pwshPath)) return;
 
@@ -168,7 +168,7 @@ public class OutOfProcessCancellationTests
 
         var poolOptions = new OutOfProcessSubprocessPoolOptions
         {
-            PoolSize = 2,
+            PoolSize = 1,
             MinHealthyForStartup = 1,
             ReconcilerInterval = TimeSpan.FromMilliseconds(500),
         };
@@ -180,48 +180,39 @@ public class OutOfProcessCancellationTests
 
         await pool.StartAsync(CancellationToken.None);
 
-        // Two long invokes in parallel, both cancelled. Must observe OCE
-        // promptly on both. Slots should stay healthy (soft cancel — no kill
-        // required since Start-Sleep is interruptable).
-        using var cts1 = new CancellationTokenSource();
-        using var cts2 = new CancellationTokenSource();
+        var pidBefore = (await pool.InvokeAsync(
+            "Get-Variable",
+            new Dictionary<string, object?> { ["Name"] = "PID", ["ValueOnly"] = true },
+            CancellationToken.None)).Trim();
 
-        var t1 = pool.InvokeAsync(
+        using var cts = new CancellationTokenSource();
+        var invoke = pool.InvokeAsync(
             "Start-Sleep",
             new Dictionary<string, object?> { ["Seconds"] = 60 },
-            cts1.Token);
-        var t2 = pool.InvokeAsync(
-            "Start-Sleep",
-            new Dictionary<string, object?> { ["Seconds"] = 60 },
-            cts2.Token);
+            cts.Token);
 
         await Task.Delay(TimeSpan.FromMilliseconds(750));
         var sw = Stopwatch.StartNew();
-        cts1.Cancel();
-        cts2.Cancel();
+        cts.Cancel();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            async () => await t1.WaitAsync(ObservationTimeout));
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            async () => await t2.WaitAsync(ObservationTimeout));
+            async () => await invoke.WaitAsync(ObservationTimeout));
 
         sw.Stop();
         Assert.True(sw.Elapsed < ObservationTimeout,
             $"ProcessPool cancellation took {sw.Elapsed.TotalSeconds:F1}s — exceeded budget.");
 
-        // Brief settle for the pipelines to fully unwind on the host side and
-        // for the slots to be returned to the pool. Then a follow-up invoke
-        // on the pool must succeed promptly — proves slots are reusable.
-        await Task.Delay(TimeSpan.FromSeconds(1));
+        var deadline = DateTime.UtcNow + ObservationTimeout;
+        while (DateTime.UtcNow < deadline && pool.HealthyCount < 1)
+            await Task.Delay(100);
+        Assert.Equal(1, pool.HealthyCount);
 
         using var followUpCts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
-        var output = await pool.InvokeAsync(
-            "Get-Date",
-            new Dictionary<string, object?>(),
-            followUpCts.Token);
-        Assert.False(string.IsNullOrEmpty(output));
-        Assert.True(pool.HealthyCount >= 1,
-            $"Pool reported HealthyCount={pool.HealthyCount} after soft cancel; expected >= 1.");
+        var pidAfter = (await pool.InvokeAsync(
+            "Get-Variable",
+            new Dictionary<string, object?> { ["Name"] = "PID", ["ValueOnly"] = true },
+            followUpCts.Token)).Trim();
+        Assert.NotEqual(pidBefore, pidAfter);
     }
 
     private static bool TryResolvePwsh(out string pwshPath)

--- a/PoshMcp.Tests/OutOfProcess/OutOfProcessSubprocessPoolTests.cs
+++ b/PoshMcp.Tests/OutOfProcess/OutOfProcessSubprocessPoolTests.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
 using PoshMcp.Server.PowerShell;
 using PoshMcp.Server.PowerShell.OutOfProcess;
 using Xunit;
@@ -62,6 +65,21 @@ public class OutOfProcessSubprocessPoolTests
                 new OutOfProcessSubprocessPoolOptions { PoolSize = 2, MinHealthyForStartup = 5 }));
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_InvalidCleanupTimeout_Throws(int timeoutMilliseconds)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new OutOfProcessSubprocessPool(
+                "pwsh", "x.ps1",
+                new OutOfProcessSubprocessPoolOptions
+                {
+                    PoolSize = 1,
+                    CleanupTimeout = TimeSpan.FromMilliseconds(timeoutMilliseconds),
+                }));
+    }
+
     [Fact]
     public async Task DisposeAsync_BeforeStart_DoesNotThrow()
     {
@@ -78,6 +96,77 @@ public class OutOfProcessSubprocessPoolTests
             "pwsh", "x.ps1",
             new OutOfProcessSubprocessPoolOptions { PoolSize = 1 });
         await pool.DisposeAsync();
+        await pool.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task AwaitCleanupAsync_TimeoutIsBoundedByConfiguredTimeProvider()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var pool = new OutOfProcessSubprocessPool(
+            "pwsh", "x.ps1",
+            new OutOfProcessSubprocessPoolOptions
+            {
+                PoolSize = 1,
+                CleanupTimeout = TimeSpan.FromSeconds(5),
+                TimeProvider = timeProvider,
+            });
+        var neverCompletes = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var cleanup = pool.AwaitCleanupAsync(neverCompletes.Task, "test worker");
+        Assert.False(cleanup.IsCompleted);
+
+        timeProvider.Advance(TimeSpan.FromSeconds(5));
+
+        var failure = await cleanup;
+        Assert.IsType<TimeoutException>(failure);
+        await pool.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task AwaitCleanupAsync_UsesCallerCancellationWithoutWaitingForTimeout()
+    {
+        var pool = new OutOfProcessSubprocessPool(
+            "pwsh", "x.ps1",
+            new OutOfProcessSubprocessPoolOptions
+            {
+                PoolSize = 1,
+                CleanupTimeout = TimeSpan.FromHours(1),
+            });
+        var neverCompletes = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        var failure = await pool.AwaitCleanupAsync(
+            neverCompletes.Task,
+            "test worker",
+            cancellation.Token);
+
+        Assert.IsType<OperationCanceledException>(failure);
+        await pool.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task AwaitCleanupAsync_LogsAndReturnsDisposalFailure()
+    {
+        var loggerProvider = new CapturingLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(loggerProvider));
+        var pool = new OutOfProcessSubprocessPool(
+            "pwsh", "x.ps1",
+            new OutOfProcessSubprocessPoolOptions { PoolSize = 1 },
+            loggerFactory);
+        var expected = new InvalidOperationException("worker teardown failed");
+
+        var failure = await pool.AwaitCleanupAsync(
+            Task.FromException(expected),
+            "test worker");
+
+        Assert.Same(expected, failure);
+        Assert.Contains(
+            loggerProvider.Messages,
+            message => message.Level == LogLevel.Error
+                && message.Exception == expected
+                && message.Message.Contains("OOP cleanup failed", StringComparison.Ordinal));
         await pool.DisposeAsync();
     }
 
@@ -185,4 +274,37 @@ public class OutOfProcessSubprocessPoolTests
         Assert.Throws<ArgumentNullException>(
             () => OutOfProcessSubprocessPool.ComputeEnvironmentFingerprint(null!, null));
     }
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        public ConcurrentQueue<LogMessage> Messages { get; } = new();
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(Messages);
+
+        public void Dispose() { }
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        private readonly ConcurrentQueue<LogMessage> _messages;
+
+        public CapturingLogger(ConcurrentQueue<LogMessage> messages) => _messages = messages;
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            _messages.Enqueue(new LogMessage(logLevel, exception, formatter(state, exception)));
+        }
+    }
+
+    private sealed record LogMessage(LogLevel Level, Exception? Exception, string Message);
 }

--- a/PoshMcp.Tests/OutOfProcess/OutOfProcessSubprocessPoolTests.cs
+++ b/PoshMcp.Tests/OutOfProcess/OutOfProcessSubprocessPoolTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -77,6 +78,21 @@ public class OutOfProcessSubprocessPoolTests
                 {
                     PoolSize = 1,
                     CleanupTimeout = TimeSpan.FromMilliseconds(timeoutMilliseconds),
+                }));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_InvalidMaxTrackedCleanupOperations_Throws(int maxOperations)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new OutOfProcessSubprocessPool(
+                "pwsh", "x.ps1",
+                new OutOfProcessSubprocessPoolOptions
+                {
+                    PoolSize = 1,
+                    MaxTrackedCleanupOperations = maxOperations,
                 }));
     }
 
@@ -167,6 +183,70 @@ public class OutOfProcessSubprocessPoolTests
             message => message.Level == LogLevel.Error
                 && message.Exception == expected
                 && message.Message.Contains("OOP cleanup failed", StringComparison.Ordinal));
+        await pool.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task CleanupTracking_CompletedAndFaultedTasksAreObservedAndRemoved()
+    {
+        var loggerProvider = new CapturingLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(loggerProvider));
+        var pool = new OutOfProcessSubprocessPool(
+            "pwsh", "x.ps1",
+            new OutOfProcessSubprocessPoolOptions { PoolSize = 1 },
+            loggerFactory);
+        var expected = new InvalidOperationException("worker teardown failed");
+
+        await pool.TrackCleanupTask(Task.CompletedTask, 1);
+        var faulted = pool.TrackCleanupTask(Task.FromException(expected), 2);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => faulted);
+
+        Assert.Equal(0, pool.PendingCleanupTaskCount);
+        Assert.Contains(
+            loggerProvider.Messages,
+            message => message.Level == LogLevel.Error
+                && message.Exception?.InnerException == expected
+                && message.Message.Contains("cleanup faulted asynchronously", StringComparison.Ordinal));
+        await pool.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task CleanupTracking_StuckOperationsAreCappedAndLaterRetired()
+    {
+        var loggerProvider = new CapturingLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(loggerProvider));
+        var pool = new OutOfProcessSubprocessPool(
+            "pwsh", "x.ps1",
+            new OutOfProcessSubprocessPoolOptions
+            {
+                PoolSize = 1,
+                MaxTrackedCleanupOperations = 2,
+            },
+            loggerFactory);
+        var sources = new List<TaskCompletionSource>();
+        var cleanups = new List<Task>();
+
+        for (var index = 0; index < 5; index++)
+        {
+            var source = new TaskCompletionSource();
+            sources.Add(source);
+            cleanups.Add(pool.TrackCleanupTask(source.Task, index));
+        }
+
+        Assert.Equal(2, pool.PendingCleanupTaskCount);
+        Assert.Equal(
+            3,
+            loggerProvider.Messages.Count(message =>
+                message.Level == LogLevel.Warning
+                && message.Message.Contains("tracking capacity", StringComparison.Ordinal)));
+
+        foreach (var source in sources)
+            source.SetResult();
+
+        await Task.WhenAll(cleanups);
+
+        Assert.Equal(0, pool.PendingCleanupTaskCount);
         await pool.DisposeAsync();
     }
 

--- a/PoshMcp.Tests/PoshMcp.Tests.csproj
+++ b/PoshMcp.Tests/PoshMcp.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />

--- a/PoshMcp.Tests/Unit/McpOriginValidationMiddlewareTests.cs
+++ b/PoshMcp.Tests/Unit/McpOriginValidationMiddlewareTests.cs
@@ -50,6 +50,19 @@ public class McpOriginValidationMiddlewareTests
     }
 
     [Fact]
+    public async Task InvokeAsync_RejectsInvalidOriginOnTrailingSlashMcpRoute()
+    {
+        var called = false;
+        var middleware = CreateMiddleware(() => called = true);
+        var context = CreateContext("/mcp/", "https://attacker.example");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.False(called);
+        Assert.Equal(StatusCodes.Status403Forbidden, context.Response.StatusCode);
+    }
+
+    [Fact]
     public async Task InvokeAsync_DoesNotApplyToNonMcpEndpoint()
     {
         var called = false;

--- a/PoshMcp.Tests/Unit/McpOriginValidationMiddlewareTests.cs
+++ b/PoshMcp.Tests/Unit/McpOriginValidationMiddlewareTests.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace PoshMcp.Tests.Unit;
+
+[Trait("Category", "Unit")]
+public class McpOriginValidationMiddlewareTests
+{
+    [Fact]
+    public async Task InvokeAsync_AllowsSameOriginMcpRequest()
+    {
+        var called = false;
+        var middleware = CreateMiddleware(() => called = true);
+        var context = CreateContext("/mcp", "https://localhost:8080");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(called);
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_AllowsConfiguredCrossOrigin()
+    {
+        var called = false;
+        var middleware = CreateMiddleware(
+            () => called = true,
+            new[] { "https://client.example" });
+        var context = CreateContext("/mcp", "https://client.example");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(called);
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_RejectsInvalidMcpOrigin()
+    {
+        var called = false;
+        var middleware = CreateMiddleware(() => called = true);
+        var context = CreateContext("/mcp", "https://attacker.example");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.False(called);
+        Assert.Equal(StatusCodes.Status403Forbidden, context.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_DoesNotApplyToNonMcpEndpoint()
+    {
+        var called = false;
+        var middleware = CreateMiddleware(() => called = true);
+        var context = CreateContext("/health", "https://attacker.example");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(called);
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+    }
+
+    private static McpOriginValidationMiddleware CreateMiddleware(
+        System.Action nextAction,
+        IEnumerable<string>? allowedOrigins = null)
+    {
+        return new McpOriginValidationMiddleware(
+            _ =>
+            {
+                nextAction();
+                return Task.CompletedTask;
+            },
+            new[] { "/mcp" },
+            allowedOrigins ?? []);
+    }
+
+    private static DefaultHttpContext CreateContext(string path, string origin)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("localhost", 8080);
+        context.Request.Path = path;
+        context.Request.Headers.Origin = origin;
+        return context;
+    }
+}

--- a/PoshMcp.Tests/Unit/McpSessionLifecycleTests.cs
+++ b/PoshMcp.Tests/Unit/McpSessionLifecycleTests.cs
@@ -164,6 +164,31 @@ public class McpSessionLifecycleTests
                   runspaces.GetStats().ActiveSessions == 0);
     }
 
+    [Fact]
+    public async Task ApplicationStopped_DisposesSessionRunspaceManager()
+    {
+        var httpContextAccessor = new HttpContextAccessor();
+        using var runspaces = new SessionAwarePowerShellRunspace(
+            httpContextAccessor,
+            NullLogger<SessionAwarePowerShellRunspace>.Instance,
+            new SessionRunspaceOptions { WarmStandbyCount = 1 });
+
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton<IPowerShellRunspace>(runspaces);
+
+        await using var app = builder.Build();
+        app.Lifetime.ApplicationStopped.Register(runspaces.Dispose);
+        await app.StartAsync();
+
+        Assert.Equal(1, runspaces.GetStats().WarmStandbyCount);
+
+        await app.StopAsync();
+
+        Assert.Equal(0, runspaces.GetStats().WarmStandbyCount);
+        Assert.Throws<ObjectDisposedException>(() => runspaces.ExecuteThreadSafe(_ => 0));
+    }
+
     private static async Task WaitForAsync(Func<bool> condition)
     {
         var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);

--- a/PoshMcp.Tests/Unit/McpSessionLifecycleTests.cs
+++ b/PoshMcp.Tests/Unit/McpSessionLifecycleTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using ModelContextProtocol.AspNetCore;
+using PoshMcp.Server.PowerShell;
+using Xunit;
+
+namespace PoshMcp.Tests.Unit;
+
+[Trait("Category", "Unit")]
+public class McpSessionLifecycleTests
+{
+    [Fact]
+    public async Task IdleSessionExpiry_ReleasesProtocolAndRunspaceState()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var httpContextAccessor = new HttpContextAccessor();
+        using var runspaces = new SessionAwarePowerShellRunspace(
+            httpContextAccessor,
+            NullLogger<SessionAwarePowerShellRunspace>.Instance);
+        var lifecycle = new McpSessionLifecycle(runspaces.CleanupSession);
+
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton(lifecycle);
+        builder.Services
+            .AddMcpServer()
+            .WithHttpTransport(options =>
+            {
+                options.IdleTimeout = TimeSpan.FromHours(1);
+                options.TimeProvider = timeProvider;
+#pragma warning disable MCPEXP002 // The lifecycle callback is the production cleanup integration point.
+                options.RunSessionHandler = lifecycle.RunSessionAsync;
+#pragma warning restore MCPEXP002
+            });
+
+        await using var app = builder.Build();
+        app.UseMiddleware<McpProtocolVersionMiddleware>((object)new[] { "/" });
+        app.MapMcp();
+        await app.StartAsync();
+
+        using var client = app.GetTestClient();
+        client.DefaultRequestHeaders.Accept.ParseAdd("application/json");
+        client.DefaultRequestHeaders.Accept.ParseAdd("text/event-stream");
+
+        using var initializeResponse = await client.PostAsync(
+            "/",
+            new StringContent(
+                JsonSerializer.Serialize(new
+                {
+                    jsonrpc = "2.0",
+                    id = 1,
+                    method = "initialize",
+                    @params = new
+                    {
+                        protocolVersion = McpProtocolVersionMiddleware.CurrentProtocolVersion,
+                        capabilities = new { },
+                        clientInfo = new { name = "idle-expiry-test", version = "1.0" }
+                    }
+                }),
+                Encoding.UTF8,
+                "application/json"));
+
+        Assert.Equal(HttpStatusCode.OK, initializeResponse.StatusCode);
+        var sessionId = initializeResponse.Headers.GetValues("Mcp-Session-Id").Single();
+        Assert.True(lifecycle.TryGetProtocolVersion(sessionId, out var protocolVersion));
+        Assert.Equal(McpProtocolVersionMiddleware.CurrentProtocolVersion, protocolVersion);
+
+        httpContextAccessor.HttpContext = new DefaultHttpContext();
+        httpContextAccessor.HttpContext.Request.Headers["Mcp-Session-Id"] = sessionId;
+        _ = runspaces.Instance;
+        Assert.Equal(1, runspaces.GetStats().ActiveSessions);
+
+        timeProvider.Advance(TimeSpan.FromHours(1) + TimeSpan.FromSeconds(5));
+        await WaitForAsync(
+            () => !lifecycle.TryGetProtocolVersion(sessionId, out _) &&
+                  runspaces.GetStats().ActiveSessions == 0);
+
+        using var expiredRequest = new HttpRequestMessage(
+            HttpMethod.Post,
+            "/")
+        {
+            Content = new StringContent(
+                """{"jsonrpc":"2.0","id":2,"method":"tools/list"}""",
+                Encoding.UTF8,
+                "application/json")
+        };
+        expiredRequest.Headers.Add("Mcp-Session-Id", sessionId);
+        expiredRequest.Headers.Add("MCP-Protocol-Version", McpProtocolVersionMiddleware.CurrentProtocolVersion);
+        using var expiredResponse = await client.SendAsync(expiredRequest);
+
+        Assert.Equal(HttpStatusCode.NotFound, expiredResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task ServerShutdown_ReleasesSessionState()
+    {
+        var httpContextAccessor = new HttpContextAccessor();
+        using var runspaces = new SessionAwarePowerShellRunspace(
+            httpContextAccessor,
+            NullLogger<SessionAwarePowerShellRunspace>.Instance);
+        var lifecycle = new McpSessionLifecycle(runspaces.CleanupSession);
+
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton(lifecycle);
+        builder.Services
+            .AddMcpServer()
+            .WithHttpTransport(options =>
+            {
+                options.IdleTimeout = Timeout.InfiniteTimeSpan;
+#pragma warning disable MCPEXP002 // The lifecycle callback is the production cleanup integration point.
+                options.RunSessionHandler = lifecycle.RunSessionAsync;
+#pragma warning restore MCPEXP002
+            });
+
+        await using var app = builder.Build();
+        app.UseMiddleware<McpProtocolVersionMiddleware>((object)new[] { "/" });
+        app.MapMcp();
+        await app.StartAsync();
+
+        using var client = app.GetTestClient();
+        client.DefaultRequestHeaders.Accept.ParseAdd("application/json");
+        client.DefaultRequestHeaders.Accept.ParseAdd("text/event-stream");
+        using var initializeResponse = await client.PostAsync(
+            "/",
+            new StringContent(
+                JsonSerializer.Serialize(new
+                {
+                    jsonrpc = "2.0",
+                    id = 1,
+                    method = "initialize",
+                    @params = new
+                    {
+                        protocolVersion = McpProtocolVersionMiddleware.CurrentProtocolVersion,
+                        capabilities = new { },
+                        clientInfo = new { name = "shutdown-cleanup-test", version = "1.0" }
+                    }
+                }),
+                Encoding.UTF8,
+                "application/json"));
+
+        var sessionId = initializeResponse.Headers.GetValues("Mcp-Session-Id").Single();
+        httpContextAccessor.HttpContext = new DefaultHttpContext();
+        httpContextAccessor.HttpContext.Request.Headers["Mcp-Session-Id"] = sessionId;
+        _ = runspaces.Instance;
+        Assert.Equal(1, runspaces.GetStats().ActiveSessions);
+
+        await app.StopAsync();
+        await WaitForAsync(
+            () => !lifecycle.TryGetProtocolVersion(sessionId, out _) &&
+                  runspaces.GetStats().ActiveSessions == 0);
+    }
+
+    private static async Task WaitForAsync(Func<bool> condition)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (!condition())
+        {
+            if (DateTime.UtcNow >= deadline)
+            {
+                throw new TimeoutException("Timed out waiting for the idle session cleanup callback.");
+            }
+
+            await Task.Delay(10);
+        }
+    }
+}

--- a/PoshMcp.Tests/Unit/McpToolSchemaTests.cs
+++ b/PoshMcp.Tests/Unit/McpToolSchemaTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Reflection;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+using PoshMcp;
+using Xunit;
+
+namespace PoshMcp.Tests.Unit;
+
+[Trait("Category", "Unit")]
+public sealed class McpToolSchemaTests
+{
+    [Fact]
+    public void ApplyStrictEmptyObjectSchema_ReplacesSdkParameterlessSchema()
+    {
+        var tool = McpServerTool.Create(
+            new Func<CancellationToken, Task<string>>(_ => Task.FromResult("ok")),
+            new McpServerToolCreateOptions { Name = "parameterless-probe" });
+
+        McpToolSchema.ApplyStrictEmptyObjectSchema(tool);
+
+        var schema = JsonNode.Parse(tool.ProtocolTool.InputSchema.GetRawText())?.AsObject();
+        Assert.NotNull(schema);
+        Assert.Equal("object", schema!["type"]?.GetValue<string>());
+        Assert.Empty(schema["properties"]?.AsObject() ?? new JsonObject());
+        Assert.False(schema["additionalProperties"]?.GetValue<bool>() ?? true);
+    }
+
+    [Fact]
+    public void HasOnlyInfrastructureParameters_IdentifiesParameterlessToolMethods()
+    {
+        var parameterless = typeof(McpToolSchemaTests).GetMethod(
+            nameof(ParameterlessProbe),
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+        var parameterized = typeof(McpToolSchemaTests).GetMethod(
+            nameof(ParameterizedProbe),
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        Assert.True(McpToolSchema.HasOnlyInfrastructureParameters(parameterless));
+        Assert.False(McpToolSchema.HasOnlyInfrastructureParameters(parameterized));
+    }
+
+    private static Task<string> ParameterlessProbe(CancellationToken cancellationToken) =>
+        Task.FromResult("ok");
+
+    private static Task<string> ParameterizedProbe(string value, CancellationToken cancellationToken) =>
+        Task.FromResult(value);
+}

--- a/PoshMcp.Tests/Unit/McpToolSetupServiceDecisionTests.cs
+++ b/PoshMcp.Tests/Unit/McpToolSetupServiceDecisionTests.cs
@@ -95,6 +95,9 @@ public sealed class McpToolSetupServiceDecisionTests
         Assert.Contains("set-result-caching", toolNames);
         Assert.DoesNotContain("get-configuration-guidance", toolNames);
         Assert.DoesNotContain("get-configuration-troubleshooting", toolNames);
+
+        AssertStrictEmptyInputSchema(toolSetupResult.Tools, "reload-configuration-from-file");
+        AssertStrictEmptyInputSchema(toolSetupResult.Tools, "get-configuration-status");
     }
 
     [PwshAvailableFact]
@@ -119,6 +122,9 @@ public sealed class McpToolSetupServiceDecisionTests
         Assert.DoesNotContain("reload-configuration-from-file", toolNames);
         Assert.DoesNotContain("update-configuration", toolNames);
         Assert.DoesNotContain("get-configuration-status", toolNames);
+
+        AssertStrictEmptyInputSchema(toolSetupResult.Tools, "get-configuration-guidance");
+        AssertStrictEmptyInputSchema(toolSetupResult.Tools, "get-configuration-troubleshooting");
     }
 
     [PwshAvailableFact]
@@ -194,6 +200,18 @@ public sealed class McpToolSetupServiceDecisionTests
         return tools.Select(tool => tool.ProtocolTool.Name)
             .Where(name => !string.IsNullOrWhiteSpace(name))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static void AssertStrictEmptyInputSchema(IEnumerable<McpServerTool> tools, string toolName)
+    {
+        var tool = Assert.Single(tools, tool =>
+            string.Equals(tool.ProtocolTool.Name, toolName, StringComparison.OrdinalIgnoreCase));
+        var schema = JsonNode.Parse(tool.ProtocolTool.InputSchema.GetRawText())?.AsObject();
+
+        Assert.NotNull(schema);
+        Assert.Equal("object", schema!["type"]?.GetValue<string>());
+        Assert.Empty(schema["properties"]?.AsObject() ?? []);
+        Assert.False(schema["additionalProperties"]?.GetValue<bool>() ?? true);
     }
 
     private sealed class TemporaryConfigFile : IDisposable

--- a/PoshMcp.Tests/Unit/ServerSessionAwarePowerShellRunspaceTests.cs
+++ b/PoshMcp.Tests/Unit/ServerSessionAwarePowerShellRunspaceTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Reflection;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Time.Testing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Moq;
@@ -76,6 +78,89 @@ public class ServerSessionAwarePowerShellRunspaceTests : IDisposable
         Assert.Same(runspace1, runspace2);
     }
 
+    [Fact]
+    public void CapacityEvictionAndReplacement_AreBoundedAndSessionAffine()
+    {
+        var time = new FakeTimeProvider();
+        using var runspaces = CreateManagedRunspaces(new SessionRunspaceOptions
+        {
+            Capacity = 1,
+            WarmStandbyCount = 1,
+            IdleTtl = TimeSpan.FromMinutes(1),
+            SweepInterval = TimeSpan.FromHours(1),
+            AcquisitionTimeout = TimeSpan.Zero
+        }, time);
+
+        SetSession("first");
+        var first = GetSessionRunspaceViaReflection(runspaces);
+        Assert.Equal(1, runspaces.GetStats().ActiveSessions);
+        Assert.Equal(1, runspaces.GetStats().OwnedSessionRunspaces);
+
+        SetSession("second");
+        Assert.Throws<TargetInvocationException>(() => GetSessionRunspaceViaReflection(runspaces));
+
+        runspaces.CleanupSession("first");
+        var second = GetSessionRunspaceViaReflection(runspaces);
+        Assert.NotSame(first, second);
+        Assert.Equal(1, runspaces.GetStats().ActiveSessions);
+        Assert.Equal(1, runspaces.GetStats().OwnedSessionRunspaces);
+        Assert.InRange(runspaces.GetStats().WarmStandbyCount, 0, 1);
+    }
+
+    [Fact]
+    public void IdleSweep_EvictsExpiredSessionAndDoesNotTransferItsState()
+    {
+        var time = new FakeTimeProvider();
+        using var runspaces = CreateManagedRunspaces(new SessionRunspaceOptions
+        {
+            Capacity = 2,
+            WarmStandbyCount = 0,
+            IdleTtl = TimeSpan.FromSeconds(10),
+            SweepInterval = TimeSpan.FromHours(1)
+        }, time);
+
+        SetSession("expired");
+        var expired = GetSessionRunspaceViaReflection(runspaces);
+        time.Advance(TimeSpan.FromSeconds(11));
+        runspaces.SweepIdleRunspaces();
+
+        Assert.Equal(0, runspaces.GetStats().ActiveSessions);
+        SetSession("replacement");
+        var replacement = GetSessionRunspaceViaReflection(runspaces);
+        Assert.NotSame(expired, replacement);
+        Assert.Equal(new[] { "replacement" }, runspaces.GetStats().SessionIds);
+    }
+
+    [Fact]
+    public async Task CleanupDuringActiveInvocation_DefersDisposalUntilInvocationCompletes()
+    {
+        using var runspaces = CreateManagedRunspaces(new SessionRunspaceOptions
+        {
+            Capacity = 1,
+            WarmStandbyCount = 0,
+            AcquisitionTimeout = TimeSpan.Zero
+        });
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var complete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        SetSession("active");
+        var invocation = runspaces.ExecuteThreadSafeAsync(async _ =>
+        {
+            started.SetResult();
+            await complete.Task;
+            return 1;
+        });
+        await started.Task;
+
+        runspaces.CleanupSession("active");
+        Assert.Equal(0, runspaces.GetStats().ActiveSessions);
+        Assert.Equal(1, runspaces.GetStats().OwnedSessionRunspaces);
+
+        complete.SetResult();
+        Assert.Equal(1, await invocation);
+        Assert.Equal(0, runspaces.GetStats().OwnedSessionRunspaces);
+    }
+
     private void SetupMockHttpContextWithMcpSessionId(string sessionId)
     {
         var mockHttpContext = new Mock<HttpContext>();
@@ -104,10 +189,21 @@ public class ServerSessionAwarePowerShellRunspaceTests : IDisposable
         return context;
     }
 
-    private object? GetSessionRunspaceViaReflection()
+    private SessionAwarePowerShellRunspace CreateManagedRunspaces(SessionRunspaceOptions options, TimeProvider? timeProvider = null)
+    {
+        return new SessionAwarePowerShellRunspace(
+            _mockHttpContextAccessor.Object,
+            _mockLogger.Object,
+            options,
+            timeProvider);
+    }
+
+    private void SetSession(string sessionId) => SetupMockHttpContextWithMcpSessionId(sessionId);
+
+    private object? GetSessionRunspaceViaReflection(SessionAwarePowerShellRunspace? runspace = null)
     {
         var method = typeof(SessionAwarePowerShellRunspace).GetMethod("GetSessionRunspace", BindingFlags.NonPublic | BindingFlags.Instance);
-        return method?.Invoke(_runspace, null);
+        return method?.Invoke(runspace ?? _runspace, null);
     }
 
     public void Dispose()

--- a/PoshMcp.Tests/Unit/ServerSessionAwarePowerShellRunspaceTests.cs
+++ b/PoshMcp.Tests/Unit/ServerSessionAwarePowerShellRunspaceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -51,31 +52,48 @@ public class ServerSessionAwarePowerShellRunspaceTests : IDisposable
     }
 
     [Fact]
-    public void NoHttpContext_UsesDefaultSessionRunspace()
+    public void NoHttpContext_UsesDedicatedDiscoveryRunspace()
     {
         _mockHttpContextAccessor.Setup(a => a.HttpContext).Returns((HttpContext?)null);
 
-        var runspace1 = GetSessionRunspaceViaReflection();
-        var runspace2 = GetSessionRunspaceViaReflection();
+        var runspace1 = _runspace.Instance;
+        var runspace2 = _runspace.Instance;
 
         Assert.NotNull(runspace1);
         Assert.Same(runspace1, runspace2);
+        Assert.Empty(_runspace.GetStats().SessionIds);
     }
 
     [Fact]
-    public void HttpRequestsWithoutMcpSessionId_UseDefaultSessionRunspace()
+    public void HeaderlessHttpRequests_UseCleanOneShotRunspaces()
     {
         var context1 = CreateHttpContextWithoutMcpSessionId("conn-1", "trace-1");
         var context2 = CreateHttpContextWithoutMcpSessionId("conn-2", "trace-2");
 
         _mockHttpContextAccessor.Setup(a => a.HttpContext).Returns(context1);
-        var runspace1 = GetSessionRunspaceViaReflection();
+        _runspace.ExecuteThreadSafe(powerShell => InvokeScript(powerShell, "$global:HeaderlessRequestState = 'first-request'"));
 
         _mockHttpContextAccessor.Setup(a => a.HttpContext).Returns(context2);
-        var runspace2 = GetSessionRunspaceViaReflection();
+        var state = _runspace.ExecuteThreadSafe(powerShell =>
+            InvokeScript(powerShell, "if ($global:HeaderlessRequestState) { $global:HeaderlessRequestState } else { 'clean' }"));
 
-        Assert.NotNull(runspace1);
-        Assert.Same(runspace1, runspace2);
+        Assert.Equal("clean", state);
+        Assert.Equal(0, _runspace.GetStats().ActiveSessions);
+        Assert.Equal(0, _runspace.GetStats().OwnedSessionRunspaces);
+    }
+
+    [Fact]
+    public void SameMcpSessionId_PreservesPowerShellState()
+    {
+        SetupMockHttpContextWithMcpSessionId("persistent-session");
+        _runspace.ExecuteThreadSafe(powerShell => InvokeScript(powerShell, "$global:PersistentSessionState = 'retained'"));
+
+        SetupMockHttpContextWithMcpSessionId("persistent-session");
+        var state = _runspace.ExecuteThreadSafe(powerShell =>
+            InvokeScript(powerShell, "$global:PersistentSessionState"));
+
+        Assert.Equal("retained", state);
+        Assert.Equal(new[] { "persistent-session" }, _runspace.GetStats().SessionIds);
     }
 
     [Fact]
@@ -199,6 +217,15 @@ public class ServerSessionAwarePowerShellRunspaceTests : IDisposable
     }
 
     private void SetSession(string sessionId) => SetupMockHttpContextWithMcpSessionId(sessionId);
+
+    private static string? InvokeScript(System.Management.Automation.PowerShell powerShell, string script)
+    {
+        powerShell.Commands.Clear();
+        powerShell.AddScript(script);
+        var result = powerShell.Invoke().SingleOrDefault()?.ToString();
+        powerShell.Commands.Clear();
+        return result;
+    }
 
     private object? GetSessionRunspaceViaReflection(SessionAwarePowerShellRunspace? runspace = null)
     {

--- a/README.md
+++ b/README.md
@@ -168,6 +168,19 @@ Configure which PowerShell commands to expose in `appsettings.json`:
 }
 ```
 
+#### Production MCP compatibility
+
+The production server uses `ModelContextProtocol` and
+`ModelContextProtocol.AspNetCore` **1.4.1** and targets MCP
+**2025-11-25** Streamable HTTP. HTTP clients should use the negotiated
+session and protocol headers after `initialize`. PoshMcp also retains
+compatibility for 2024-11-05 Streamable HTTP clients and can opt into the
+deprecated HTTP-with-SSE endpoints for a transition period. See
+[Transport Modes](docs/articles/transport-modes.md#http-mode) for the
+endpoint, negotiation, origin-validation, and legacy-compatibility details,
+and [Configuration](docs/articles/configuration.md#mcp-server-http-sessions)
+for the bounded session-runspace settings.
+
 ### Configuration source diagnostics
 
 Use doctor to verify whether the server is running from a file-backed config or environment-only appsettings-style variables:
@@ -445,6 +458,7 @@ For architectural details, see [DESIGN.md](DESIGN.md).
   - Configuration via CLI, environment variables, or appsettings.json
   - Performance characteristics and trade-offs
   - Troubleshooting and best practices
+- **[PoshMcp.Benchmarks/README.md](PoshMcp.Benchmarks/README.md)** — Benchmark commands, artifact interpretation, and CI contract coverage
 
 ### Advanced Topics
 - **[docs/articles/azure-integration.md](docs/articles/azure-integration.md)** — Azure deployment and integration guidance

--- a/TestClient/Program.cs
+++ b/TestClient/Program.cs
@@ -235,7 +235,7 @@ Examples:
             method = "initialize",
             @params = new
             {
-                protocolVersion = "2024-11-05",
+                protocolVersion = "2025-11-25",
                 capabilities = new
                 {
                     tools = new { }

--- a/docs/articles/advanced.md
+++ b/docs/articles/advanced.md
@@ -149,11 +149,14 @@ ProcessPool example for tenant isolation:
 
 ### Cancellation
 
-The MCP request `CancellationToken` propagates into the subprocess channel for all three host modes via a `cancel` control frame sent by `OutOfProcessHost.SendRequestAsync`. The host attempts a cooperative `BeginStop` on the in-flight pipeline; the .NET awaiter completes with `OperationCanceledException` immediately without waiting for the host to acknowledge. Per-mode behavior:
+The MCP request `CancellationToken` sends a best-effort `cancel` control frame
+through `OutOfProcessHost.SendRequestAsync`. The host dispatcher attempts a
+cooperative `BeginStop` on the in-flight pipeline; cancellation is not a
+guarantee that a blocked cmdlet has already stopped. Per-mode behavior:
 
-- `Pool`: `PoolDispatcher` looks up the active `[powershell]` instance by request id and calls `BeginStop` on it. The runspace is returned to the pool when the pipeline unwinds, so pool capacity recovers without restart. Pool capacity under stuck-but-cancelled invokes is `N - in_flight_uncancelled`.
-- `ProcessPool`: each leased host runs the Single-mode script and inherits the same soft-cancel via the inherited `OutOfProcessHost` cancel frame. If the host honors `BeginStop`, the slot stays healthy and is returned to the pool; other hosts are unaffected. The existing per-request kill-on-timeout path in `OutOfProcessSubprocessPool` remains as a backstop for wedged hosts (e.g., a cmdlet stuck in unmanaged code) that do not honor `BeginStop` within the per-request timeout.
-- `Single`: `SingleDispatcher` runs the invoke on a background dispatcher thread and calls `BeginStop` on the matching `[powershell]` instance when the cancel frame arrives. The host stays healthy for follow-up requests; the per-request timeout serves as the backstop and recycles the host only if `BeginStop` does not unwind the pipeline in time.
+- `Pool`: `PoolDispatcher` looks up the active `[powershell]` instance by request id and calls `BeginStop`. When the pipeline unwinds, its runspace returns to the pool; a wedged invocation continues to consume capacity until the timeout backstop intervenes.
+- `ProcessPool`: each leased host inherits the same cooperative cancellation. If `BeginStop` unwinds the pipeline, the slot returns to the pool and other hosts remain unaffected. The per-request timeout can restart a wedged host, such as one blocked in unmanaged code.
+- `Single`: `SingleDispatcher` calls `BeginStop` on the matching `[powershell]` instance. The host remains usable after a successful unwind; the per-request timeout recycles it only as a backstop.
 
 ### Diagnostics
 
@@ -172,7 +175,9 @@ Automatically reload tool definitions when configuration changes (experimental):
 }
 ```
 
-**Note:** This can be slow; use sparingly.
+**Note:** This can be slow; use sparingly. In HTTP mode, reload releases all
+managed session runspaces. Established clients must initialize a new MCP
+session afterwards and should treat session-scoped PowerShell state as lost.
 
 ---
 

--- a/docs/articles/configuration.md
+++ b/docs/articles/configuration.md
@@ -178,6 +178,15 @@ Full configuration structure:
     "RuntimeMode": "InProcess",
     "SubprocessHostMode": "Pool",
     "SubprocessRunspacePoolSize": 0
+  },
+  "McpServer": {
+    "IdleSessionTimeoutSeconds": 60,
+    "SessionRunspaceCapacity": 16,
+    "SessionRunspaceIdleTtlSeconds": 300,
+    "SessionRunspaceSweepIntervalSeconds": 30,
+    "SessionRunspaceWarmStandbyCount": 2,
+    "SessionRunspaceAcquisitionTimeoutSeconds": 15,
+    "EnableLegacySse": false
   }
 }
 ```
@@ -199,6 +208,41 @@ When `RuntimeMode` is `OutOfProcess`, `SubprocessHostMode` selects the subproces
 
 See [Advanced Configuration → Out-of-Process PowerShell](advanced.md#out-of-process-powershell) for sizing options (`SubprocessRunspacePoolSize`, `SubprocessPoolSize`, `SubprocessMinHealthyForStartup`), the cancellation contract, and the benchmark study driving the default.
 
+### MCP Server HTTP Sessions
+
+`McpServer` applies to HTTP transport. Each request with an
+`Mcp-Session-Id` is assigned one clean, initialized PowerShell runspace for
+the lifetime of that MCP session; it is not reassigned to another session.
+Requests without that header use a one-shot runspace and do not retain
+PowerShell state.
+
+| Setting | Default | Effect |
+|---------|--------:|--------|
+| `IdleSessionTimeoutSeconds` | 60 | Closes an inactive MCP session. |
+| `SessionRunspaceCapacity` | 16 | Maximum session-affine and one-shot runspaces owned at once. |
+| `SessionRunspaceIdleTtlSeconds` | 300 | Retains an inactive session runspace for this many seconds before release. |
+| `SessionRunspaceSweepIntervalSeconds` | 30 | Interval for checking idle session runspaces. |
+| `SessionRunspaceWarmStandbyCount` | 2 | Clean initialized runspaces kept ready for new sessions. |
+| `SessionRunspaceAcquisitionTimeoutSeconds` | 15 | Maximum time to wait for runspace capacity before the request fails. |
+| `EnableLegacySse` | `false` | Enables deprecated HTTP-with-SSE endpoints for legacy clients. |
+
+Capacity includes warm standbys. Size `SessionRunspaceCapacity` for expected
+concurrent stateful sessions plus the configured standby count, and account
+for each initialized runspace's module and startup-script memory footprint.
+When capacity is exhausted, a new session or one-shot request waits only for
+`SessionRunspaceAcquisitionTimeoutSeconds` before failing; it is not assigned
+another session's state.
+
+The server releases a session runspace when the SDK session completes, the
+client explicitly sends `DELETE`, or the runspace reaches its idle TTL. A
+release requested during an active invocation completes after that invocation
+unwinds. Dynamic tool reload also releases all managed HTTP session runspaces,
+so clients must initialize a new session and should not rely on session state
+surviving a reload.
+
+For Streamable HTTP negotiation, endpoint paths, and origin validation, see
+[Transport Modes](transport-modes.md#http-mode).
+
 ## Environment Variables
 
 Override configuration via environment variables:
@@ -213,8 +257,8 @@ export POSHMCP_LOG_LEVEL=debug
 # Use custom config file
 export POSHMCP_CONFIGURATION=/config/appsettings.json
 
-# Session timeout (minutes)
-export POSHMCP_SESSION_TIMEOUT_MINUTES=120
+# Override an appsettings key with the standard .NET environment-variable form
+export McpServer__IdleSessionTimeoutSeconds=120
 
 # Container module pre-install
 export POSHMCP_MODULES="Az.Accounts Az.Resources Az.Storage"

--- a/docs/articles/configuration.md
+++ b/docs/articles/configuration.md
@@ -219,17 +219,19 @@ PowerShell state.
 | Setting | Default | Effect |
 |---------|--------:|--------|
 | `IdleSessionTimeoutSeconds` | 60 | Closes an inactive MCP session. |
-| `SessionRunspaceCapacity` | 16 | Maximum session-affine and one-shot runspaces owned at once. |
+| `SessionRunspaceCapacity` | 16 | Maximum runspaces concurrently assigned to sessions or leased for one-shot requests. |
 | `SessionRunspaceIdleTtlSeconds` | 300 | Retains an inactive session runspace for this many seconds before release. |
 | `SessionRunspaceSweepIntervalSeconds` | 30 | Interval for checking idle session runspaces. |
 | `SessionRunspaceWarmStandbyCount` | 2 | Clean initialized runspaces kept ready for new sessions. |
 | `SessionRunspaceAcquisitionTimeoutSeconds` | 15 | Maximum time to wait for runspace capacity before the request fails. |
 | `EnableLegacySse` | `false` | Enables deprecated HTTP-with-SSE endpoints for legacy clients. |
 
-Capacity includes warm standbys. Size `SessionRunspaceCapacity` for expected
-concurrent stateful sessions plus the configured standby count, and account
-for each initialized runspace's module and startup-script memory footprint.
-When capacity is exhausted, a new session or one-shot request waits only for
+Warm standbys are initialized separately and do not count against
+`SessionRunspaceCapacity`; the manager can therefore hold more initialized
+runspaces than the capacity setting. Account for both settings when sizing
+memory for module and startup-script initialization. Capacity limits only
+runspaces assigned to sessions or leased for one-shot work. When that limit is
+exhausted, a new session or one-shot request waits only for
 `SessionRunspaceAcquisitionTimeoutSeconds` before failing; it is not assigned
 another session's state.
 

--- a/docs/articles/session-management.md
+++ b/docs/articles/session-management.md
@@ -47,12 +47,14 @@ are released when the SDK session completes, the client sends `DELETE`, or the
 runspace remains idle for its configured TTL. A release requested while a tool
 is running waits for that invocation to finish.
 
-The defaults are a 60-second MCP session idle timeout, 16 total owned
-runspaces, a 300-second runspace idle TTL, a 30-second sweep interval, two
-warm standbys, and a 15-second acquisition timeout. Capacity includes warm
-standbys and one-shot requests. When capacity is full, a request waits up to
-the acquisition timeout and then fails rather than receiving another
-session's runspace.
+The defaults are a 60-second MCP session idle timeout, a capacity of 16
+runspaces assigned to sessions or leased for one-shot work, a 300-second
+runspace idle TTL, a 30-second sweep interval, two warm standbys, and a
+15-second acquisition timeout. Warm standbys are initialized separately and
+do not count toward capacity, so the manager can hold more initialized
+runspaces than the capacity setting. When assigned or leased capacity is full,
+a request waits up to the acquisition timeout and then fails rather than
+receiving another session's runspace.
 
 Configure session behavior under `McpServer`:
 
@@ -66,6 +68,9 @@ Configure session behavior under `McpServer`:
   }
 }
 ```
+
+The example's standby count is additional to its assigned/leased capacity; it
+does not reserve two of the 24 capacity slots.
 
 For the complete setting reference and operational sizing guidance, see
 [Configuration](configuration.md#mcp-server-http-sessions). Dynamic tool

--- a/docs/articles/session-management.md
+++ b/docs/articles/session-management.md
@@ -5,7 +5,7 @@ title: Session Management
 
 # Session Management
 
-PoshMcp manages PowerShell runspaces and session state for each connection.
+PoshMcp manages PowerShell runspaces and session state for each MCP session.
 
 ## Persistent State
 
@@ -25,7 +25,7 @@ $MyData.Timestamp
 
 ## Per-User Isolation (HTTP Mode)
 
-Each user maintains independent state:
+Each HTTP MCP session maintains independent state:
 
 ```powershell
 # User A's session
@@ -38,19 +38,44 @@ $Global:Data = @{ ... }
 # User B never sees User A's data
 ```
 
-## Session Timeouts
+## HTTP Session Lifecycle
 
-Runspaces are cleaned up after inactivity (default: 30-60 minutes).
+In HTTP mode, a request with `Mcp-Session-Id` receives one clean initialized
+runspace that is never shared with another session. Requests without that
+header use a one-shot runspace and do not preserve state. Session runspaces
+are released when the SDK session completes, the client sends `DELETE`, or the
+runspace remains idle for its configured TTL. A release requested while a tool
+is running waits for that invocation to finish.
 
-Configure timeout:
+The defaults are a 60-second MCP session idle timeout, 16 total owned
+runspaces, a 300-second runspace idle TTL, a 30-second sweep interval, two
+warm standbys, and a 15-second acquisition timeout. Capacity includes warm
+standbys and one-shot requests. When capacity is full, a request waits up to
+the acquisition timeout and then fails rather than receiving another
+session's runspace.
 
-```bash
-export POSHMCP_SESSION_TIMEOUT_MINUTES=120
+Configure session behavior under `McpServer`:
+
+```json
+{
+  "McpServer": {
+    "IdleSessionTimeoutSeconds": 120,
+    "SessionRunspaceCapacity": 24,
+    "SessionRunspaceWarmStandbyCount": 2,
+    "SessionRunspaceAcquisitionTimeoutSeconds": 15
+  }
+}
 ```
+
+For the complete setting reference and operational sizing guidance, see
+[Configuration](configuration.md#mcp-server-http-sessions). Dynamic tool
+reload releases managed HTTP session runspaces, so clients must create a new
+session and should not expect in-session PowerShell state to survive a reload.
 
 ## Startup Scripts
 
-Run PowerShell code when a new session starts.
+Run PowerShell code when PoshMcp creates a clean runspace. This includes warm
+standbys before they are assigned to a session.
 
 Edit `appsettings.json`:
 

--- a/docs/articles/transport-modes.md
+++ b/docs/articles/transport-modes.md
@@ -6,6 +6,8 @@ title: Transport Modes
 # Transport Modes
 
 PoshMcp supports two transport modes for different deployment scenarios.
+The production implementation uses `ModelContextProtocol` and
+`ModelContextProtocol.AspNetCore` 1.4.1 and targets MCP 2025-11-25.
 
 ## Stdio Mode
 

--- a/docs/articles/transport-modes.md
+++ b/docs/articles/transport-modes.md
@@ -41,7 +41,7 @@ poshmcp serve --transport stdio
 **Best for:** Multi-user deployments, web integration, cloud infrastructure.
 
 **Characteristics:**
-- RESTful API (JSON request/response)
+- MCP Streamable HTTP (2025-11-25)
 - Per-user isolation
 - Horizontal scaling capable
 - Built-in health checks
@@ -52,19 +52,77 @@ poshmcp serve --transport stdio
 poshmcp serve --transport http --port 8080
 ```
 
-**API endpoints:**
+### MCP Endpoint and Protocol
+
+The default Streamable HTTP endpoint is `/`; `/mcp` is also available as a
+compatibility alias. For a production deployment, set a dedicated endpoint with
+`--mcp-path /mcp` (or `POSHMCP_MCP_PATH=/mcp`) and publish only that endpoint
+through the reverse proxy or ingress.
+
+Clients initialize with a JSON-RPC `POST` containing
+`protocolVersion: "2025-11-25"` and `Accept:
+application/json, text/event-stream`. The response provides
+`Mcp-Session-Id`; 2025-11-25 clients must send that header and the negotiated
+`MCP-Protocol-Version` header on all subsequent `POST`, `GET`, and `DELETE`
+requests. Responses may be JSON or Server-Sent Events, according to the
+client's `Accept` header.
 
 ```bash
-# List available tools
-curl http://localhost:8080/tools
-
-# Call a tool
-curl -X POST http://localhost:8080/call \
+# Initialize a Streamable HTTP session.
+curl -i https://poshmcp.example/mcp \
   -H "Content-Type: application/json" \
-  -d '{"tool": "Get-Service", "arguments": {"Name": "wuauserv"}}'
+  -H "Accept: application/json, text/event-stream" \
+  --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"example","version":"1.0"}}}'
 
-# Health check
-curl http://localhost:8080/health
+# Open the optional server-to-client event stream with the negotiated headers.
+curl -N https://poshmcp.example/mcp \
+  -H "Accept: text/event-stream" \
+  -H "Mcp-Session-Id: <session-id>" \
+  -H "MCP-Protocol-Version: 2025-11-25"
+
+# Explicitly end the session.
+curl -X DELETE https://poshmcp.example/mcp \
+  -H "Mcp-Session-Id: <session-id>" \
+  -H "MCP-Protocol-Version: 2025-11-25"
+```
+
+The server returns `400` for a missing, invalid, or unsupported negotiated
+protocol version. `DELETE` returns `200` for a live session; requests made
+after deletion or idle expiry return `404` and the client must initialize a new
+session. `McpServer:IdleSessionTimeoutSeconds` controls expiry (60 seconds by
+default); the SDK checks expired sessions in the background approximately every
+five seconds.
+
+`2024-11-05` Streamable HTTP clients remain supported for compatibility and
+may omit the protocol-version header after initialization. The deprecated
+HTTP-with-SSE transport is disabled by default. Enable it only for a required
+legacy-client transition:
+
+```json
+{
+  "McpServer": {
+    "EnableLegacySse": true
+  }
+}
+```
+
+### Deployment Security
+
+When an `Origin` header is present on an MCP request, PoshMcp accepts only a
+same-origin request or a value in `Authentication:Cors:AllowedOrigins`; other
+origins receive `403`. Configure exact HTTPS origins for browser clients rather
+than using a wildcard. Non-browser clients normally omit `Origin`.
+
+Enable `Authentication:Enabled` for external deployments. MCP endpoints then
+require the configured `McpAccess` policy; `/health` and `/health/ready` remain
+anonymous for platform probes. See [Authentication](authentication.md) for
+Entra ID and API-key setup.
+
+Health probes remain separate from the MCP endpoint:
+
+```bash
+curl https://poshmcp.example/health
+curl https://poshmcp.example/health/ready
 ```
 
 ## Override via Environment Variable

--- a/docs/logging-and-metrics.md
+++ b/docs/logging-and-metrics.md
@@ -155,6 +155,22 @@ The `errorType` field on error/warning log events can be one of:
 | `PowerShell runspace disposed successfully` | Information | `PowerShellCleanupService` |
 | `Error disposing PowerShell runspace` | Warning | `PowerShellCleanupService` |
 
+#### HTTP Session Runspaces
+
+HTTP transport also logs the session-runspace manager lifecycle:
+
+| Event | Level | Source |
+|-------|-------|--------|
+| `Session runspace manager started with capacity {Capacity}, idle TTL {IdleTtl}, and {WarmStandbyCount} warm standbys` | Information | `SessionAwarePowerShellRunspace` |
+| `Assigned clean PowerShell runspace to session {SessionId}` | Information | `SessionAwarePowerShellRunspace` |
+| `Releasing PowerShell runspace for session {SessionId}: {Reason}` | Information | `SessionAwarePowerShellRunspace` |
+
+Use these events to correlate capacity configuration with session assignment and
+release. Session IDs are identifiers; protect HTTP logs according to
+your organization's telemetry-retention policy. For lifecycle semantics and
+configuration defaults, see [Session Management](articles/session-management.md)
+and [Configuration](articles/configuration.md#mcp-server-http-sessions).
+
 ### Authentication and Authorization
 
 These events are only emitted when authentication is enabled (`Authentication.Enabled: true`):

--- a/spikes/PoshMcp.Sdk2TasksSpike/PoshMcp.Sdk2TasksSpike.csproj
+++ b/spikes/PoshMcp.Sdk2TasksSpike/PoshMcp.Sdk2TasksSpike.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);MCPEXP001;MCPEXP002;MCPEXP004</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol" Version="2.0.0-preview.3" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="2.0.0-preview.3" />
+    <PackageReference Include="ModelContextProtocol.Extensions.Tasks" Version="2.0.0-preview.3" />
+  </ItemGroup>
+
+</Project>

--- a/spikes/PoshMcp.Sdk2TasksSpike/Program.cs
+++ b/spikes/PoshMcp.Sdk2TasksSpike/Program.cs
@@ -1,0 +1,141 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Extensions.Tasks;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+using System.IO.Pipelines;
+using System.Text.Json;
+
+Pipe clientToServerPipe = new();
+Pipe serverToClientPipe = new();
+var store = new InMemoryMcpTaskStore
+{
+    DefaultPollIntervalMs = 20,
+    DefaultTimeToLive = TimeSpan.FromMinutes(1)
+};
+
+var services = new ServiceCollection();
+services.AddLogging();
+services.AddMcpServer()
+    // This is the same McpServerTool.Create shape used by McpToolFactoryV2.
+    .WithTools([
+        McpServerTool.Create(SpikeTools.RunReport, new() { Name = "run-report" }),
+        McpServerTool.Create(SpikeTools.WaitForCancellation, new() { Name = "wait-for-cancellation" })
+    ])
+    .WithTasks(store);
+services.AddSingleton<ITransport>(new StreamServerTransport(
+    clientToServerPipe.Reader.AsStream(),
+    serverToClientPipe.Writer.AsStream()));
+
+await using var serviceProvider = services.BuildServiceProvider();
+var server = McpServer.Create(
+    serviceProvider.GetRequiredService<ITransport>(),
+    serviceProvider.GetRequiredService<IOptions<McpServerOptions>>().Value,
+    serviceProvider.GetRequiredService<ILoggerFactory>(),
+    serviceProvider);
+_ = server.RunAsync();
+
+await using McpClient client = await McpClient.CreateAsync(new StreamClientTransport(
+    serverInput: clientToServerPipe.Writer.AsStream(),
+    serverOutput: serverToClientPipe.Reader.AsStream()));
+
+var automaticResult = await client.CallToolWithPollingAsync(new CallToolRequestParams { Name = "run-report" });
+AssertText(automaticResult, "report ready");
+Console.WriteLine("PASS auto-poll: completed task returned tool result");
+
+var taskCall = await client.CallToolAsTaskAsync(new CallToolRequestParams { Name = "run-report" });
+if (!taskCall.IsTask)
+{
+    throw new InvalidOperationException("Tasks extension did not create a task for an opted-in tool call.");
+}
+
+var taskId = taskCall.TaskCreated!.TaskId;
+GetTaskResult completed = await PollForTerminalStateAsync(client, taskId);
+if (completed is not CompletedTaskResult completedTask)
+{
+    throw new InvalidOperationException($"Expected completed task, received {completed.Status}.");
+}
+
+CallToolResult? manualResult = completedTask.Result.Deserialize<CallToolResult>();
+if (manualResult is null)
+{
+    throw new InvalidOperationException("Completed task did not contain a CallToolResult.");
+}
+
+AssertText(manualResult, "report ready");
+Console.WriteLine("PASS manual-poll: created task was completed and preserved CallToolResult");
+
+var cancellationCall = await client.CallToolAsTaskAsync(new CallToolRequestParams { Name = "wait-for-cancellation" });
+if (!cancellationCall.IsTask)
+{
+    throw new InvalidOperationException("Cancellation test tool did not create a task.");
+}
+
+await SpikeTools.CancellationToolStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+await client.CancelTaskAsync(cancellationCall.TaskCreated!.TaskId);
+await SpikeTools.CancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(2));
+GetTaskResult cancelled = await PollForTerminalStateAsync(client, cancellationCall.TaskCreated.TaskId);
+if (cancelled is not CancelledTaskResult)
+{
+    throw new InvalidOperationException($"Expected cancelled task, received {cancelled.Status}.");
+}
+
+Console.WriteLine("PASS cancellation: tasks/cancel cancelled the tool CancellationToken and task state");
+Console.WriteLine("SDK 2 Tasks spike completed successfully.");
+
+static async Task<GetTaskResult> PollForTerminalStateAsync(McpClient client, string taskId)
+{
+    for (var attempt = 0; attempt < 100; attempt++)
+    {
+        GetTaskResult state = await client.GetTaskAsync(taskId);
+        if (state is not WorkingTaskResult and not InputRequiredTaskResult)
+        {
+            return state;
+        }
+
+        await Task.Delay(TimeSpan.FromMilliseconds(state.PollIntervalMs ?? 20));
+    }
+
+    throw new TimeoutException($"Task '{taskId}' did not reach a terminal state.");
+}
+
+static void AssertText(CallToolResult result, string expected)
+{
+    var content = result.Content.SingleOrDefault() as TextContentBlock;
+    if (content?.Text != expected)
+    {
+        throw new InvalidOperationException($"Expected '{expected}', received '{content?.Text ?? "(no text content)"}'.");
+    }
+}
+
+internal static class SpikeTools
+{
+    internal static TaskCompletionSource CancellationToolStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    internal static TaskCompletionSource CancellationObserved { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    [Description("Runs a short task to exercise task completion and result serialization.")]
+    public static async Task<string> RunReport(CancellationToken cancellationToken)
+    {
+        await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken);
+        return "report ready";
+    }
+
+    [Description("Waits until the caller cancels the task.")]
+    public static async Task<string> WaitForCancellation(CancellationToken cancellationToken)
+    {
+        CancellationToolStarted.TrySetResult();
+        try
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return "unexpected completion";
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            CancellationObserved.TrySetResult();
+            throw;
+        }
+    }
+}

--- a/spikes/PoshMcp.Sdk2TasksSpike/README.md
+++ b/spikes/PoshMcp.Sdk2TasksSpike/README.md
@@ -1,0 +1,51 @@
+# MCP SDK 2 Tasks compatibility spike
+
+This isolated `net10.0` console project evaluates `ModelContextProtocol` 2.0.0-preview.3 and
+`ModelContextProtocol.Extensions.Tasks` 2.0.0-preview.3. It is intentionally not in
+`PoshMcp.sln`; production remains on SDK 1.4.1 and protocol 2025-11-25.
+
+Run:
+
+```powershell
+dotnet run --project spikes\PoshMcp.Sdk2TasksSpike\PoshMcp.Sdk2TasksSpike.csproj
+```
+
+The executable creates task-enabled tools with the same `McpServerTool.Create` mechanism used
+by `McpToolFactoryV2`, then validates:
+
+- automatic polling returns a normal `CallToolResult`;
+- manual polling receives a task handle, reaches `Completed`, and preserves the tool result;
+- `tasks/cancel` cancels the tool's `CancellationToken` and reaches `Cancelled`.
+
+## Findings (2026-07-16)
+
+SDK 2 preview Tasks work with the dynamic tool shape, but only when client and server negotiate
+the July 2026 draft protocol (`2026-07-28`) and the client opts into the extension per tool
+call. `WithTasks` adds `tasks/get`, `tasks/update`, and `tasks/cancel`, wraps calls in a
+background task, and supplies a task-specific cancellation token.
+
+Validation on .NET SDK 10.0.302:
+
+```text
+Build succeeded. 0 Warning(s), 0 Error(s)
+PASS auto-poll: completed task returned tool result
+PASS manual-poll: created task was completed and preserved CallToolResult
+PASS cancellation: tasks/cancel cancelled the tool CancellationToken and task state
+```
+
+The preview package set resolves together (`ModelContextProtocol`,
+`ModelContextProtocol.AspNetCore`, and `ModelContextProtocol.Extensions.Tasks`, all
+`2.0.0-preview.3`). The standalone stream transport setup must construct the server with
+`McpServer.Create(...)`; `AddMcpServer()` alone does not register an `McpServer` service. This
+is a source-level hosting difference to account for in any isolated transport migration.
+
+The in-memory store is appropriate only for this executable: it is process-local and loses task
+state on restart. An HTTP deployment needs a durable, session-isolated `IMcpTaskStore`, plus task
+retention, cleanup, ownership, authorization, and observability policies. The preview uses
+experimental (`MCPEXP001`, `MCPEXP002`, `MCPEXP004`) extensibility seams and moves Tasks into a
+new package. SDK 2 also changes Streamable HTTP behavior (including standalone GET-stream
+configuration), so its transport upgrade needs separate HTTP/session lifecycle validation. It
+cannot be safely mixed into the stable 1.4.1/2025-11-25 server path.
+
+**Recommendation: defer adoption.** Revisit after the Tasks protocol and SDK 2 APIs stabilize,
+with a separate durable-store and HTTP/session-lifecycle design.


### PR DESCRIPTION
## Why

Modernize PoshMcp for the stable MCP 1.4.1 SDK and protocol 2025-11-25 while removing cold-start and lifecycle risks from long-lived HTTP and PowerShell workloads.

## What changed

- Upgrades the MCP SDK to 1.4.1 and aligns tool schemas and PowerShell error semantics.
- Completes Streamable HTTP support: protocol negotiation, Origin validation, session lifecycle cleanup, JSON/SSE client handling, and legacy compatibility coverage.
- Adds bounded session-affine warm runspaces with TTL sweeping, safe active-operation disposal, isolated headerless execution, and configurable standby capacity.
- Hardens out-of-process cancellation and configuration reloads with poisoned-worker replacement, generation draining, bounded cleanup, and observable fault handling.
- Adds HTTP/session performance benchmarks and a deterministic CI discovery contract without machine-dependent timing thresholds.
- Updates migration and operational documentation, plus an isolated SDK 2 Tasks spike that recommends deferring production adoption.

## Validation

Focused unit/integration suites, OOP resilience suites, benchmark discovery and dry runs, TestClient build, solution builds, and DocFX documentation builds passed during implementation and review.

## Notes

SDK 2 Tasks remains intentionally isolated under `spikes/`; production continues to target SDK 1.4.1.